### PR TITLE
fix: patch sequence

### DIFF
--- a/community/patches.txt
+++ b/community/patches.txt
@@ -12,9 +12,9 @@ community.patches.v0_0.course_instructor_update
 execute:frappe.delete_doc("DocType", "Discussion Message")
 execute:frappe.delete_doc("DocType", "Discussion Thread")
 community.patches.v0_0.rename_chapters_and_lessons_doctype
-execute:frappe.delete_doc("DocType", "Chapters")
-execute:frappe.delete_doc("DocType", "Lessons")
-execute:frappe.delete_doc("DocType", "Chapter")
-execute:frappe.delete_doc("DocType", "Lesson")
-execute:frappe.delete_doc("DocType", "LMS Topic")
 community.patches.v0_0.rename_chapter_and_lesson_doctype #30-09-2021
+execute:frappe.delete_doc("DocType", "Chapters") #06-10-2021
+execute:frappe.delete_doc("DocType", "Lessons") #06-10-2021
+execute:frappe.delete_doc("DocType", "Chapter") #06-10-2021
+execute:frappe.delete_doc("DocType", "Lesson") #06-10-2021
+execute:frappe.delete_doc("DocType", "LMS Topic") #06-10-2021


### PR DESCRIPTION
1. Changed the sequence of patches to execute the **community.patches.v0_0.rename_chapter_and_lesson_doctype** patch before doctype deletion.