### PR TITLE
fix: style for certificate button and card responsive

### DIFF
--- a/community/public/css/style.css
+++ b/community/public/css/style.css
@@ -124,7 +124,7 @@ input[type=checkbox] {
 
 .course-card-content {
   width: 100%;
-  padding: 0px 24px 20px;
+  padding: 0px 1rem 1.25rem;
 }
 
 @media (max-width: 350px) {
@@ -161,7 +161,7 @@ input[type=checkbox] {
 }
 
 .course-instructor {
-  margin: 0px 8px;
+  margin-left: 8px;
   font-size: 12px;
   line-height: 135%;
   color: var(--text-color);

--- a/community/www/courses/certificate.html
+++ b/community/www/courses/certificate.html
@@ -14,7 +14,7 @@
     </div>
 
     {% if certificate.student == frappe.session.user %}
-    <div class="comment-footer mb-5">
+    <div class="d-flex justify-content-end mb-5">
       <div class="button is-secondary pull-right" id="export-as-pdf" data-certificate="{{ certificate.name }}"
         data-certificate-name="{{ student.full_name }} - {{ course.title }}">Export</div>
     </div>


### PR DESCRIPTION
Issues:

1. Course card was breaking in responsive if the instructor name was too long.

<img width="346" alt="Screenshot 2021-10-19 at 7 10 05 PM" src="https://user-images.githubusercontent.com/31363128/137922033-92e7861e-93a3-4e23-8ab9-c8518b27fa09.png">

2. Export button on certificate page was misaligned.