### PR TITLE
fix: format amount on course cards

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -189,7 +189,8 @@ jinja = {
         "lms.lms.utils.is_instructor",
         "lms.lms.utils.convert_number_to_character",
         "lms.lms.utils.get_signup_optin_checks",
-        "lms.lms.utils.get_popular_courses"
+        "lms.lms.utils.get_popular_courses",
+        "lms.lms.utils.format_amount"
     ],
     "filters": []
 }

--- a/lms/lms/doctype/lms_course/lms_course.json
+++ b/lms/lms/doctype/lms_course/lms_course.json
@@ -203,13 +203,15 @@
    "depends_on": "paid_certificate",
    "fieldname": "price_certificate",
    "fieldtype": "Currency",
-   "label": "Certificate Price"
+   "label": "Certificate Price",
+   "mandatory_depends_on": "paid_certificate"
   },
   {
    "depends_on": "paid_certificate",
    "fieldname": "currency",
    "fieldtype": "Link",
    "label": "Currency",
+   "mandatory_depends_on": "paid_certificate",
    "options": "Currency"
   },
   {
@@ -258,7 +260,7 @@
    "link_fieldname": "course"
   }
  ],
- "modified": "2022-05-04 11:03:24.001015",
+ "modified": "2022-05-19 16:59:21.933367",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Course",

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1,6 +1,6 @@
 import re
 import frappe
-from frappe.utils import flt, cint, cstr, getdate, add_months
+from frappe.utils import flt, cint, cstr, getdate, add_months, fmt_money
 from lms.lms.md import markdown_to_html, find_macros
 import string
 from frappe import _
@@ -366,3 +366,10 @@ def get_evaluation_details(course, member=None):
         "request": request,
         "no_of_attempts": no_of_attempts
     })
+
+def format_amount(amount, currency):
+    amount_reduced = amount / 1000
+    if amount_reduced < 1:
+        return amount
+    precision = 0 if amount % 1000 == 0 else 1
+    return _("{0}K").format(fmt_money(amount_reduced, precision, currency))

--- a/lms/lms/widgets/CourseCard.html
+++ b/lms/lms/widgets/CourseCard.html
@@ -68,7 +68,7 @@
 
     {% if course.paid_certificate %}
     <div class="certificate-price small mt-3" data-price="{{ course.price_certificate }}">
-        {{ _("Certificate Price: ") }} {{ frappe.utils.fmt_money(course.price_certificate, 2, course.currency) }}
+        {{ _("Certificate Price: {0}").format(format_amount(course.price_certificate, course.currency)) }}
     </div>
     {% endif %}
 

--- a/lms/www/courses/course.html
+++ b/lms/www/courses/course.html
@@ -151,7 +151,7 @@
 
     {% if course.paid_certificate %}
     <div class="certificate-price" data-price="{{ course.price_certificate }}">
-        {{ _("Certificate Price:") }} {{ frappe.utils.fmt_money(course.price_certificate, 2, course.currency) }}
+        {{ _("Certificate Price:") }} {{ format_amount(course.price_certificate, course.currency) }}
     </div>
     {% endif %}
 


### PR DESCRIPTION
If the certificate price is in thousands, display it with the "K" symbol.

<img width="864" alt="Screenshot 2022-05-19 at 4 53 28 PM" src="https://user-images.githubusercontent.com/31363128/169282382-a491f5df-4e93-414c-916c-65d4aa07d417.png">

