### PR TITLE
fix: delete doctypes from old modules

### DIFF
--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -28,4 +28,4 @@ lms.patches.v0_0.change_published_field_data #25-03-2022
 execute:frappe.delete_doc("Workspace", "School", ignore_missing=True, force=True)
 lms.patches.v0_0.move_certification_to_certificate
 lms.patches.v0_0.quiz_submission_member
-lms.patches.v0_0.delete_old_module_docs
+lms.patches.v0_0.delete_old_module_docs #08-07-2022

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -28,3 +28,4 @@ lms.patches.v0_0.change_published_field_data #25-03-2022
 execute:frappe.delete_doc("Workspace", "School", ignore_missing=True, force=True)
 lms.patches.v0_0.move_certification_to_certificate
 lms.patches.v0_0.quiz_submission_member
+lms.patches.v0_0.delete_old_module_docs

--- a/lms/patches/v0_0/delete_old_module_docs.py
+++ b/lms/patches/v0_0/delete_old_module_docs.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+
+    frappe.db.delete("DocType", {"module": "Conference"})
+    frappe.db.delete("DocType", {"module": "Hackathon"})
+    frappe.db.delete("DocType", {"module": "Event Management"})

--- a/lms/patches/v0_0/delete_old_module_docs.py
+++ b/lms/patches/v0_0/delete_old_module_docs.py
@@ -5,3 +5,11 @@ def execute():
     frappe.db.delete("DocType", {"module": "Conference"})
     frappe.db.delete("DocType", {"module": "Hackathon"})
     frappe.db.delete("DocType", {"module": "Event Management"})
+
+    frappe.db.delete("Web Form", {"module": "Conference"})
+    frappe.db.delete("Web Form", {"module": "Hackathon"})
+    frappe.db.delete("Web Form", {"module": "Event Management"})
+
+    frappe.db.delete("Module Def", "Conference")
+    frappe.db.delete("Module Def", "Hackathon")
+    frappe.db.delete("Module Def", "Event Management")


### PR DESCRIPTION
Deleted doctypes, webforms and module def for old unused modules Hackathon, Conference, Event Management