### PR TITLE
fix: ui misc

### DIFF
--- a/lms/lms/widgets/CourseCard.html
+++ b/lms/lms/widgets/CourseCard.html
@@ -90,10 +90,12 @@
         <a class="button-links" href="{{ get_profile_url(instructors[0].username) }}">
             <span class="course-instructor">
             {% if ins_len == 1 %}
-            {{ instructors[0].full_name }}
+                {{ instructors[0].full_name }}
+            {% elif ins_len == 2 %}
+                {{ instructors[0].full_name.split(" ")[0] }} and {{ instructors[1].full_name.split(" ")[0] }}
             {% else %}
-            {% set suffix = "other" if ins_len - 1 == 1 else "others"  %}
-            {{ instructors[0].full_name.split(" ")[0] }} and {{ ins_len - 1 }} {{ suffix }}
+                {% set suffix = "other" if ins_len - 2 == 1 else "others"  %}
+                {{ instructors[0].full_name.split(" ")[0] }}, {{ instructors[1].full_name.split(" ")[0] }} and {{ ins_len - 2 }} {{ suffix }}
             {% endif %}
             </span>
         </a>

--- a/lms/lms/widgets/CourseCard.html
+++ b/lms/lms/widgets/CourseCard.html
@@ -94,8 +94,8 @@
             {% elif ins_len == 2 %}
                 {{ instructors[0].full_name.split(" ")[0] }} and {{ instructors[1].full_name.split(" ")[0] }}
             {% else %}
-                {% set suffix = "other" if ins_len - 2 == 1 else "others"  %}
-                {{ instructors[0].full_name.split(" ")[0] }}, {{ instructors[1].full_name.split(" ")[0] }} and {{ ins_len - 2 }} {{ suffix }}
+                {% set suffix = "other" if ins_len - 1 == 1 else "others"  %}
+                {{ instructors[0].full_name.split(" ")[0] }} and {{ ins_len - 1 }} {{ suffix }}
             {% endif %}
             </span>
         </a>

--- a/lms/lms/widgets/Reviews.html
+++ b/lms/lms/widgets/Reviews.html
@@ -4,7 +4,7 @@
   <div class="mb-5">
     <span class="course-home-headings"> {{ _("Reviews") }} </span>
     {% if is_eligible_to_review(course.name, membership) and reviews | length %}
-    <span class="review-link button is-secondary pull-right">
+    <span class="btn btn-secondary btn-sm review-link">
       {{ _("Write a review") }}
     </span>
     {% endif %}

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -1677,3 +1677,13 @@ li {
         margin-bottom: 1rem;
     }
 }
+
+.indicator-pill::before {
+    width: 0;
+    height: 0;
+    margin-right: 0;
+}
+
+.review-link {
+    float: right
+}

--- a/lms/www/batch/learn.html
+++ b/lms/www/batch/learn.html
@@ -95,8 +95,8 @@
             {% elif ins_len == 2 %}
                 {{ instructors[0].full_name.split(" ")[0] }} and {{ instructors[1].full_name.split(" ")[0] }}
             {% else %}
-                {% set suffix = "other" if ins_len - 2 == 1 else "others"  %}
-                {{ instructors[0].full_name.split(" ")[0] }}, {{ instructors[1].full_name.split(" ")[0] }} and {{ ins_len - 2 }} {{ suffix }}
+                {% set suffix = "other" if ins_len - 1 == 1 else "others"  %}
+                {{ instructors[0].full_name.split(" ")[0] }} and {{ ins_len - 1 }} {{ suffix }}
             {% endif %}
         </span>
         </a>
@@ -124,9 +124,9 @@
         {% set course_link = "<a class='join-batch' data-course=" + course.name | urlencode + " href=''>" + _('here') +  "</a>" %}
             <div class="">
                 <div>
-                    {{ _("This lesson is not available for preview.
+                    {{ _("There is no preview available for this lesson.
                     Please join the course to access it.
-                    Click {0} to join the course.").format(course_link) }}
+                    Click {0} to enroll.").format(course_link) }}
                 </div>
             </div>
         {% endif %}

--- a/lms/www/batch/learn.html
+++ b/lms/www/batch/learn.html
@@ -90,12 +90,14 @@
         {% endfor %}
         <a class="button-links ml-1" href="{{ get_profile_url(instructors[0].username) }}">
         <span class="course-meta">
-        {% if ins_len == 1 %}
-            {{ instructors[0].full_name }}
-        {% else %}
-            {% set suffix = _("other") if ins_len - 1 == 1 else _("others")  %}
-            {{ instructors[0].full_name.split(" ")[0] }} and {{ ins_len - 1 }} {{ suffix }}
-        {% endif %}
+            {% if ins_len == 1 %}
+                {{ instructors[0].full_name }}
+            {% elif ins_len == 2 %}
+                {{ instructors[0].full_name.split(" ")[0] }} and {{ instructors[1].full_name.split(" ")[0] }}
+            {% else %}
+                {% set suffix = "other" if ins_len - 2 == 1 else "others"  %}
+                {{ instructors[0].full_name.split(" ")[0] }}, {{ instructors[1].full_name.split(" ")[0] }} and {{ ins_len - 2 }} {{ suffix }}
+            {% endif %}
         </span>
         </a>
         <div class="ml-5 course-meta"> {{ frappe.utils.format_date(lesson.creation, "medium") }} </div>

--- a/lms/www/profiles/profile.html
+++ b/lms/www/profiles/profile.html
@@ -58,7 +58,7 @@
             {% if frappe.session.user == member.email %}
             <div class="ml-auto mt-1">
                 <a class="btn btn-secondary btn-sm" href="/dashboard"> {{ _("Visit Dashboard") }} </a>
-                <a class="btn btn-secondary btn-sm ml-2" href="/edit-profile/{{ member.email }}"> {{ _("Edit Profile") }} </a>
+                <a class="btn btn-secondary btn-sm ml-2" href="/edit-profile/{{ member.email }}/edit"> {{ _("Edit Profile") }} </a>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
1. If there are one or two instructors for a course, their names will be directly shown in relevant places. If there are more than 2 instructors, then we will show the name of the first instructor followed by the remaining instructor count as others.

<img width="1297" alt="Screenshot 2022-09-06 at 11 27 52 AM" src="https://user-images.githubusercontent.com/31363128/188557808-6cd27a64-ab46-45b9-a68c-9b3e8f453901.png">

2. Write a review button will now be secondary
3. After recent web form changes, for editing a profile from the profile page, it used to take users to the read-only version of the web form first, where they had to click on Edit Response to edit. Now they will be redirected taken to the editable form.
4. Fixed #361 

<img width="933" alt="Screenshot 2022-09-06 at 11 33 20 AM" src="https://user-images.githubusercontent.com/31363128/188558922-92046ee5-b27d-4762-897a-c53f9ffd775a.png">
