### PR TITLE
fix: text editor for description field

### DIFF
--- a/lms/www/batch/learn.js
+++ b/lms/www/batch/learn.js
@@ -542,7 +542,6 @@ const build_attachment_table = (file_doc) => {
 
 
 const make_editor = () => {
-
     this.code_field_group = new frappe.ui.FieldGroup({
         fields: [
             {

--- a/lms/www/courses/course.html
+++ b/lms/www/courses/course.html
@@ -205,9 +205,13 @@
 
 <!-- Description -->
 {% macro Description(course) %}
-    <div class="course-description-section" {% if course.edit_mode %} style="min-height: 100px" {% endif %}
-    {% if course.edit_mode %} contenteditable="true" {% endif %} id="description"
-    data-placeholder="Description">{% if course.description %}{{ frappe.utils.md_to_html(course.description) }}{% endif %}</div>
+    {% if course.edit_mode %}
+        <div id="description" {% if course.description %} data-description="{{ course.description }}" {% endif %}></div>
+    {% else %}
+        <div class="course-description-section">
+            {{ frappe.utils.md_to_html(course.description) }}
+        </div>
+    {% endif %}
 {% endmacro %}
 
 
@@ -419,3 +423,9 @@
     </div>
 </div>
 {% endmacro %}
+
+
+{% block base_scripts %}
+    {{ include_script("frappe-web.bundle.js") }}
+    {{ include_script('controls.bundle.js') }}
+{% endblock %}

--- a/lms/www/courses/course.js
+++ b/lms/www/courses/course.js
@@ -70,6 +70,10 @@ frappe.ready(() => {
         remove_tag(e);
     });
 
+    if ($("#description").length) {
+        make_editor();
+    }
+
 });
 
 
@@ -338,7 +342,7 @@ const save_course = (e) => {
             "short_introduction": $("#intro").text(),
             "video_link": $("#video-link").text(),
             "image": $("#image").attr("href"),
-            "description": $("#description").text(),
+            "description": this.code_field_group.fields_dict["code_md"].value,
             "course": $("#title").data("course") ? $("#title").data("course") : "",
             "published": $("#published").prop("checked") ? 1 : 0,
             "upcoming": $("#upcoming").prop("checked") ? 1 : 0
@@ -358,4 +362,27 @@ const save_course = (e) => {
 
 const remove_tag = (e) => {
     $(e.currentTarget).closest(".course-card-pills").remove();
+};
+
+
+const make_editor = () => {
+    this.code_field_group = new frappe.ui.FieldGroup({
+        fields: [
+            {
+                fieldname: "code_md",
+                fieldtype: "Code",
+                options: "Markdown",
+                wrap: true,
+                max_lines: Infinity,
+                min_lines: 20,
+                default: $("#description").data("description"),
+                depends_on: 'eval:doc.type=="Markdown"',
+            }
+        ],
+        body: $("#description").get(0),
+    });
+    this.code_field_group.make();
+    $("#description .form-section:last").removeClass("empty-section");
+    $("#description .frappe-control").removeClass("hide-control");
+    $("#description .form-column").addClass("p-0");
 };


### PR DESCRIPTION
1. Description Field is now a text editor. It accepts normal as well as markdown content

<img width="1049" alt="Screenshot 2022-09-13 at 9 35 25 AM" src="https://user-images.githubusercontent.com/31363128/189805549-a0ef9231-ba21-4cea-ab87-de1d47cd9be5.png">

<img width="1344" alt="Screenshot 2022-09-13 at 9 34 59 AM" src="https://user-images.githubusercontent.com/31363128/189805486-46e86fac-93e2-4475-87b3-3049560b733f.png">


