### PR TITLE
fix: change private files to public for company logo, user and course image

### DIFF
--- a/lms/job/doctype/job_opportunity/job_opportunity.py
+++ b/lms/job/doctype/job_opportunity/job_opportunity.py
@@ -7,7 +7,6 @@ from frappe.utils.user import get_system_managers
 from frappe import _
 from frappe.utils import get_link_to_form
 from lms.lms.utils import validate_image
-from lms.lms.utils import validate_image
 
 class JobOpportunity(Document):
 

--- a/lms/job/doctype/job_opportunity/job_opportunity.py
+++ b/lms/job/doctype/job_opportunity/job_opportunity.py
@@ -6,25 +6,21 @@ from frappe.model.document import Document
 from frappe.utils.user import get_system_managers
 from frappe import _
 from frappe.utils import get_link_to_form
+from lms.lms.utils import validate_image
+from lms.lms.utils import validate_image
 
 class JobOpportunity(Document):
 
 
     def validate(self):
         self.validate_urls()
-        self.validate_logo()
+        self.company_logo = validate_image(self.company_logo)
 
 
     def validate_urls(self):
         frappe.utils.validate_url(self.company_website, True)
         frappe.utils.validate_url(self.application_link, True)
 
-
-    def validate_logo(self):
-        if "/private" in self.company_logo:
-            frappe.db.set_value("File", {"file_url": self.company_logo}, "is_private", 0)
-            frappe.db.set_value("File", {"file_url": self.company_logo}, "file_url", self.company_logo.replace("/private", ""))
-            self.company_logo = self.company_logo.replace("/private", "")
 
 @frappe.whitelist()
 def report(job, reason):

--- a/lms/lms/doctype/lms_course/lms_course.py
+++ b/lms/lms/doctype/lms_course/lms_course.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 import json
-from ...utils import generate_slug
-from frappe.utils import flt, cint
+from ...utils import generate_slug, validate_image
+from frappe.utils import cint
 from lms.lms.utils import get_chapters
 
 
@@ -15,7 +15,7 @@ class LMSCourse(Document):
     def validate(self):
         self.validate_instructors()
         self.validate_status()
-
+        self.image = validate_image(self.image)
 
     def validate_instructors(self):
         if self.is_new() and not self.instructors:

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -463,7 +463,7 @@ def get_certificates(member=None):
 
 
 def validate_image(path):
-    if "/private" in path:
+    if path and "/private" in path:
         file = frappe.get_doc("File", {"file_url": path})
         file.is_private = 0
         file.save(ignore_permissions=True)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -460,3 +460,12 @@ def get_certificates(member=None):
     return frappe.get_all("LMS Certificate", {
         "member": member or frappe.session.user
     }, ["course", "member", "issue_date", "expiry_date", "name"])
+
+
+def validate_image(path):
+    if "/private" in path:
+        file = frappe.get_doc("File", {"file_url": path})
+        file.is_private = 0
+        file.save(ignore_permissions=True)
+        return file.file_url
+    return path

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -6,17 +6,22 @@ import random
 import re
 from frappe import _
 from frappe.website.utils import is_signup_disabled
+from lms.lms.utils import validate_image
 import requests
-from frappe.geo.country_info import get_all
 from lms.widgets import Widgets
 
+
 class CustomUser(User):
+
 
     def validate(self):
         super(CustomUser, self).validate()
         self.validate_username_characters()
         self.validate_skills()
         self.validate_completion()
+        self.user_image = validate_image(self.user_image)
+        self.cover_image = validate_image(self.cover_image)
+
 
     def validate_username_characters(self):
         if len(self.username):

--- a/lms/www/profiles/profile.html
+++ b/lms/www/profiles/profile.html
@@ -97,7 +97,7 @@
 {% set enrollment_suffix = _("Courses") if enrollment > 1 else _("Course") %}
 
 <div class="container">
-    <div class="profile-banner" style="background-image: url({{ cover_image }})">
+    <div class="profile-banner" style="background-image: url({{ cover_image | urlencode }})">
         <div class="profile-avatar">
             {{ widgets.Avatar(member=member, avatar_class="avatar-square") }}
         </div>


### PR DESCRIPTION
1. While uploading attachments, Frappe Framework has made the default to private.
2. Since it's a small checkbox, it goes unnoticed by a lot of users. So when they add a profile image, course image, or company logo, it gets saved as private, and it's not visible to other users.
3. So, now whenever a user saves these images, there will be a check from the backend if these are private and if yes then they will be made public automatically.