### PR TITLE
feat: dashboard stat

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -197,7 +197,8 @@ jinja = {
         "lms.lms.utils.get_courses_under_review",
         "lms.lms.utils.has_course_instructor_role",
         "lms.lms.utils.has_course_moderator_role",
-        "lms.lms.utils.get_certificates"
+        "lms.lms.utils.get_certificates",
+        "lms.lms.utils.format_number"
     ],
     "filters": []
 }

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -419,6 +419,13 @@ def format_amount(amount, currency):
     return _("{0}k").format(fmt_money(amount_reduced, precision, currency))
 
 
+def format_number(number):
+    number_reduced = number / 1000
+    if number_reduced < 1:
+        return number
+    return "{0}k".format(frappe.utils.flt(number_reduced, 1))
+
+
 def first_lesson_exists(course):
     first_chapter = frappe.db.get_value("Chapter Reference", {"parent": course, "idx": 1}, "name")
     if not first_chapter:

--- a/lms/lms/web_template/dashboard_stats/dashboard_stats.html
+++ b/lms/lms/web_template/dashboard_stats/dashboard_stats.html
@@ -1,0 +1,1 @@
+{% include "lms/templates/dashboard_stats.html" %}

--- a/lms/lms/web_template/dashboard_stats/dashboard_stats.json
+++ b/lms/lms/web_template/dashboard_stats/dashboard_stats.json
@@ -1,0 +1,35 @@
+{
+ "__unsaved": 1,
+ "creation": "2022-09-28 15:30:58.893302",
+ "docstatus": 0,
+ "doctype": "Web Template",
+ "fields": [
+  {
+   "fieldname": "published_courses",
+   "fieldtype": "Check",
+   "label": "Published Courses",
+   "reqd": 0
+  },
+  {
+   "fieldname": "total_signups",
+   "fieldtype": "Check",
+   "label": "Total Signups",
+   "reqd": 0
+  },
+  {
+   "fieldname": "enrollment_count",
+   "fieldtype": "Check",
+   "label": "Enrollment Count",
+   "reqd": 0
+  }
+ ],
+ "idx": 0,
+ "modified": "2022-09-28 17:44:37.982923",
+ "modified_by": "Administrator",
+ "module": "LMS",
+ "name": "Dashboard Stats",
+ "owner": "Administrator",
+ "standard": 1,
+ "template": "",
+ "type": "Section"
+}

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -1726,3 +1726,26 @@ li {
 .timestamp {
     font-size: var(--text-xs);
 }
+
+.stats-parent {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-gap: 2rem;
+}
+
+.stats-label {
+    color: var(--text-muted);
+    font-weight: bold;
+}
+
+.stats-value {
+    color: var(--gray-900);
+    font-weight: 600;
+    font-size: 2rem;
+}
+
+.stats-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}

--- a/lms/templates/dashboard_stats.html
+++ b/lms/templates/dashboard_stats.html
@@ -1,0 +1,36 @@
+<div class="stats-parent">
+
+    {% if published_courses %}
+    <div class="stats-card">
+        <div class="stats-label">
+            {{ _("Published Courses") }}
+        </div>
+        <div class="stats-value">
+            {{ format_number(frappe.db.count("LMS Course", { "published": 1, "upcoming": 0 })) }}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if total_signups %}
+    <div class="stats-card">
+        <div class="stats-label">
+            {{ _("Total Signups") }}
+        </div>
+        <div class="stats-value">
+            {{ format_number(frappe.db.count("User", { "enabled": 1 })) }}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if enrollment_count %}
+    <div class="stats-card">
+        <div class="stats-label">
+            {{ _("Enrollment Count") }}
+        </div>
+        <div class="stats-value">
+            {{ format_number(frappe.db.count("LMS Batch Membership")) }}
+        </div>
+    </div>
+    {% endif %}
+
+</div>

--- a/lms/www/dashboard/index.html
+++ b/lms/www/dashboard/index.html
@@ -5,6 +5,7 @@
 
 
 {% block content %}
+
 <div class="common-page-style dashboard">
     <div class="container">
 


### PR DESCRIPTION
A web template that will show some important LMS stats.

<img width="1440" alt="Screenshot 2022-09-29 at 8 50 25 AM" src="https://user-images.githubusercontent.com/31363128/192931799-d3b29cf8-63fe-4119-9542-3c582664c93a.png">

This is configurable through the page building block settings.

<img width="621" alt="Screenshot 2022-09-29 at 8 57 00 AM" src="https://user-images.githubusercontent.com/31363128/192931865-a8ed2640-f05b-472a-9975-f75231fa115c.png">
