### PR TITLE
fix: delete custom fields after app in uninstalled

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -60,7 +60,8 @@ web_include_js = ["website.bundle.js", "controls.bundle.js"]
 # ------------
 
 # before_install = "lms.install.before_install"
-# after_install = "lms.install.after_install"
+after_uninstall = "lms.install.after_uninstall"
+
 
 # Desk Notifications
 # ------------------

--- a/lms/install.py
+++ b/lms/install.py
@@ -1,0 +1,17 @@
+import frappe
+
+def after_uninstall():
+    delete_custom_fields()
+
+def delete_custom_fields():
+    fields = [ "user_category", "headline", "college", "city", "verify_terms", "country", "preferred_location",
+        "preferred_functions", "preferred_industries", "work_environment_column", "time", "role", "carrer_preference_details",
+        "skill", "certification_details", "internship", "branch", "github", "medium", "linkedin", "profession", "looking_for_job",
+        "work_environment", "dream_companies", "career_preference_column", "attire", "collaboration", "location_preference",
+        "company_type", "skill_details", "certification", "education", "work_experience", "education_details", "hide_private",
+        "work_experience_details", "profile_complete", "cover_image"
+    ]
+
+    for field in fields:
+        frappe.db.delete("Custom Field", {"fieldname": field})
+        frappe.db.commit()


### PR DESCRIPTION
When the app was uninstalled, the custom fields created for User doctype still used to be present. They caused issues in opening and editing the user doctype. So now when the app is uninstalled, the custom fields will be deleted.

Related to: #393 and #369 