### PR TITLE
fix: stats template

### DIFF
--- a/lms/lms/web_template/lms_statistics/lms_statistics.html
+++ b/lms/lms/web_template/lms_statistics/lms_statistics.html
@@ -1,1 +1,15 @@
-{% include "lms/templates/statistics.html" %}
+{% if title %}
+    <h2 class="hero-title">
+        {{ _(title) }}
+    </h2>
+{% endif %}
+
+{% if subtitle %}
+    <p class="hero-subtitle">
+        {{ _(subtitle) }}
+    </p>
+{%- endif -%}
+
+<div class="mt-12">
+    {% include "lms/templates/statistics.html" %}
+</div>

--- a/lms/lms/web_template/lms_statistics/lms_statistics.json
+++ b/lms/lms/web_template/lms_statistics/lms_statistics.json
@@ -5,6 +5,22 @@
  "doctype": "Web Template",
  "fields": [
   {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "reqd": 0
+  },
+  {
+   "__islocal": 1,
+   "__unsaved": 1,
+   "fieldname": "subtitle",
+   "fieldtype": "Text",
+   "label": "Subtitle",
+   "reqd": 0
+  },
+  {
    "fieldname": "published_courses",
    "fieldtype": "Check",
    "label": "Published Courses",
@@ -24,10 +40,10 @@
   }
  ],
  "idx": 0,
- "modified": "2022-09-28 17:44:37.982923",
+ "modified": "2022-10-20 20:10:48.490785",
  "modified_by": "Administrator",
  "module": "LMS",
- "name": "Dashboard Stats",
+ "name": "LMS Statistics",
  "owner": "Administrator",
  "standard": 1,
  "template": "",

--- a/lms/templates/statistics.html
+++ b/lms/templates/statistics.html
@@ -6,7 +6,7 @@
             {{ _("Published Courses") }}
         </div>
         <div class="stats-value">
-            {{ format_number(frappe.db.count("LMS Course", { "published": 1, "upcoming": 0 })) }}
+            {{ frappe.db.count("LMS Course", { "published": 1, "upcoming": 0 }) }}
         </div>
     </div>
     {% endif %}
@@ -17,7 +17,7 @@
             {{ _("Total Signups") }}
         </div>
         <div class="stats-value">
-            {{ format_number(frappe.db.count("User", { "enabled": 1 })) }}
+            {{ frappe.db.count("User", { "enabled": 1 }) }}
         </div>
     </div>
     {% endif %}
@@ -28,7 +28,7 @@
             {{ _("Enrollment Count") }}
         </div>
         <div class="stats-value">
-            {{ format_number(frappe.db.count("LMS Batch Membership")) }}
+            {{ frappe.db.count("LMS Batch Membership") }}
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
1. Added title and subtitle to the LMS Statistics template
2. Removed the k format for numbers.

<img width="612" alt="Screenshot 2022-10-21 at 11 01 30 AM" src="https://user-images.githubusercontent.com/31363128/197120045-775c8781-9c2c-4716-8862-7ce4826da814.png">
