### PR TITLE
fix: course permission messages

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -205,7 +205,8 @@ jinja = {
         "lms.lms.utils.get_lesson_count",
         "lms.lms.utils.get_all_memberships",
         "lms.lms.utils.get_filtered_membership",
-        "lms.lms.utils.show_start_learing_cta"
+        "lms.lms.utils.show_start_learing_cta",
+        "lms.lms.utils.can_create_courses"
     ],
     "filters": []
 }

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -466,6 +466,14 @@ def has_course_instructor_role(member=None):
         }, "name")
 
 
+def can_create_courses(member=None):
+    if not member:
+        member = frappe.session.user
+
+    portal_course_creation = frappe.db.get_single_value("LMS Settings", "portal_course_creation")
+    return frappe.session.user != "Guest" and (portal_course_creation == "Anyone" or has_course_instructor_role(member))
+
+
 def has_course_moderator_role(member=None):
     return frappe.db.get_value("Has Role", {
         "parent": member or frappe.session.user,

--- a/lms/www/batch/learn.py
+++ b/lms/www/batch/learn.py
@@ -1,7 +1,9 @@
 import frappe
 from lms.www.utils import get_common_context, redirect_to_lesson
-from lms.lms.utils import get_lesson_url, has_course_moderator_role, is_instructor, redirect_to_courses_list
+from lms.lms.utils import get_lesson_url, has_course_moderator_role, is_instructor
 from frappe.utils import cstr, flt
+from frappe import _
+
 
 def get_context(context):
     get_common_context(context)
@@ -28,7 +30,7 @@ def get_context(context):
 
     if frappe.form_dict.get("edit"):
         if not instructor and not has_course_moderator_role():
-            redirect_to_courses_list()
+            raise frappe.PermissionError(_("You do not have permission to access this page."))
         context.lesson.edit_mode = True
     else:
         neighbours = get_neighbours(lesson_number, context.lessons)

--- a/lms/www/courses/course.py
+++ b/lms/www/courses/course.py
@@ -1,6 +1,6 @@
 import frappe
-from lms.lms.utils import get_membership, has_course_moderator_role, is_instructor, is_certified, get_evaluation_details, redirect_to_courses_list
-
+from lms.lms.utils import can_create_courses, get_membership, has_course_moderator_role, is_instructor, is_certified, get_evaluation_details, redirect_to_courses_list
+from frappe import _
 
 def get_context(context):
     context.no_cache = 1
@@ -11,8 +11,13 @@ def get_context(context):
         redirect_to_courses_list()
 
     if course_name == "new-course":
-        if frappe.session.user == "Guest":
-            redirect_to_courses_list()
+        if not can_create_courses():
+            message = "You do not have permission to access this page."
+            if frappe.session.user == "Guest":
+                message = "Please login to access this page."
+
+            raise frappe.PermissionError(_(message))
+
         context.course = frappe._dict()
         context.course.edit_mode = True
         context.membership = None

--- a/lms/www/courses/course.py
+++ b/lms/www/courses/course.py
@@ -34,12 +34,11 @@ def set_course_context(context, course_name):
 
     if frappe.form_dict.get("edit"):
         if not is_instructor(course.name) and not has_course_moderator_role():
-            redirect_to_courses_list()
+            raise frappe.PermissionError(_("You do not have permission to access this page."))
         course.edit_mode = True
 
     if course is None:
-        frappe.local.flags.redirect_location = "/courses"
-        raise frappe.Redirect
+        redirect_to_courses_list()
 
     related_courses = frappe.get_all("Related Courses", {"parent": course.name}, ["course"])
     for csr in related_courses:

--- a/lms/www/courses/index.py
+++ b/lms/www/courses/index.py
@@ -1,15 +1,13 @@
 import frappe
 from frappe import _
-from lms.lms.utils import has_course_instructor_role, has_course_moderator_role, check_profile_restriction, get_restriction_details
+from lms.lms.utils import can_create_courses, has_course_moderator_role, check_profile_restriction, get_restriction_details
 
 
 def get_context(context):
     context.no_cache = 1
     context.live_courses, context.upcoming_courses = get_courses()
     context.restriction = check_profile_restriction()
-    portal_course_creation = frappe.db.get_single_value("LMS Settings", "portal_course_creation")
-    context.show_creators_section = frappe.session.user != "Guest" and \
-        (portal_course_creation == "Anyone" or has_course_instructor_role())
+    context.show_creators_section = can_create_courses()
     context.show_review_section = has_course_moderator_role() and frappe.session.user != "Guest"
 
     if context.restriction:


### PR DESCRIPTION
## Issue

Previously, when a Guest users used to visit the new course creation page from the portal, they were redirected to the course list page, because they should not be allowed to create a new course. There was no proper message given to the user here and the users got confused.

## Fix

A message will be shown to users in this scenario where they will be asked to log in.

<img width="1440" alt="Screenshot 2022-11-03 at 11 00 08 AM" src="https://user-images.githubusercontent.com/31363128/199653698-ca31fd61-35c1-4036-9943-4c23b304377d.png">
