### PR TITLE
fix: tab urls

### DIFF
--- a/lms/www/courses/index.html
+++ b/lms/www/courses/index.html
@@ -33,12 +33,19 @@
                 {{ _("All Courses") }}
             </div>
 
-            {% if show_creators_section %}
             <div class="pull-right">
-                <a class="btn btn-secondary btn-sm" href="/users"> {{ _("Visit Dashboard") }} </a>
-                <a class="btn btn-secondary btn-sm ml-2" href="/courses/new-course"> {{ _("Create a Course") }} </a>
+                {% if frappe.session.user %}
+                <a class="btn btn-secondary btn-sm" href="/users">
+                    {{ _("Visit Dashboard") }}
+                </a>
+                {% endif %}
+
+                {% if show_creators_section %}
+                <a class="btn btn-secondary btn-sm ml-2" href="/courses/new-course">
+                    {{ _("Create a Course") }}
+                </a>
+                {% endif %}
             </div>
-            {% endif %}
 
             <ul class="nav lms-nav" id="courses-tab">
                 <li class="nav-item">

--- a/lms/www/courses/index.js
+++ b/lms/www/courses/index.js
@@ -2,6 +2,14 @@
 frappe.ready(() => {
     generate_graph("New Signups");
     generate_graph("Course Enrollments");
+
+    $(".nav-link").click((e) => {
+        change_hash(e);
+    });
+
+    if (window.location.hash) {
+        open_tab();
+    }
 });
 
 
@@ -39,4 +47,14 @@ const render_chart = (data, chart_name) => {
             "regionFill": 1
         }
     });
+};
+
+
+const change_hash = (e) => {
+    window.location.hash = $(e.currentTarget).attr("href");
+};
+
+
+const open_tab = () => {
+    $(`a[href="${window.location.hash}"]`).click();
 };

--- a/lms/www/profiles/profile.js
+++ b/lms/www/profiles/profile.js
@@ -6,6 +6,14 @@ frappe.ready(() => {
         save_role(e);
     });
 
+    $(".nav-link").click((e) => {
+        change_hash(e);
+    });
+
+    if (window.location.hash) {
+        open_tab();
+    }
+
 });
 
 
@@ -17,7 +25,7 @@ const make_profile_active_in_navbar = () => {
             link_array.length && $(link_array[0]).addClass("active");
         }, 0)
     }
-}
+};
 
 
 const save_role = (e) => {
@@ -39,4 +47,14 @@ const save_role = (e) => {
             }
         }
     })
-}
+};
+
+
+const change_hash = (e) => {
+    window.location.hash = $(e.currentTarget).attr("href");
+};
+
+
+const open_tab = () => {
+    $(`a[href="${window.location.hash}"]`).click();
+};


### PR DESCRIPTION
## Issue

There are tabs on the course list and profile page. Previously, when the tabs were changed on this page, there was no hash change in the URL. People were unable to share a particular tab because of this.

## Fix:

The hash in the URL will now change with the tab change.

<img width="1440" alt="Screenshot 2022-11-04 at 10 47 09 AM" src="https://user-images.githubusercontent.com/31363128/199897856-43664469-8501-4315-9b8d-0d7cfc0a3896.png">
