### PR TITLE
fix: format stats

### DIFF
--- a/lms/templates/statistics.html
+++ b/lms/templates/statistics.html
@@ -6,10 +6,16 @@
             {{ _("Published Courses") }}
         </div>
         <div class="stats-value">
-            {{ frappe.db.count("LMS Course", { "published": 1, "upcoming": 0 }) }}
+            {{ frappe.utils.fmt_money(
+				frappe.db.count("LMS Course", {
+					"published": 1,
+					"upcoming": 0
+				})
+				, 0) }}
         </div>
     </div>
     {% endif %}
+
 
     {% if total_signups %}
     <div class="common-card-style p-4 flex-column">
@@ -17,10 +23,15 @@
             {{ _("Total Signups") }}
         </div>
         <div class="stats-value">
-            {{ frappe.db.count("User", { "enabled": 1 }) }}
+            {{ frappe.utils.fmt_money(
+				frappe.db.count("User", {
+					"enabled": 1
+				})
+				, 0) }}
         </div>
     </div>
     {% endif %}
+
 
     {% if enrollment_count %}
     <div class="common-card-style p-4 flex-column">
@@ -28,7 +39,9 @@
             {{ _("Enrollment Count") }}
         </div>
         <div class="stats-value">
-            {{ frappe.db.count("LMS Batch Membership") }}
+            {{ frappe.utils.fmt_money(
+				frappe.db.count("LMS Batch Membership")
+				, 0) }}
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
Stat numbers will be formatted with commas.

<img width="1440" alt="Screenshot 2022-11-08 at 11 29 28 AM" src="https://user-images.githubusercontent.com/31363128/200487010-f0d845b7-f30e-4386-864f-33c8fd816d53.png">
