### PR TITLE
feat: last active time of class students

### DIFF
--- a/lms/www/classes/class.html
+++ b/lms/www/classes/class.html
@@ -108,22 +108,40 @@
 	{{ AddStudents() }}
 
 	{% if class_students | length %}
-	<div class="mt-10">
+	<table class="table mt-10">
+		<tr>
+			<th style="width: 70%">
+				{{ _("Student") }}
+			</th>
+			<th style="width: 20%">
+				{{ _("Last Active") }}
+			</th>
+			<th style="width: 10%"></th>
+		</tr>
 		{% for student in class_students %}
-		<div class="d-flex" style="position: relative;">
-			<a class="subheading button-links flex-grow-1" href="/classes/{{ class_info.name }}/students/{{ student.username }}">
-				{{ student.student_name }}
-			</a>
-			<svg class="icon icon-md pull-right remove-student" data-student="{{ student.student }}">
-				<use href="#icon-delete"></use>
-			</svg>
-		</div>
-		{% if not loop.last %} <hr> {% endif %}
+		{% set last_active = frappe.db.get_value("User", student.student, "last_active") %}
+		<tr>
+			<td>
+				<a class="subheading button-links d-block" href="/classes/{{ class_info.name }}/students/{{ student.username }}">
+					{{ student.student_name }}
+				</a>
+			</td>
+			<td>
+				{{ frappe.utils.format_datetime(last_active, "medium") }}
+			</td>
+			<td>
+				<svg class="icon icon-md pull-right remove-student" data-student="{{ student.student }}">
+					<use href="#icon-delete"></use>
+				</svg>
+			</td>
+		</tr>
 		{% endfor %}
-	</div>
+
+	</table>
 	{% else %}
 	<p class="text-muted mt-3"> {{ _("No Students are added to this class.") }} </p>
 	{% endif %}
+
 </div>
 {% endmacro %}
 

--- a/lms/www/classes/progress.html
+++ b/lms/www/classes/progress.html
@@ -9,8 +9,13 @@
 	<div class="container">
 		{{ BreadCrumb(class_info, student) }}
 		<div class="common-card-style column-card">
-			<div class="course-home-headings">
-				{{ student.full_name }}
+			<div class="mb-5">
+				<div class="medium pull-right">
+					{{ frappe.utils.format_datetime(student.last_active, "medium") }}
+				</div>
+				<div class="course-home-headings">
+					{{ student.full_name }}
+				</div>
 			</div>
 			{{ Progress(class_courses, student) }}
 		</div>

--- a/lms/www/classes/progress.py
+++ b/lms/www/classes/progress.py
@@ -17,7 +17,7 @@ def get_context(context):
 	classname = frappe.form_dict["classname"]
 
 	context.student = frappe.db.get_value(
-		"User", {"username": student}, ["first_name", "full_name", "name"], as_dict=True
+		"User", {"username": student}, ["first_name", "full_name", "name", "last_active"], as_dict=True
 	)
 	context.class_info = frappe.db.get_value(
 		"LMS Class", classname, ["name"], as_dict=True

--- a/lms/www/classes/progress.py
+++ b/lms/www/classes/progress.py
@@ -17,7 +17,10 @@ def get_context(context):
 	classname = frappe.form_dict["classname"]
 
 	context.student = frappe.db.get_value(
-		"User", {"username": student}, ["first_name", "full_name", "name", "last_active"], as_dict=True
+		"User",
+		{"username": student},
+		["first_name", "full_name", "name", "last_active"],
+		as_dict=True,
 	)
 	context.class_info = frappe.db.get_value(
 		"LMS Class", classname, ["name"], as_dict=True


### PR DESCRIPTION
## Last Active Time

Display the last active time of the student on the class and progress page.

<img width="1440" alt="Screenshot 2022-11-22 at 8 44 21 AM" src="https://user-images.githubusercontent.com/31363128/203212519-327d453a-e0a9-4f0f-88d4-4f0bd7de62b1.png">

<img width="1440" alt="Screenshot 2022-11-22 at 8 44 38 AM" src="https://user-images.githubusercontent.com/31363128/203212528-dbf1a415-f077-4b05-a88f-310f39083ebd.png">
