### PR TITLE
fix: rename instructor role to course creator

### DIFF
--- a/lms/install.py
+++ b/lms/install.py
@@ -17,7 +17,7 @@ def after_uninstall():
 
 
 def create_lms_roles():
-	create_instructor_role()
+	create_course_creator_role()
 	create_moderator_role()
 
 
@@ -25,12 +25,12 @@ def set_default_home():
 	frappe.db.set_value("Portal Settings", None, "default_portal_home", "/courses")
 
 
-def create_instructor_role():
-	if not frappe.db.exists("Role", "Course Instructor"):
+def create_course_creator_role():
+	if not frappe.db.exists("Role", "Course Creator"):
 		role = frappe.get_doc(
 			{
 				"doctype": "Role",
-				"role_name": "Course Instructor",
+				"role_name": "Course Creator",
 				"home_page": "",
 				"desk_access": 0,
 			}
@@ -39,11 +39,11 @@ def create_instructor_role():
 
 
 def create_moderator_role():
-	if not frappe.db.exists("Role", "Course Moderator"):
+	if not frappe.db.exists("Role", "Moderator"):
 		role = frappe.get_doc(
 			{
 				"doctype": "Role",
-				"role_name": "Course Moderator",
+				"role_name": "Moderator",
 				"home_page": "",
 				"desk_access": 0,
 			}

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -102,11 +102,11 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "Course Instructor Role",
+   "default": "Course Creator Role",
    "fieldname": "portal_course_creation",
    "fieldtype": "Select",
    "label": "Course Creation Access Through Website To",
-   "options": "Course Instructor Role\nAnyone"
+   "options": "Course Creator Role\nAnyone"
   },
   {
    "fieldname": "column_break_9",
@@ -142,7 +142,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-10-11 16:26:15.898514",
+ "modified": "2022-12-01 15:13:39.901611",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -486,7 +486,7 @@ def redirect_to_courses_list():
 def has_course_instructor_role(member=None):
 	return frappe.db.get_value(
 		"Has Role",
-		{"parent": member or frappe.session.user, "role": "Instructor"},
+		{"parent": member or frappe.session.user, "role": "Course Creator"},
 		"name",
 	)
 

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -40,3 +40,4 @@ lms.patches.v0_0.add_pages_to_nav #25-11-2022
 lms.patches.v0_0.change_role_names
 lms.patches.v0_0.quiz_submission_result
 lms.patches.v0_0.skill_to_user_skill
+lms.patches.v0_0.rename_instructor_role

--- a/lms/patches/v0_0/rename_instructor_role.py
+++ b/lms/patches/v0_0/rename_instructor_role.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.rename_doc("Role", "Instructor", "Course Creator")


### PR DESCRIPTION
Rename Instructor role to Course Creator because there is already a role with the same name in Education App