### PR TITLE
fix: hide start learning when no lesson in course

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -624,14 +624,14 @@ def show_start_learing_cta(course, membership):
 
 def has_lessons(course):
 	lesson_exists = False
-	chapter_exists = frappe.db.get_value("Chapter Reference", {
-		"parent": course.name
-	}, ["name", "chapter"], as_dict=True)
+	chapter_exists = frappe.db.get_value(
+		"Chapter Reference", {"parent": course.name}, ["name", "chapter"], as_dict=True
+	)
 
 	if chapter_exists:
-		lesson_exists = frappe.db.exists("Lesson Reference", {
-			"parent": chapter_exists.chapter
-		})
+		lesson_exists = frappe.db.exists(
+			"Lesson Reference", {"parent": chapter_exists.chapter}
+		)
 
 	return lesson_exists
 

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -618,7 +618,22 @@ def show_start_learing_cta(course, membership):
 		and not check_profile_restriction()
 		and not is_instructor(course.name)
 		and course.status == "Approved"
+		and has_lessons(course)
 	)
+
+
+def has_lessons(course):
+	lesson_exists = False
+	chapter_exists = frappe.db.get_value("Chapter Reference", {
+		"parent": course.name
+	}, ["name", "chapter"], as_dict=True)
+
+	if chapter_exists:
+		lesson_exists = frappe.db.exists("Lesson Reference", {
+			"parent": chapter_exists.chapter
+		})
+
+	return lesson_exists
 
 
 @frappe.whitelist(allow_guest=True)

--- a/lms/lms/widgets/CourseCard.html
+++ b/lms/lms/widgets/CourseCard.html
@@ -1,5 +1,6 @@
 {% if frappe.session.user != "Guest" %}
-{% set membership = frappe.db.get_value("LMS Batch Membership", {"member": frappe.session.user},
+{% set membership = frappe.db.get_value("LMS Batch Membership",
+	{"member": frappe.session.user, "course": course.name},
 	["name", "course", "batch", "current_lesson", "member_type", "progress"], as_dict=1) %}
 {% set progress = frappe.utils.cint(membership.progress) %}
 {% else %}
@@ -113,19 +114,17 @@
 
         {% if read_only %}
             <a class="stretched-link" href="/courses/{{ course.name }}"></a>
-            {% else %}
-
-            {% set lesson_index = get_lesson_index(membership.current_lesson) if membership and
-            membership.current_lesson else '1.1' %}
-            {% set query_parameter = "?batch=" + membership.batch if membership and
-            membership.batch else "" %}
-
+		{% else %}
             {% if progress != 100 and membership and not course.upcoming %}
-            <a class="stretched-link" href="{{ get_lesson_url(course.name, lesson_index) }}{{ query_parameter }}"></a>
 
-            {% else %}
-            <a class="stretched-link" href="/courses/{{ course.name }}"></a>
+				{% set lesson_index = get_lesson_index(membership.current_lesson or "1.1") %}
 
+				{% set query_parameter = "?batch=" + membership.batch if membership.batch else "" %}
+
+				<a class="stretched-link" href="{{ get_lesson_url(course.name, lesson_index) }}{{ query_parameter }}"></a>
+
+			{% else %}
+				<a class="stretched-link" href="/courses/{{ course.name }}"></a>
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
## Issue

When there is no lesson in a course, and the user clicks on the Start Learning button, they are redirected to lesson 1.1. But as no such lesson exists, it leads to a 404 page.

## Fix

The Start Learning button will not be shown when there are no lessons in a course.