### PR TITLE
fix: login redirect condition

### DIFF
--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -299,7 +299,8 @@ def on_login(login_manager):
 
 
 def on_session_creation(login_manager):
-	frappe.local.response["home_page"] = "/courses"
+	if frappe.db.get_single_value("LMS Settings", "setup_complete"):
+		frappe.local.response["home_page"] = "/courses"
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
### Issue

After creating a new site, an Administrator was redirected to the /courses page even before completing the setup wizard.

### Fix

Before redirecting to the /courses page, it will be checked if the setup wizard is complete. Users will be only redirected after the completion of setup wizard.