### PR TITLE
fix: user doctype singles issue

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -287,6 +287,4 @@ profile_url_prefix = "/users/"
 
 signup_form_template = "lms.plugins.show_custom_signup"
 
-on_login = "lms.overrides.user.on_login"
-
 on_session_creation = "lms.overrides.user.on_session_creation"

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -273,7 +273,6 @@ def sign_up(email, full_name, verify_terms, user_category):
 def set_country_from_ip(login_manager=None, user=None):
 	if not user and login_manager:
 		user = login_manager.user
-
 	user_country = frappe.db.get_value("User", user, "country")
 	# if user_country:
 	#    return
@@ -292,10 +291,6 @@ def get_country_code():
 	except Exception:
 		pass
 	return
-
-
-def on_login(login_manager):
-	set_country_from_ip()
 
 
 def on_session_creation(login_manager):

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -44,3 +44,4 @@ lms.patches.v0_0.rename_instructor_role
 lms.patches.v0_0.change_course_creation_settings #12-12-2022
 lms.patches.v0_0.check_onboarding_status #21-12-2022
 lms.patches.v0_0.assignment_file_type
+lms.patches.v0_0.user_singles_issue #23-11-2022

--- a/lms/patches/v0_0/user_singles_issue.py
+++ b/lms/patches/v0_0/user_singles_issue.py
@@ -2,9 +2,9 @@ import frappe
 
 
 def execute():
-	rows = frappe.db.sql(
-		"select field from `tabSingles` where doctype='User'", as_dict=True
-	)
+	table = frappe.qb.DocType("Singles")
+	q = frappe.qb.from_(table).select(table.field).where(table.doctype == "User")
+	rows = q.run()
 
 	if len(rows):
-		frappe.db.sql("delete from `tabSingles` where doctype='User'")
+		frappe.db.delete("Singles", {"doctype": "User"})

--- a/lms/patches/v0_0/user_singles_issue.py
+++ b/lms/patches/v0_0/user_singles_issue.py
@@ -1,7 +1,10 @@
 import frappe
 
+
 def execute():
-	rows = frappe.db.sql("select field from `tabSingles` where doctype='User'", as_dict = True)
+	rows = frappe.db.sql(
+		"select field from `tabSingles` where doctype='User'", as_dict=True
+	)
 
 	if len(rows):
 		frappe.db.sql("delete from `tabSingles` where doctype='User'")

--- a/lms/patches/v0_0/user_singles_issue.py
+++ b/lms/patches/v0_0/user_singles_issue.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+	rows = frappe.db.sql("select field from `tabSingles` where doctype='User'", as_dict = True)
+
+	if len(rows):
+		frappe.db.sql("delete from `tabSingles` where doctype='User'")


### PR DESCRIPTION
## Issue

Blogs were not getting rendered. On visiting the page this error used to appear.

<img width="725" alt="Screenshot 2023-01-04 at 4 32 29 PM" src="https://user-images.githubusercontent.com/31363128/210541554-f5ac5cd7-cd6a-4d68-adb6-e1cdb8c56f65.png">

This was happening because using the hook on_login, the user's country was being set using their IP. And if the user was not passed correctly, then it was creating an entry for User doctype in tabSingles. For details refer  to https://github.com/frappe/frappe/issues/19471

The avatar for blogs queries the get_user_info_for_avatar function with user_id as None. This resulted in a faulty response from the tabSingles which caused the issue.

## Fix

No need to set country from IP during login. The call has been removed. A patch will delete the User doctype entries from tabSingles.