### PR TITLE
fix: default home setting

### DIFF
--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -7,6 +7,7 @@
  "field_order": [
   "search_placeholder",
   "portal_course_creation",
+  "default_home",
   "is_onboarding_complete",
   "column_break_2",
   "custom_certificate_template",
@@ -145,12 +146,18 @@
    "fieldtype": "Check",
    "label": "Is Onboarding Complete",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "default_home",
+   "fieldtype": "Check",
+   "label": "Make LMS the default home"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-12-20 11:44:06.317159",
+ "modified": "2023-02-07 19:53:46.073914",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -294,7 +294,9 @@ def get_country_code():
 
 
 def on_session_creation(login_manager):
-	if frappe.db.get_single_value("System Settings", "setup_complete"):
+	if frappe.db.get_single_value(
+		"System Settings", "setup_complete"
+	) and frappe.db.get_single_value("LMS Settings", "default_home"):
 		frappe.local.response["home_page"] = "/courses"
 
 


### PR DESCRIPTION
#472 

The course list page used to be the default home once the setup wizard was complete and any user logged into the system. This was a problem with users who had other apps also installed on the site.

As a fix, there will now be a setting for this in LMS Settings. A checkbox to **Make LMS the default home**. Only when this is checked, the course list will be default home. Else everything will work as it should.

<img width="1440" alt="Screenshot 2023-02-07 at 8 04 53 PM" src="https://user-images.githubusercontent.com/31363128/217274203-38e87420-8bb0-4456-b4bb-dd1f65cddb4a.png">
