### PR TITLE
fix: accept only embed id for preview video

### DIFF
--- a/lms/lms/doctype/lms_course/lms_course.py
+++ b/lms/lms/doctype/lms_course/lms_course.py
@@ -15,6 +15,7 @@ from ...utils import generate_slug, validate_image
 class LMSCourse(Document):
 	def validate(self):
 		self.validate_instructors()
+		self.validate_video_link()
 		self.validate_status()
 		self.image = validate_image(self.image)
 
@@ -29,6 +30,10 @@ class LMSCourse(Document):
 					"parenttype": "LMS Course",
 				}
 			).save(ignore_permissions=True)
+
+	def validate_video_link(self):
+		if self.video_link and "/" in self.video_link:
+			self.video_link = self.video_link.split("/")[-1]
 
 	def validate_status(self):
 		if self.published:

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -46,3 +46,4 @@ lms.patches.v0_0.check_onboarding_status #21-12-2022
 lms.patches.v0_0.assignment_file_type
 lms.patches.v0_0.user_singles_issue #23-11-2022
 lms.patches.v0_0.rename_community_to_users #06-01-2023
+lms.patches.v0_0.video_embed_link

--- a/lms/patches/v0_0/video_embed_link.py
+++ b/lms/patches/v0_0/video_embed_link.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	courses = frappe.get_all(
+		"LMS Course", {"video_link": ["is", "set"]}, ["name", "video_link"]
+	)
+	for course in courses:
+		if course.video_link:
+			link = course.video_link.split("/")[-1]
+			frappe.db.set_value("LMS Course", course.name, "video_link", link)

--- a/lms/www/courses/course.html
+++ b/lms/www/courses/course.html
@@ -151,7 +151,7 @@
     <div class="course-overlay-card">
 
         {% if course.video_link %}
-        <iframe class="preview-video" frameborder="0" allowfullscreen src="{{ course.video_link }}"
+        <iframe class="preview-video" frameborder="0" allowfullscreen src="https://www.youtube.com/embed/{{ course.video_link }}"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
         {% endif %}
 


### PR DESCRIPTION
1. To add a preview video, previously users had to add the complete iframe src that youtube provides.
2. This involved multiple clicks on the youtube platform plus was confusing for users.
3. This PR simplifies the process. Now users just need to end the last parameter of the URL that youtube provides for sharing a video. The rest will be handled by the app.
 
<img width="1440" alt="Screenshot 2023-02-21 at 9 56 53 AM" src="https://user-images.githubusercontent.com/31363128/220247616-43e0f31c-fc13-449e-b625-477a38dc88c2.png">
