### PR TITLE
fix: redirection after completing setup wizard

### DIFF
--- a/lms/public/js/setup_wizard.js
+++ b/lms/public/js/setup_wizard.js
@@ -2,4 +2,4 @@ frappe.provide("lms.setup");
 
 // redirect to desk page 'lms' after setup wizard is complete
 // 'lms' desk page redirects to '/courses'
-frappe.setup.welcome_page = "/app/lms-home";
+//frappe.setup.welcome_page = "/app/lms-home";


### PR DESCRIPTION
## Issue

When the app was installed on a new site, after completion of the setup wizard, the user was redirected to the Courses Dashboard. This should not happen as the user has not yet opted to have LMS as the default home.

## Fix

After completion of the setup wizard, the user will now be redirected to the backend desk.