### PR TITLE
feat: Text editor for course description and Lesson Content

### DIFF
--- a/lms/lms/doctype/course_lesson/course_lesson.json
+++ b/lms/lms/doctype/course_lesson/course_lesson.json
@@ -66,7 +66,7 @@
   },
   {
    "fieldname": "body",
-   "fieldtype": "Markdown Editor",
+   "fieldtype": "Text Editor",
    "ignore_xss_filter": 1,
    "label": "Body",
    "reqd": 1
@@ -135,7 +135,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-12-28 16:01:42.191123",
+ "modified": "2023-04-05 12:42:16.926753",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Course Lesson",

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -53,7 +53,7 @@ class CourseLesson(Document):
 			ex.course = None
 			ex.index_ = 0
 			ex.index_label = ""
-			ex.save()
+			ex.save(ignore_permissions=True)
 
 	def check_and_create_folder(self):
 		args = {

--- a/lms/lms/doctype/lms_course/lms_course.json
+++ b/lms/lms/doctype/lms_course/lms_course.json
@@ -57,7 +57,7 @@
   },
   {
    "fieldname": "description",
-   "fieldtype": "Markdown Editor",
+   "fieldtype": "Text Editor",
    "label": "Description",
    "reqd": 1
   },
@@ -260,7 +260,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2023-02-23 09:45:54.826327",
+ "modified": "2023-02-23 09:45:54.826328",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Course",

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -269,6 +269,7 @@ def get_progress(course, lesson):
 
 
 def render_html(lesson):
+	print(lesson.body)
 	youtube = lesson.youtube
 	quiz_id = lesson.quiz_id
 	body = lesson.body

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -269,7 +269,6 @@ def get_progress(course, lesson):
 
 
 def render_html(lesson):
-	print(lesson.body)
 	youtube = lesson.youtube
 	quiz_id = lesson.quiz_id
 	body = lesson.body

--- a/lms/lms/widgets/CourseOutline.html
+++ b/lms/lms/widgets/CourseOutline.html
@@ -5,7 +5,7 @@
 
 
     {% if course.edit_mode and course.name %}
-    <button class="btn btn-md btn-secondary btn-chapter pull-right"> {{ _("New Chapter") }} </button>
+    <button class="btn btn-sm btn-secondary btn-chapter pull-right"> {{ _("New Chapter") }} </button>
     {% endif %}
 
     {% if course.name and (course.edit_mode or chapters | length) %}

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -51,3 +51,4 @@ lms.patches.v0_0.rename_exercise_doctype
 lms.patches.v0_0.add_question_type
 lms.patches.v0_0.add_evaluator_to_assignment
 lms.patches.v0_0.convert_lesson_markdown_to_html #05-04-2023
+lms.patches.v0_0.convert_course_description_to_html

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -50,3 +50,4 @@ lms.patches.v0_0.video_embed_link
 lms.patches.v0_0.rename_exercise_doctype
 lms.patches.v0_0.add_question_type
 lms.patches.v0_0.add_evaluator_to_assignment
+lms.patches.v0_0.convert_lesson_markdown_to_html #05-04-2023

--- a/lms/patches/v0_0/convert_course_description_to_html.py
+++ b/lms/patches/v0_0/convert_course_description_to_html.py
@@ -1,0 +1,12 @@
+import frappe
+from lms.lms.md import markdown_to_html
+
+
+def execute():
+	courses = frappe.get_all("LMS Course", fields=["name", "description"])
+
+	for course in courses:
+		html = markdown_to_html(course.description)
+		frappe.db.set_value("LMS Course", course.name, "description", html)
+
+	frappe.reload_doc("lms", "doctype", "lms_course")

--- a/lms/patches/v0_0/convert_lesson_markdown_to_html.py
+++ b/lms/patches/v0_0/convert_lesson_markdown_to_html.py
@@ -1,0 +1,12 @@
+import frappe
+from lms.lms.md import markdown_to_html
+
+
+def execute():
+	lessons = frappe.get_all("Course Lesson", fields=["name", "body"])
+
+	for lesson in lessons:
+		html = markdown_to_html(lesson.body)
+		frappe.db.set_value("Course Lesson", lesson.name, "body", html)
+
+	frappe.reload_doc("lms", "doctype", "course_lesson")

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -1561,7 +1561,7 @@ li {
 	outline: none;
 	background-color: var(--bg-light-gray);
 	border-radius: var(--border-radius);
-	border: 1px dashed var(--gray-600);
+	border: 1px solid var(--gray-300);
 	padding: 0.5rem 0.75rem;
 	color: var(--gray-900);
 }
@@ -1575,7 +1575,7 @@ li {
 	margin-top: 0.25rem;
 	background-color: var(--bg-light-gray);
 	border-radius: var(--border-radius);
-	border: 1px dashed var(--gray-600);
+	border: 1px solid var(--gray-300);
 	padding: 0.5rem 0.75rem;
 	width: fit-content;
 }

--- a/lms/www/batch/learn.html
+++ b/lms/www/batch/learn.html
@@ -176,7 +176,10 @@
         id="quiz-id">{% if lesson.quiz_id %}{{ lesson.quiz_id }}{% endif %}</div>
     </div>
 
-    <div id="body" {% if lesson.body %} data-body="{{ lesson.body }}" {% endif %}></div>
+    {% if lesson.body %}
+    <div class="body-data hide"> {{ lesson.body }} </div>
+    {% endif %}
+    <div id="body"></div>
 
     <div class="d-flex medium mx-0 mb-4">
         <div class="flex-grow-1" contenteditable="true" data-placeholder="{{ _('Assignment Question') }}"

--- a/lms/www/batch/learn.js
+++ b/lms/www/batch/learn.js
@@ -597,13 +597,8 @@ const make_editor = () => {
 		fields: [
 			{
 				fieldname: "code_md",
-				fieldtype: "Code",
-				options: "Markdown",
-				wrap: true,
-				max_lines: Infinity,
-				min_lines: 20,
-				default: $("#body").data("body"),
-				depends_on: 'eval:doc.type=="Markdown"',
+				fieldtype: "Text Editor",
+				default: $(".body-data").html(),
 			},
 		],
 		body: $("#body").get(0),

--- a/lms/www/courses/course.html
+++ b/lms/www/courses/course.html
@@ -201,7 +201,10 @@
 <!-- Description -->
 {% macro Description(course) %}
     {% if course.edit_mode %}
-        <div id="description" {% if course.description %} data-description="{{ course.description }}" {% endif %}></div>
+        {% if course.description %}
+        <div class="description-data hide">{{ course.description }}</div>
+        {% endif %}
+        <div id="description"></div>
     {% else %}
         <div class="course-description-section">
             {{ frappe.utils.md_to_html(course.description) }}
@@ -232,12 +235,12 @@
 <!-- Save -->
 {% macro Save(course) %}
     {% if course.edit_mode %}
-    <div class="mt-4 mb-16">
-        <button class="btn btn-primary btn-md btn-save-course">
+    <div class="mb-16">
+        <button class="btn btn-primary btn-sm btn-save-course">
             {{ _("Save Course Details") }}
         </button>
         {% if course.name %}
-        <a class="btn btn-secondary btn-md btn-exit-edit ml-2" href="/courses/{{ course.name }}">
+        <a class="btn btn-secondary btn-sm btn-exit-edit ml-2" href="/courses/{{ course.name }}">
             {{ _("Back to Course") }}
         </a>
         {% endif %}

--- a/lms/www/courses/course.js
+++ b/lms/www/courses/course.js
@@ -396,13 +396,8 @@ const make_editor = () => {
 		fields: [
 			{
 				fieldname: "code_md",
-				fieldtype: "Code",
-				options: "Markdown",
-				wrap: true,
-				max_lines: Infinity,
-				min_lines: 20,
-				default: $("#description").data("description"),
-				depends_on: 'eval:doc.type=="Markdown"',
+				fieldtype: "Text Editor",
+				default: $(".description-data").html(),
 			},
 		],
 		body: $("#description").get(0),


### PR DESCRIPTION
The Course Description and Lesson Body fields will now be markdown fields.

<img width="876" alt="Screenshot 2023-04-06 at 7 42 11 PM" src="https://user-images.githubusercontent.com/31363128/230403853-25bcc7ec-a56a-4661-9f24-79231df3f1ba.png">

<img width="1286" alt="Screenshot 2023-04-06 at 7 41 59 PM" src="https://user-images.githubusercontent.com/31363128/230403844-4e7845b0-c4b2-40b2-9a51-8de4d10744ac.png">

On migration, a patch will run to convert all markdown content to HTML for the Text Editor.