### PR TITLE
fix: don't allow guest users to search the people page

### DIFF
--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -300,7 +300,7 @@ def on_session_creation(login_manager):
 		frappe.local.response["home_page"] = "/courses"
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def search_users(start=0, text=""):
 	or_filters = get_or_filters(text)
 	count = len(get_users(or_filters, 0, 900000000, text))

--- a/lms/www/people/index.html
+++ b/lms/www/people/index.html
@@ -8,7 +8,9 @@
 <div class="common-page-style">
 	<div class="container">
 
+		{% if frappe.session.user != "Guest" %}
 		<input class="search pull-right" id="search-user" placeholder="{{ _('Search') }}">
+		{% endif  %}
 		<div class="course-home-headings">{{ _("People") }} </div>
 
 		<div class="empty-state alert alert-dismissible hide" id="search-empty-state">


### PR DESCRIPTION
Guest users will no longer be able to search the people page.