### PR TITLE
fix: telemetry capture on client side

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -235,6 +235,7 @@ jinja = {
 		"lms.lms.utils.get_filtered_membership",
 		"lms.lms.utils.show_start_learing_cta",
 		"lms.lms.utils.can_create_courses",
+		"lms.lms.utils.get_telemetry_boot_info",
 	],
 	"filters": [],
 }

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -698,3 +698,19 @@ def get_course_completion_data():
 			}
 		],
 	}
+
+
+def get_telemetry_boot_info():
+	POSTHOG_PROJECT_FIELD = "posthog_project_id"
+	POSTHOG_HOST_FIELD = "posthog_host"
+
+	if not frappe.conf.get(POSTHOG_HOST_FIELD) or not frappe.conf.get(
+		POSTHOG_PROJECT_FIELD
+	):
+		return {}
+
+	return {
+		"posthog_host": frappe.conf.get(POSTHOG_HOST_FIELD),
+		"posthog_project_id": frappe.conf.get(POSTHOG_PROJECT_FIELD),
+		"enable_telemetry": 1,
+	}

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -124,7 +124,7 @@ textarea.field-input {
 	border-bottom: none;
 }
 
-.outline-lesson .level {
+.outline-lesson .level, .chapter-container .level {
 	justify-content: start;
 }
 

--- a/lms/public/js/website.bundle.js
+++ b/lms/public/js/website.bundle.js
@@ -1,4 +1,3 @@
 import "./profile.js";
 import "./common_functions.js";
 import "../../../../frappe/frappe/public/js/frappe/ui/chart.js";
-import "../../../../frappe/frappe/public/js/telemetry/index.js";

--- a/lms/templates/lms_base.html
+++ b/lms/templates/lms_base.html
@@ -17,6 +17,6 @@
 		if (telemetry_boot_info && Object.keys(telemetry_boot_info).length)
 			Object.assign(frappe.boot, telemetry_boot_info)
 	</script>
-    {{ include_script("telemetry.bundle.js") }}
 	{% endif %}
+    {{ include_script("telemetry.bundle.js") }}
 {%- endblock -%}

--- a/lms/templates/lms_base.html
+++ b/lms/templates/lms_base.html
@@ -7,3 +7,16 @@
 		Hello, world!
 	{% endblock %}
 {% endblock %}
+
+{%- block script -%}
+	{{ super() }}
+	{% if frappe.get_system_settings("enable_telemetry") %}
+	{% set telemetry_boot_info = get_telemetry_boot_info() %}
+	<script>
+		const telemetry_boot_info = {{ get_telemetry_boot_info() }}
+		if (telemetry_boot_info && Object.keys(telemetry_boot_info).length)
+			Object.assign(frappe.boot, telemetry_boot_info)
+	</script>
+    {{ include_script("telemetry.bundle.js") }}
+	{% endif %}
+{%- endblock -%}


### PR DESCRIPTION
1. Client-side telemetry events were not getting captured
2. This was because the Posthog info was not getting set in the boot on the client side.
