### PR TITLE
fix: remove space from username

### DIFF
--- a/lms/overrides/test_user.py
+++ b/lms/overrides/test_user.py
@@ -20,14 +20,6 @@ class TestCustomUser(unittest.TestCase):
 		user = new_user("Username", "test-without-username@example.com")
 		self.assertTrue(user.username)
 
-	def test_with_illegal_characters(self):
-		user = new_user("Username$$", "test_with_illegal_characters@example.com")
-		self.assertEqual(user.username[:8], "username")
-
-	def test_with_underscore_at_end(self):
-		user = new_user("Username___", "test_with_underscore_at_end@example.com")
-		self.assertNotEqual(user.username[-1], "_")
-
 	def test_with_short_first_name(self):
 		user = new_user("USN", "test_with_short_first_name@example.com")
 		self.assertGreaterEqual(len(user.username), 4)
@@ -37,8 +29,6 @@ class TestCustomUser(unittest.TestCase):
 		users = [
 			"test_with_basic_username@example.com",
 			"test-without-username@example.com",
-			"test_with_illegal_characters@example.com",
-			"test_with_underscore_at_end@example.com",
 			"test_with_short_first_name@example.com",
 		]
 		frappe.db.delete("User", {"name": ["in", users]})

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -30,12 +30,6 @@ class CustomUser(User):
 		if " " in self.username:
 			self.username = self.username.replace(" ", "")
 
-	def get_username_from_first_name(self):
-		return frappe.scrub(self.first_name) + str(random.randint(0, 99))
-
-	def remove_illegal_characters(self):
-		return re.sub(r"[^\w]+", "", self.username).strip("_")
-
 	def validate_skills(self):
 		unique_skills = []
 		for skill in self.skill:

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -30,6 +30,9 @@ class CustomUser(User):
 		if " " in self.username:
 			self.username = self.username.replace(" ", "")
 
+		if len(self.username) < 4:
+			self.username = self.email.replace("@", "").replace(".", "")
+
 	def validate_skills(self):
 		unique_skills = []
 		for skill in self.skill:

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -57,8 +57,8 @@ class ProfilePage(BaseRenderer):
 		self.renderer = None
 
 	def can_render(self):
-		if "." in self.path:
-			return False
+		"""if "." in self.path:
+		return False"""
 
 		# has prefix and path starts with prefix?
 		prefix = get_profile_url_prefix().lstrip("/")
@@ -67,8 +67,8 @@ class ProfilePage(BaseRenderer):
 
 		# not a userpage?
 		username = self.get_username()
-		if RE_INVALID_USERNAME.search(username):
-			return False
+		""" if RE_INVALID_USERNAME.search(username):
+			return False """
 		# if there is prefix then we can allow all usernames
 		if prefix:
 			return True

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -2,7 +2,6 @@
 	--text-3-5xl: 24px;
 	--text-3-8xl: 34px;
 	--text-4xl: 36px;
-	--checkbox-gradient: linear-gradient(180deg, #3d4142 -124.51%, var(--primary) 100%);
 }
 
 .nav-link .course-list-count {
@@ -651,8 +650,12 @@ input[type=checkbox] {
 }
 
 .avatar-xl {
-  width: 112px;
-  height: 112px;
+  width: 8rem;
+  height: 8rem;
+}
+
+.avatar-xl .standard-image {
+	border: 4px solid #ffffff;
 }
 
 @media (max-width: 500px) {
@@ -791,9 +794,9 @@ input[type=checkbox] {
 }
 
 .profile-banner {
-  height: 248px;
-  background-size: cover;
-  background-position: center;
+	height: 248px;
+	background-size: cover;
+	background-position: center;
 }
 
 @media (max-width: 500px) {
@@ -803,24 +806,24 @@ input[type=checkbox] {
 }
 
 .profile-info {
-  height: 90px;
-  background: #ffffff;
-  border-radius: 0px 0px 8px 8px;
-  font-size: var(--text-sm);
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 2.5rem;
-  padding-left: 200px;
-  padding-right: 1rem;
-  box-shadow: var(--shadow-sm);
+	height: 90px;
+	background: #ffffff;
+	border-radius: 0px 0px 8px 8px;
+	font-size: var(--text-sm);
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 2.5rem;
+	padding-left: 200px;
+	padding-right: 1rem;
+	border: 1px solid var(--gray-300);
 }
 
 @media (max-width: 550px) {
-  .profile-info {
-	align-items: flex-end;
-	padding-left: 0;
-	height: 150px;
-  }
+	.profile-info {
+		align-items: flex-end;
+		padding-left: 0;
+		height: 150px;
+	}
 }
 
 .profile-avatar {
@@ -1524,10 +1527,6 @@ pre {
   margin: 0 1rem;
 }
 
-.profile-page-body {
-  background-color: var(--gray-50);
-}
-
 .profile-column-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
@@ -1802,6 +1801,8 @@ li {
 }
 
 .role {
+	display: flex;
+	align-items: center;
 	margin-bottom: 0;
 	cursor: pointer;
 }

--- a/lms/www/profiles/profile.html
+++ b/lms/www/profiles/profile.html
@@ -68,7 +68,7 @@
 
             <div class="tab-content">
                 <div class="tab-pane active" id="profile" role="tabpanel" aria-labelledby="profile">
-                    <div class="common-card-style column-card mt-5">
+                    <div class="">
                         {{ About(member) }}
                         {{ EducationDetails(member) }}
                         {{ WorkDetails(member) }}
@@ -126,7 +126,7 @@
 <div class="container">
     <div class="profile-banner" style="background-image: url({{ cover_image | urlencode }})">
         <div class="profile-avatar">
-            {{ widgets.Avatar(member=member, avatar_class="avatar-square") }}
+            {{ widgets.Avatar(member=member, avatar_class="avatar-xl") }}
         </div>
     </div>
 
@@ -201,9 +201,9 @@
 {% macro RoleSettings(member) %}
     {% if has_course_moderator_role() %}
         <div class="">
-            <div class="common-card-style column-card">
+            <div class="">
                 <div class="course-home-headings"> {{ _("Role Settings") }} </div>
-                <div class="medium">
+                <div class="d-flex">
                     <label class="role">
                         <input type="checkbox" id="course-creator" data-role="Course Creator"
                         {% if has_course_instructor_role(member.name) %} checked {% endif %}>


### PR DESCRIPTION
1. There were way too many restrictions on usernames.
2. If the app was installed on an existing site, and the users in the site had username set that did not meet these restrictions, validation messages are used to pop up on saving the user.
3. This behavior was confusing as there were no such issues before the app was installed.

![image](https://github.com/frappe/lms/assets/31363128/99566da5-9159-4572-80f1-dd0925fe85e8)

4. This PR removes all such restrictions.
5. There will only be a few checks on the username. Username should not contain space and the username cannot be duplicated.
6. All other restrictions and validations have been removed.