### PR TITLE
fix: embed video with spaces in name

### DIFF
--- a/lms/plugins.py
+++ b/lms/plugins.py
@@ -15,6 +15,7 @@ be loaded in a webpage.
 """
 
 import frappe
+from urllib.parse import quote
 
 
 class PageExtension:
@@ -138,7 +139,9 @@ def youtube_video_renderer(video_id):
 
 
 def video_renderer(src):
-	return f"<video controls width='100%'><source src={src} type='video/mp4'></video>"
+	return (
+		f"<video controls width='100%'><source src={quote(src)} type='video/mp4'></video>"
+	)
 
 
 def assignment_renderer(detail):

--- a/lms/www/batch/edit.js
+++ b/lms/www/batch/edit.js
@@ -263,6 +263,10 @@ class YouTubeVideo {
 		</iframe>`;
 	}
 
+	validate(savedData) {
+		return !savedData.youtube || !savedData.youtube.trim() ? false : true;
+	}
+
 	save(block_content) {
 		return {
 			youtube: this.data.youtube || this.youtube,
@@ -329,6 +333,10 @@ class Quiz {
 		</div>`;
 	}
 
+	validate(savedData) {
+		return !savedData.quiz || !savedData.quiz.trim() ? false : true;
+	}
+
 	save(block_content) {
 		return {
 			quiz: this.data.quiz || this.quiz,
@@ -383,6 +391,10 @@ class Upload {
 		} else {
 			return `<img src=${encodeURI(url)} width='100%'>`;
 		}
+	}
+
+	validate(savedData) {
+		return !savedData.file_url || !savedData.file_url.trim() ? false : true;
 	}
 
 	save(block_content) {


### PR DESCRIPTION
## Issue

When adding a video from our computer to the lesson, if the video name had spaces it was not working in the lesson.

## Fix

Videos with spaces will be accepted in lessons.

Also Fixes: #504