### PR TITLE
fix: show course settings only to moderators

### DIFF
--- a/lms/www/courses/create.html
+++ b/lms/www/courses/create.html
@@ -127,6 +127,7 @@
         </div>
     </div>
 
+    {% if is_moderator %}
     <div class="field-group vertically-center">
         <label for="published" class="vertically-center mb-0">
             <input type="checkbox" id="published" {% if course.published %} checked {% endif %}>
@@ -137,6 +138,7 @@
             {{ _("Upcoming") }}
         </label>
     </div>
+    {% endif %}
 
     <div class="field-group">
         <div>

--- a/lms/www/courses/create.py
+++ b/lms/www/courses/create.py
@@ -1,5 +1,9 @@
 import frappe
-from lms.lms.utils import redirect_to_courses_list, can_create_courses
+from lms.lms.utils import (
+	redirect_to_courses_list,
+	can_create_courses,
+	has_course_moderator_role,
+)
 from frappe import _
 
 
@@ -27,6 +31,7 @@ def get_context(context):
 	else:
 		set_course_context(context, course_name)
 
+	context.is_moderator = has_course_moderator_role()
 	context.member = frappe.db.get_value(
 		"User", frappe.session.user, ["full_name", "username"], as_dict=True
 	)


### PR DESCRIPTION
## Issue

Course Settings are visible to everyone right now

## Fix

Course Settings will only be visible to moderators