### PR TITLE
fix: quiz list in dialog

### DIFF
--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -7,8 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cstr
-
-from lms.lms.utils import generate_slug
+from lms.lms.utils import generate_slug, has_course_moderator_role
 
 
 class LMSQuiz(Document):
@@ -263,6 +262,5 @@ def check_input_answers(question, answer):
 
 @frappe.whitelist()
 def get_user_quizzes():
-	return frappe.get_all(
-		"LMS Quiz", filters={"owner": frappe.session.user}, fields=["name", "title"]
-	)
+	filters = {} if has_course_moderator_role() else {"owner": frappe.session.user}
+	return frappe.get_all("LMS Quiz", filters=filters, fields=["name", "title"])

--- a/lms/www/batch/edit.js
+++ b/lms/www/batch/edit.js
@@ -357,8 +357,6 @@ class Quiz {
 			primary_action(values) {
 				me.analyze_quiz_list(values);
 				quizdialog.hide();
-				/* self.quiz = values.quiz;
-				$(self.wrapper).html(self.render_quiz(self.quiz)); */
 			},
 			secondary_action_label: __("Create New Quiz"),
 			secondary_action: () => {
@@ -373,8 +371,7 @@ class Quiz {
 	}
 
 	analyze_quiz_list(values) {
-		/* If quiz is selected and is not already in the lesson then render it.
-		If quiz is in the lesson and is unselected then unrender it */
+		/* If quiz is selected and is not already in the lesson then render it.*/
 
 		this.quiz_to_render = [];
 		Object.keys(values).forEach((key) => {


### PR DESCRIPTION
When adding a quiz to a lesson, the dialog previously showed a link field. The dialog will now show a list of quizzes instead. Also, clear instructions on how to add a new quiz have been added.

https://github.com/frappe/lms/assets/31363128/c76244f1-88a4-4225-8aa9-7f719a2bbeb6

