### PR TITLE
fix: profile web form

### DIFF
--- a/lms/lms/doctype/work_experience/work_experience.json
+++ b/lms/lms/doctype/work_experience/work_experience.json
@@ -49,6 +49,7 @@
    "depends_on": "eval: !doc.current",
    "fieldname": "to_date",
    "fieldtype": "Date",
+   "in_list_view": 1,
    "label": "To Date",
    "mandatory_depends_on": "eval: !doc.current"
   },
@@ -61,6 +62,7 @@
    "default": "0",
    "fieldname": "current",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "I am currently working here"
   },
   {
@@ -71,7 +73,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-12-21 09:58:56.254035",
+ "modified": "2023-06-19 10:47:42.739249",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Work Experience",
@@ -79,5 +81,6 @@
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
## Issue

On entering work experience in the profile web form, it was throwing an error for **To Date**. But the field was not visible to users.

<img width="871" alt="Screenshot 2023-06-19 at 10 55 24 AM" src="https://github.com/frappe/lms/assets/31363128/2d7ff832-4763-4183-a77f-ffe2e5dab5cd">

## Fix

Both the **To Date** and **Currently Working here** fields will be visible to users now.