### PR TITLE
fix: course when instructor is not set

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -156,7 +156,7 @@ def get_tags(course):
 def get_instructors(course):
 	instructor_details = []
 	instructors = frappe.get_all(
-		"Course Instructor", {"parent": course}, ["instructor"], order_by="idx"
+		"Course Instructor", {"parent": course}, ["instructor"], order_by="idx", pluck="instructor"
 	)
 	if not instructors:
 		instructors = frappe.db.get_value("LMS Course", course, "owner").split(" ")
@@ -164,7 +164,7 @@ def get_instructors(course):
 		instructor_details.append(
 			frappe.db.get_value(
 				"User",
-				instructor.instructor,
+				instructor,
 				["name", "username", "full_name", "user_image"],
 				as_dict=True,
 			)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -156,7 +156,7 @@ def get_tags(course):
 def get_instructors(course):
 	instructor_details = []
 	instructors = frappe.get_all(
-		"Course Instructor", {"parent": course}, ["instructor"], order_by="idx", pluck="instructor"
+		"Course Instructor", {"parent": course}, order_by="idx", pluck="instructor"
 	)
 	if not instructors:
 		instructors = frappe.db.get_value("LMS Course", course, "owner").split(" ")


### PR DESCRIPTION
instructors = frappe.get_all(
		"Course Instructor", {"parent": course}, ["instructor"], order_by="idx"
	)
it return like
	[
		{"instructor": "user1"},
		{"instructor": "user2"}
	]
and the
if not instructors:
    instructors = frappe.db.get_value("LMS Course", course, "owner").split(" ")

return ["user1", "user2"]

and it make error if get all return []
because instructor.instructor at  https://github.com/frappe/lms/blob/main/lms/lms/utils.py#L167