### PR TITLE
Update certificate.py

### DIFF
--- a/lms/www/courses/certificate.py
+++ b/lms/www/courses/certificate.py
@@ -40,6 +40,20 @@ def get_context(context):
 		as_dict=True,
 	)
 
+	# SET Default Print Format For Certificate
+	if  not default_print_format:
+		default_print_format = frappe.get_doc(
+			{
+				"doctype": "Property Setter",
+				"doctype_or_field": "DocType",
+				"doc_type": "LMS Certificate",
+				"property": "default_print_format",
+				"property_type": "Data",
+				"value": "Certificate",
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
 	template = frappe.db.get_value(
 		"Print Format", default_print_format.value, ["html", "css"], as_dict=True
 	)


### PR DESCRIPTION
Because Of there is no default print format for LMS Certificate Doctype, the following error appears
![image](https://github.com/frappe/lms/assets/29175410/26e38250-80b4-4c65-a360-20ff0318fcd4)
..
So We Need to Create a Property Setter to Set Default Print Format For LMS Certificate Doctype