### PR TITLE
Update edit.js

### DIFF
--- a/lms/www/batch/edit.js
+++ b/lms/www/batch/edit.js
@@ -1,6 +1,8 @@
 frappe.ready(() => {
 	frappe.telemetry.capture("on_lesson_creation_page", "lms");
 	let self = this;
+	this.quiz_in_lesson = [];
+
 	if ($("#current-lesson-content").length) {
 		parse_string_to_lesson();
 	}


### PR DESCRIPTION
when you create new lesson and add a quiz , it throw error in console since 
	this.quiz_in_lesson = [];
get defiend in 		parse_string_to_lesson();

	if ($("#current-lesson-content").length) {
		parse_string_to_lesson();
	}
this function only get called if you saved the quiz and you are editing it , new quiz won't trigger the initialization for 	this.quiz_in_lesson = [];
