### PR TITLE
fix: Resolve issue with course not visible on website.

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -171,7 +171,7 @@ def get_instructors(course):
 		instructor_details.append(
 			frappe.db.get_value(
 				"User",
-				instructor.instructor,
+				instructor,
 				["name", "username", "full_name", "user_image"],
 				as_dict=True,
 			)


### PR DESCRIPTION
Fixed  https://github.com/frappe/lms/issues/587

**Problem**
- If `instructor` is not added for the course, then this issue arises.