### PR TITLE
fix: batch course sequence id issue

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -245,6 +245,10 @@ def fetch_lessons(courses):
 @frappe.whitelist()
 def add_course(course, parent, name=None, evaluator=None):
 	frappe.only_for("Moderator")
+
+	if frappe.db.exists("Batch Course", {"course": course, "parent": parent}):
+		frappe.throw(_("Course already added to the batch."))
+
 	if name:
 		doc = frappe.get_doc("Batch Course", name)
 	else:

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -69,3 +69,4 @@ lms.patches.v1_0.rename_lms_class_to_lms_batch
 lms.patches.v1_0.rename_classes_in_navbar
 lms.patches.v1_0.publish_batches
 lms.patches.v1_0.publish_certificates
+lms.patches.v1_0.change_naming_for_batch_course #14-09-2023

--- a/lms/patches/v1_0/change_naming_for_batch_course.py
+++ b/lms/patches/v1_0/change_naming_for_batch_course.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	frappe.db.create_sequence("Batch Course", check_not_exists=True)
+	frappe.db.set_next_sequence_val("Batch Course", 500, is_val_used=False)

--- a/lms/www/batches/batch_details.js
+++ b/lms/www/batches/batch_details.js
@@ -31,6 +31,7 @@ const show_course_modal = (e) => {
 				reqd: 1,
 				only_select: 1,
 				default: course || "",
+				read_only: course ? 1 : 0,
 			},
 			{
 				fieldtype: "Link",


### PR DESCRIPTION
## Issue

On adding new courses to a batch, an error was thrown

<img width="688" alt="Screenshot 2023-09-14 at 11 32 49 AM" src="https://github.com/frappe/lms/assets/31363128/22d5a629-a44b-4377-8316-6ebd23c11fba">

## Fix

A patch will run that will add a sequence for Batch Course if not already present and will set the next value to 500.