### PR TITLE
feat: audio in lessons

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -305,6 +305,7 @@ lms_markdown_macro_renderers = {
 	"Video": "lms.plugins.video_renderer",
 	"Assignment": "lms.plugins.assignment_renderer",
 	"Embed": "lms.plugins.embed_renderer",
+	"Audio": "lms.plugins.audio_renderer",
 }
 
 # page_renderer to manage profile pages

--- a/lms/plugins.py
+++ b/lms/plugins.py
@@ -178,9 +178,11 @@ def embed_renderer(details):
 
 
 def video_renderer(src):
-	return (
-		f"<video controls width='100%'><source src={quote(src)} type='video/mp4'></video>"
-	)
+	return f"<video controls width='100%' controls controlsList='nodownload'><source src={quote(src)} type='video/mp4'></video>"
+
+
+def audio_renderer(src):
+	return f"<audio width='100%' controls controlsList='nodownload'><source src={quote(src)} type='audio/mp3'></audio>"
 
 
 def assignment_renderer(detail):

--- a/lms/www/batches/batch.py
+++ b/lms/www/batches/batch.py
@@ -101,8 +101,8 @@ def get_context(context):
 	custom_tabs = frappe.get_hooks("lms_batch_tabs")
 
 	if custom_tabs:
-		context.custom_tabs_header = (custom_tabs.get("header_html")[0],)
-		context.custom_tabs_content = (custom_tabs.get("content_html")[0],)
+		context.custom_tabs_header = custom_tabs.get("header_html")[0]
+		context.custom_tabs_content = custom_tabs.get("content_html")[0]
 		context.update(frappe.get_attr(custom_tabs.get("context")[0])())
 
 


### PR DESCRIPTION
## Audio Support

You can now add audio files to your lesson. 

https://github.com/frappe/lms/assets/31363128/be543ec4-6547-4115-b7c7-78cba774e5b8

## Minor Fix

Previously, on adding a video file, the lesson showed a download option. This will no longer be shown.