### PR TITLE
feat: Days and Duration in timetable template

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.js
+++ b/lms/lms/doctype/lms_batch/lms_batch.js
@@ -39,9 +39,10 @@ frappe.ui.form.on("LMS Batch", {
 					fields: [
 						"reference_doctype",
 						"reference_docname",
-						"date",
+						"day",
 						"start_time",
 						"end_time",
+						"duration",
 					],
 					filters: {
 						parent: frm.doc.timetable_template,
@@ -61,9 +62,17 @@ const add_timetable_rows = (frm, timetable) => {
 		let child = frm.add_child("timetable");
 		child.reference_doctype = row.reference_doctype;
 		child.reference_docname = row.reference_docname;
-		child.date = row.date;
+		child.date = frappe.datetime.add_days(frm.doc.start_date, row.day - 1);
 		child.start_time = row.start_time;
-		child.end_time = row.end_time;
+		child.end_time = row.end_time
+			? row.end_time
+			: row.duration
+			? moment
+					.utc(row.start_time, "HH:mm")
+					.add(row.duration, "hour")
+					.format("HH:mm")
+			: null;
+		child.duration = row.duration;
 	});
 	frm.refresh_field("timetable");
 	frm.save();

--- a/lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
+++ b/lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
@@ -12,6 +12,7 @@
   "reference_doctype",
   "reference_docname",
   "date",
+  "day",
   "column_break_merq",
   "start_time",
   "end_time",
@@ -37,9 +38,9 @@
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.parenttype == \"LMS Batch\";",
    "fieldname": "date",
    "fieldtype": "Date",
-   "in_list_view": 1,
    "label": "Date"
   },
   {
@@ -51,7 +52,6 @@
   {
    "fieldname": "duration",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Duration"
   },
   {
@@ -63,12 +63,18 @@
    "fieldtype": "Time",
    "in_list_view": 1,
    "label": "End Time"
+  },
+  {
+   "depends_on": "eval: doc.parenttype == \"LMS Timetable Template\";",
+   "fieldname": "day",
+   "fieldtype": "Int",
+   "label": "Day"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-15 10:35:40.642660",
+ "modified": "2023-10-03 17:40:31.530181",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch Timetable",

--- a/lms/www/batches/index.py
+++ b/lms/www/batches/index.py
@@ -43,7 +43,7 @@ def get_context(context):
 		)
 		if not batch.published:
 			private_batches.append(batch)
-		elif getdate(batch.start_date) < getdate():
+		elif getdate(batch.start_date) <= getdate():
 			past_batches.append(batch)
 		else:
 			upcoming_batches.append(batch)


### PR DESCRIPTION
1. The timetable template will now have a Day field. You can add a day for all rows of the template. Based on this day, the dates in the actual timetable get populated.

2. The timetable template also has a duration field. So in case you don't add an end time, the end time in the timetable gets populated based on the duration in hours.

<img width="992" alt="Screenshot 2023-10-04 at 12 54 24 PM" src="https://github.com/frappe/lms/assets/31363128/20caa2a7-3240-48b5-ae67-4da50a9a412a">
