### PR TITLE
chore: bumped down paragraph plugin of editor js

### DIFF
--- a/lms/www/batch/edit.html
+++ b/lms/www/batch/edit.html
@@ -127,7 +127,7 @@
 {%- block script %}
     {{ super() }}
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/paragraph@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/paragraph@2.10.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/embed@latest"></script>
 {% endblock %}


### PR DESCRIPTION
LMS used the latest version of the paragraph plugin of Editor JS.

Due to some recent changes, it has stopped working.

So I have bumped down the version to 2.10