### PR TITLE
feat: batch source

### DIFF
--- a/lms/install.py
+++ b/lms/install.py
@@ -191,7 +191,7 @@ def create_batch_source():
 	]
 
 	for source in sources:
-		if not frappe.db.exists("LMS Batch Source", source):
-			doc = frappe.new_doc("LMS Batch Source")
+		if not frappe.db.exists("LMS Source", source):
+			doc = frappe.new_doc("LMS Source")
 			doc.source = source
 			doc.save()

--- a/lms/install.py
+++ b/lms/install.py
@@ -4,11 +4,11 @@ from frappe.desk.page.setup_wizard.setup_wizard import add_all_roles_to
 
 def after_install():
 	add_pages_to_nav()
+	create_batch_source()
 
 
 def after_sync():
 	create_lms_roles()
-	set_default_home()
 	set_default_certificate_print_format()
 	add_all_roles_to("Administrator")
 
@@ -62,10 +62,6 @@ def delete_lms_roles():
 	for role in roles:
 		if frappe.db.exists("Role", role):
 			frappe.db.delete("Role", role)
-
-
-def set_default_home():
-	frappe.db.set_single_value("Portal Settings", "default_portal_home", "/courses")
 
 
 def create_course_creator_role():
@@ -182,3 +178,20 @@ def delete_custom_fields():
 
 	for field in fields:
 		frappe.db.delete("Custom Field", {"fieldname": field})
+
+
+def create_batch_source():
+	sources = [
+		"Newsletter",
+		"LinkedIn",
+		"Twitter",
+		"Website",
+		"Friend/Colleague/Connection",
+		"Google Search",
+	]
+
+	for source in sources:
+		if not frappe.db.exists("LMS Batch Source", source):
+			doc = frappe.new_doc("LMS Batch Source")
+			doc.source = source
+			doc.save()

--- a/lms/lms/doctype/batch_student/batch_student.json
+++ b/lms/lms/doctype/batch_student/batch_student.json
@@ -9,11 +9,12 @@
  "field_order": [
   "student_details_section",
   "student",
-  "payment",
-  "confirmation_email_sent",
-  "column_break_oduu",
   "student_name",
-  "username"
+  "username",
+  "column_break_oduu",
+  "payment",
+  "source",
+  "confirmation_email_sent"
  ],
  "fields": [
   {
@@ -59,12 +60,18 @@
    "fieldname": "confirmation_email_sent",
    "fieldtype": "Check",
    "label": "Confirmation Email Sent"
+  },
+  {
+   "fieldname": "source",
+   "fieldtype": "Link",
+   "label": "Source",
+   "options": "LMS Source"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-09 17:09:50.481794",
+ "modified": "2023-10-26 16:52:04.266693",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Batch Student",

--- a/lms/lms/doctype/lms_payment/lms_payment.json
+++ b/lms/lms/doctype/lms_payment/lms_payment.json
@@ -10,6 +10,7 @@
  "field_order": [
   "payment_for_document_type",
   "member",
+  "source",
   "column_break_rqkd",
   "payment_for_document",
   "billing_name",
@@ -129,11 +130,17 @@
    "fieldtype": "Dynamic Link",
    "label": "Payment for Document",
    "options": "payment_for_document_type"
+  },
+  {
+   "fieldname": "source",
+   "fieldtype": "Link",
+   "label": "Source",
+   "options": "LMS Source"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-17 23:17:50.334975",
+ "modified": "2023-10-26 16:54:12.408274",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Payment",

--- a/lms/lms/doctype/lms_source/lms_source.js
+++ b/lms/lms/doctype/lms_source/lms_source.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("LMS Source", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/lms/lms/doctype/lms_source/lms_source.json
+++ b/lms/lms/doctype/lms_source/lms_source.json
@@ -1,0 +1,69 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:source",
+ "creation": "2023-10-26 16:28:53.932278",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "source"
+ ],
+ "fields": [
+  {
+   "fieldname": "source",
+   "fieldtype": "Data",
+   "label": "Source",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-10-26 17:25:09.144367",
+ "modified_by": "Administrator",
+ "module": "LMS",
+ "name": "LMS Source",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Moderator",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "LMS Student",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "source"
+}

--- a/lms/lms/doctype/lms_source/lms_source.py
+++ b/lms/lms/doctype/lms_source/lms_source.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class LMSSource(Document):
+	pass

--- a/lms/lms/doctype/lms_source/test_lms_source.py
+++ b/lms/lms/doctype/lms_source/test_lms_source.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestLMSSource(FrappeTestCase):
+	pass

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -898,7 +898,7 @@ def check_multicurrency(amount, currency, country=None):
 	currency = "USD"
 
 	if apply_rounding and amount % 100 != 0:
-		amount = ceil(amount + 100 - amount % 100)
+		amount = amount + 100 - amount % 100
 
 	return amount, currency
 
@@ -1028,12 +1028,13 @@ def record_payment(address, response, client, doctype, docname):
 			"amount_with_gst": payment_details["amount_with_gst"],
 			"gstin": address.gstin,
 			"pan": address.pan,
+			"source": address.source,
 			"payment_for_document_type": doctype,
 			"payment_for_document": docname,
 		}
 	)
 	payment_doc.save(ignore_permissions=True)
-	return payment_doc.name
+	return payment_doc
 
 
 def get_payment_details(doctype, docname, address):
@@ -1056,7 +1057,7 @@ def get_payment_details(doctype, docname, address):
 def create_membership(course, payment):
 	membership = frappe.new_doc("LMS Enrollment")
 	membership.update(
-		{"member": frappe.session.user, "course": course, "payment": payment}
+		{"member": frappe.session.user, "course": course, "payment": payment.name}
 	)
 	membership.save(ignore_permissions=True)
 	return f"/courses/{course}/learn/1.1"
@@ -1067,7 +1068,8 @@ def add_student_to_batch(batchname, payment):
 	student.update(
 		{
 			"student": frappe.session.user,
-			"payment": payment,
+			"payment": payment.name,
+			"source": payment.source,
 			"parent": batchname,
 			"parenttype": "LMS Batch",
 			"parentfield": "students",

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -76,3 +76,4 @@ lms.patches.v1_0.mark_confirmation_for_batch_students
 lms.patches.v1_0.create_quiz_questions
 lms.patches.v1_0.add_default_marks #16-10-2023
 lms.patches.v1_0.add_certificate_template #26-10-2023
+lms.patches.v1_0.create_batch_source

--- a/lms/patches/v1_0/create_batch_source.py
+++ b/lms/patches/v1_0/create_batch_source.py
@@ -1,0 +1,5 @@
+from lms.install import create_batch_source
+
+
+def execute():
+	create_batch_source()

--- a/lms/www/billing/billing.js
+++ b/lms/www/billing/billing.js
@@ -41,13 +41,13 @@ const setup_billing = () => {
 				default: address && address.city,
 			},
 			{
-				fieldtype: "Column Break",
-			},
-			{
 				fieldtype: "Data",
 				label: __("State/Province"),
 				fieldname: "state",
 				default: address && address.state,
+			},
+			{
+				fieldtype: "Column Break",
 			},
 			{
 				fieldtype: "Link",
@@ -74,6 +74,13 @@ const setup_billing = () => {
 				fieldname: "phone",
 				reqd: 1,
 				default: address && address.phone,
+			},
+			{
+				fieldtype: "Link",
+				label: __("Where did you hear about this?"),
+				fieldname: "source",
+				options: "LMS Source",
+				only_select: 1,
 			},
 			{
 				fieldtype: "Section Break",

--- a/lms/www/billing/billing.js
+++ b/lms/www/billing/billing.js
@@ -81,6 +81,7 @@ const setup_billing = () => {
 				fieldname: "source",
 				options: "LMS Source",
 				only_select: 1,
+				reqd: 1,
 			},
 			{
 				fieldtype: "Section Break",


### PR DESCRIPTION
The billing flow now has a source field where a student can select the source through which they got to know about the batch or course.

<img width="1427" alt="Screenshot 2023-10-26 at 5 45 43 PM" src="https://github.com/frappe/lms/assets/31363128/6ccb09ef-d3dd-44bb-96ee-320c1eb377a9">

This source information will be saved in the LMS Payment and LMS Batch Student doctype.

<img width="1428" alt="Screenshot 2023-10-26 at 5 47 14 PM" src="https://github.com/frappe/lms/assets/31363128/2e765d2e-d2d5-42d0-bd09-2cf4175da324">

<img width="989" alt="Screenshot 2023-10-26 at 5 46 52 PM" 
src="https://github.com/frappe/lms/assets/31363128/25cb6b95-6488-425d-82c0-2cdb5c6c45d9">

#638 