### PR TITLE
Fix: timetable validation

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -12,6 +12,7 @@ from frappe.utils import (
 	cint,
 	format_date,
 	format_datetime,
+	get_time,
 )
 from lms.lms.utils import get_lessons, get_lesson_index, get_lesson_url
 from lms.www.utils import get_quiz_details, get_assignment_details
@@ -117,7 +118,7 @@ class LMSBatch(Document):
 		for schedule in self.timetable:
 			if schedule.start_time and schedule.end_time:
 				if (
-					schedule.start_time > schedule.end_time or schedule.start_time == schedule.end_time
+					get_time(schedule.start_time) > get_time(schedule.end_time) or get_time(schedule.start_time) == get_time(schedule.end_time)
 				):
 					frappe.throw(
 						_("Row #{0} Start time cannot be greater than or equal to end time.").format(
@@ -125,14 +126,14 @@ class LMSBatch(Document):
 						)
 					)
 
-				if schedule.start_time < self.start_time or schedule.start_time > self.end_time:
+				if get_time(schedule.start_time) < get_time(self.start_time) or get_time(schedule.start_time) > get_time(self.end_time):
 					frappe.throw(
 						_("Row #{0} Start time cannot be outside the batch duration.").format(
 							schedule.idx
 						)
 					)
 
-				if schedule.end_time < self.start_time or schedule.end_time > self.end_time:
+				if get_time(schedule.end_time) < get_time(self.start_time) or get_time(schedule.end_time) > get_time(self.end_time):
 					frappe.throw(
 						_("Row #{0} End time cannot be outside the batch duration.").format(schedule.idx)
 					)


### PR DESCRIPTION
fix: typeError in validate_timetable

![image](https://github.com/frappe/lms/assets/47004596/b70b4182-9b6e-4396-98d7-4e26ecf15140)


getting error :- TypeError: '<' not supported between instances of 'str' and 'datetime.timedelta'
Possible source of error: mb_fxlh (app)

Used case :- Adding row in lms batch timetable from other doctype:
![image](https://github.com/frappe/lms/assets/47004596/39cc8331-5280-45b0-bb38-f8cfdf294be3)

with fix linters