### PR TITLE
Fix:timetable validation

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -12,6 +12,7 @@ from frappe.utils import (
 	cint,
 	format_date,
 	format_datetime,
+	get_time,
 )
 from lms.lms.utils import get_lessons, get_lesson_index, get_lesson_url
 from lms.www.utils import get_quiz_details, get_assignment_details
@@ -116,23 +117,27 @@ class LMSBatch(Document):
 	def validate_timetable(self):
 		for schedule in self.timetable:
 			if schedule.start_time and schedule.end_time:
-				if (
-					schedule.start_time > schedule.end_time or schedule.start_time == schedule.end_time
-				):
+				if get_time(schedule.start_time) > get_time(schedule.end_time) or get_time(
+					schedule.start_time
+				) == get_time(schedule.end_time):
 					frappe.throw(
 						_("Row #{0} Start time cannot be greater than or equal to end time.").format(
 							schedule.idx
 						)
 					)
 
-				if schedule.start_time < self.start_time or schedule.start_time > self.end_time:
+				if get_time(schedule.start_time) < get_time(self.start_time) or get_time(
+					schedule.start_time
+				) > get_time(self.end_time):
 					frappe.throw(
 						_("Row #{0} Start time cannot be outside the batch duration.").format(
 							schedule.idx
 						)
 					)
 
-				if schedule.end_time < self.start_time or schedule.end_time > self.end_time:
+				if get_time(schedule.end_time) < get_time(self.start_time) or get_time(
+					schedule.end_time
+				) > get_time(self.end_time):
 					frappe.throw(
 						_("Row #{0} End time cannot be outside the batch duration.").format(schedule.idx)
 					)


### PR DESCRIPTION
fix: typeError in validate_timetable

![image](https://github.com/frappe/lms/assets/47004596/8c6cc92e-6af7-4dc6-a91d-0c6cc9392090)


getting error :- TypeError: '<' not supported between instances of 'str' and 'datetime.timedelta'
Possible source of error: mb_fxlh (app)

Used case :- Adding row in lms batch timetable from other doctype:
![image](https://github.com/frappe/lms/assets/47004596/4675a1a4-c329-4583-8334-dc9890c50607)




![image](https://github.com/frappe/lms/assets/47004596/fc8dacf7-1332-4b3c-ae2f-707bd7fe4d42)


