### PR TITLE
fix: certificates in profile

### DIFF
--- a/lms/templates/certificates_section.html
+++ b/lms/templates/certificates_section.html
@@ -1,5 +1,3 @@
-{% set certificates = get_certificates(user) %}
-
 {% if certificates | length %}
 <div class="cards-parent">
     {% for certificate in certificates %}


### PR DESCRIPTION
## Issues
Profile page used to show wrong certificates on the profile page. It used to show the session users certificates instead of the profile users.

## Fix

Profile page will now show the profile users certification.