### PR TITLE
fix: get certificate button visibility

### DIFF
--- a/lms/www/courses/course.py
+++ b/lms/www/courses/course.py
@@ -56,6 +56,7 @@ def set_course_context(context, course_name):
 			"paid_course",
 			"course_price",
 			"currency",
+			"enable_certification",
 			"grant_certificate_after",
 		],
 		as_dict=True,


### PR DESCRIPTION
## Issue

After a user completes a course and the course has certification enabled, the Get Certificate button is not visible.

## Fix

The button will now be visible.

<img width="393" alt="Screenshot 2023-11-09 at 3 21 21 PM" src="https://github.com/frappe/lms/assets/31363128/796fe089-a271-42fb-8fa8-64792e406c66">
