### PR TITLE
fix: upcoming batches based on start time

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -120,12 +120,14 @@
   {
    "fieldname": "start_time",
    "fieldtype": "Time",
-   "label": "Start Time"
+   "label": "Start Time",
+   "reqd": 1
   },
   {
    "fieldname": "end_time",
    "fieldtype": "Time",
-   "label": "End Time"
+   "label": "End Time",
+   "reqd": 1
   },
   {
    "fieldname": "assessment_tab",
@@ -281,7 +283,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-12 12:53:37.351989",
+ "modified": "2023-11-17 10:41:00.340418",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",

--- a/lms/public/js/common_functions.js
+++ b/lms/public/js/common_functions.js
@@ -308,12 +308,14 @@ const open_batch_dialog = () => {
 				label: __("Start Time"),
 				fieldname: "start_time",
 				default: batch_info && batch_info.start_time,
+				reqd: 1,
 			},
 			{
 				fieldtype: "Time",
 				label: __("End Time"),
 				fieldname: "end_time",
 				default: batch_info && batch_info.end_time,
+				reqd: 1,
 			},
 			{
 				fieldtype: "Link",

--- a/lms/www/batches/index.html
+++ b/lms/www/batches/index.html
@@ -147,6 +147,18 @@
 			</span>
 		</div>
 
+		<div class="mt-auto mb-2">
+			<svg class="icon icon-sm">
+				<use href="#icon-clock"></use>
+			</svg>
+			<span>
+				{{ frappe.utils.format_time(batch.start_time, "HH:mm a") }} -
+			</span>
+			<span>
+				{{ frappe.utils.format_time(batch.end_time, "HH:mm a") }}
+			</span>
+		</div>
+
 		<div class="mb-2">
 			<svg class="icon icon-md">
 				<use href="#icon-education"></use>

--- a/lms/www/batches/index.py
+++ b/lms/www/batches/index.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import getdate
+from frappe.utils import getdate, get_time_str, nowtime
 from lms.lms.utils import (
 	has_course_moderator_role,
 	has_course_evaluator_role,
@@ -19,6 +19,8 @@ def get_context(context):
 			"description",
 			"start_date",
 			"end_date",
+			"start_time",
+			"end_time",
 			"paid_batch",
 			"amount",
 			"currency",
@@ -43,7 +45,11 @@ def get_context(context):
 		)
 		if not batch.published:
 			private_batches.append(batch)
-		elif getdate(batch.start_date) <= getdate():
+		elif getdate(batch.start_date) < getdate():
+			past_batches.append(batch)
+		elif (
+			getdate(batch.start_date) == getdate() and get_time_str(batch.start_time) < nowtime()
+		):
 			past_batches.append(batch)
 		else:
 			upcoming_batches.append(batch)


### PR DESCRIPTION
## Issue

If a batch starts this afternoon, then the batch does not appear in the upcoming batch list from today morning itself. The filters only consider the start date and not the start time. This prevents students from registering a batch even though a few hours are left before it starts.

## Fix
 A batch will be shown in the upcoming tab till its start date has passed.