### PR TITLE
fix: encode chapter during lesson creation

### DIFF
--- a/lms/www/batch/edit.html
+++ b/lms/www/batch/edit.html
@@ -70,7 +70,7 @@
             {{ _("Title") }}
         </div>
         <div class="">
-            <input id="lesson-title" type="text" class="field-input" data-index="{{ lesson_index }}" data-chapter="{{ chapter }}" data-course="{{ course.name }}" {% if lesson.name %} data-lesson="{{ lesson.name }}"  value="{{ lesson.title }}" {% endif %}>
+            <input id="lesson-title" type="text" class="field-input" data-index="{{ lesson_index }}" data-chapter="{{ chapter | urlencode }}" data-course="{{ course.name }}" {% if lesson.name %} data-lesson="{{ lesson.name }}"  value="{{ lesson.title }}" {% endif %}>
         </div>
     </div>
 

--- a/lms/www/batch/edit.js
+++ b/lms/www/batch/edit.js
@@ -234,7 +234,7 @@ const save = () => {
 		args: {
 			title: $("#lesson-title").val(),
 			body: this.lesson_content_data,
-			chapter: $("#lesson-title").data("chapter"),
+			chapter: decodeURIComponent($("#lesson-title").data("chapter")),
 			preview: $("#preview").prop("checked") ? 1 : 0,
 			idx: $("#lesson-title").data("index"),
 			lesson: lesson ? lesson : "",


### PR DESCRIPTION
## Issue

If the chapter name has special characters then it creates issues while adding a lesson to it.

![image](https://github.com/frappe/lms/assets/31363128/501b5633-7dcd-4252-ab5f-55c3aa0238fb)

## Fix

Encoding the chapter name solves the issue.