### PR TITLE
feat: evaluation end date

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -20,6 +20,7 @@
   "category",
   "column_break_flwy",
   "seat_count",
+  "evaluation_end_date",
   "section_break_6",
   "description",
   "batch_details_raw",
@@ -279,11 +280,16 @@
    "fieldname": "allow_future",
    "fieldtype": "Check",
    "label": "Allow accessing future dates"
+  },
+  {
+   "fieldname": "evaluation_end_date",
+   "fieldtype": "Date",
+   "label": "Evaluation End Date"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-17 10:41:00.340418",
+ "modified": "2023-11-29 12:06:58.776479",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
@@ -103,13 +103,13 @@
    "fieldname": "batch_name",
    "fieldtype": "Link",
    "in_standard_filter": 1,
-   "label": "Batch Name",
+   "label": "Batch",
    "options": "LMS Batch"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-23 14:50:37.618352",
+ "modified": "2023-11-29 15:00:30.617298",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Certificate Request",

--- a/lms/lms/notification/certificate_request_creation/certificate_request_creation.json
+++ b/lms/lms/notification/certificate_request_creation/certificate_request_creation.json
@@ -11,7 +11,8 @@
  "idx": 0,
  "is_standard": 1,
  "message": "{% set title = frappe.db.get_value(\"LMS Course\", doc.course, \"title\") %}\n\n<p> {{ _(\"Hey {0}\").format(doc.member_name) }} </p>\n<p> {{ _('Your evaluation for the course {0} has been scheduled on {1} at {2}.').format(title, frappe.utils.format_date(doc.date, \"medium\"), frappe.utils.format_time(doc.start_time, \"short\")) }}</p>\n<p> {{ _(\"Please prepare well and be on time for the evaluations.\") }} </p>\n",
- "modified": "2023-02-28 19:53:47.716135",
+ "message_type": "HTML",
+ "modified": "2023-11-29 17:34:54.514031",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Certificate Request Creation",
@@ -22,6 +23,9 @@
   },
   {
    "receiver_by_document_field": "evaluator"
+  },
+  {
+   "receiver_by_role": "Frappe School Admin"
   }
  ],
  "send_system_notification": 0,

--- a/lms/lms/notification/certificate_request_creation/certificate_request_creation.md
+++ b/lms/lms/notification/certificate_request_creation/certificate_request_creation.md
@@ -1,1 +1,0 @@
-<p> {{ _("Please prepare well and be on time for the evaluations.") }} </p>

--- a/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.html
+++ b/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.html
@@ -1,5 +1,5 @@
 {% set title = frappe.db.get_value("LMS Course", doc.course, "title") %}
 
-<p> {{ _("Hey {0}").format(doc.member_name) }} </p>
-<p> {{ _('Your evaluation for the course {0} has been scheduled on {1} at {2}.').format(title, frappe.utils.format_date(doc.date, "medium"), frappe.utils.format_time(doc.start_time, "short")) }}</p>
+<p> {{ _('Your evaluation for the course ${0} has been scheduled on ${1} at ${2}.').format(title, frappe.utils.format_date(doc.date, "medium"), frappe.utils.format_time(doc.start_time, "short")) }}</p>
+
 <p> {{ _("Please prepare well and be on time for the evaluations.") }} </p>

--- a/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.json
+++ b/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.json
@@ -11,8 +11,9 @@
  "event": "Days Before",
  "idx": 0,
  "is_standard": 1,
- "message": "{% set title = frappe.db.get_value(\"LMS Course\", doc.course, \"title\") %}\n<p> {{ _('Your evaluation for the course ${0} has been scheduled on ${1} at ${2}.').format(title, frappe.utils.format_date(doc.date, \"medium\"), frappe.utils.format_time(doc.start_time, \"short\")) }}</p>\n<p> {{ _(\"Please prepare well and be on time for the evaluations.\") }} </p>\n",
- "modified": "2022-06-03 11:51:02.681803",
+ "message": "{% set title = frappe.db.get_value(\"LMS Course\", doc.course, \"title\") %}\n\n<p> {{ _('Your evaluation for the course ${0} has been scheduled on ${1} at ${2}.').format(title, frappe.utils.format_date(doc.date, \"medium\"), frappe.utils.format_time(doc.start_time, \"short\")) }}</p>\n\n<p> {{ _(\"Please prepare well and be on time for the evaluations.\") }} </p>\n",
+ "message_type": "HTML",
+ "modified": "2023-11-29 17:26:53.355501",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Certificate Request Reminder",
@@ -20,6 +21,9 @@
  "recipients": [
   {
    "receiver_by_document_field": "member"
+  },
+  {
+   "receiver_by_document_field": "evaluator"
   }
  ],
  "send_system_notification": 0,

--- a/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.md
+++ b/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.md
@@ -1,3 +1,0 @@
-{% set title = frappe.db.get_value("LMS Course", doc.course, "title") %}
-<p> {{ _('Your evaluation for the course ${0} has been scheduled on ${1} at ${2}.').format(title, frappe.utils.format_date(doc.date, "medium"), frappe.utils.format_time(doc.start_time, "short")) }}</p>
-<p> {{ _("Please prepare well and be on time for the evaluations.") }} </p>

--- a/lms/www/batches/batch.html
+++ b/lms/www/batches/batch.html
@@ -639,6 +639,7 @@
 		let courses = {{ course_list | json }};
 		const legends = {{ legends | json }};
 		const allow_future = {{ batch_info.allow_future }}
+		const evaluation_end_date = "{{ batch_info.evaluation_end_date if batch_info.evaluation_end_date else '' }}"
 	</script>
 
 	<link rel="stylesheet" href="https://uicdn.toast.com/calendar/latest/toastui-calendar.min.css" />

--- a/lms/www/batches/batch.js
+++ b/lms/www/batches/batch.js
@@ -503,6 +503,7 @@ const remove_assessment = (e) => {
 };
 
 const open_evaluation_form = (e) => {
+	console.log(evaluation_end_date);
 	this.eval_form = new frappe.ui.Dialog({
 		title: __("Schedule Evaluation"),
 		fields: [
@@ -530,6 +531,9 @@ const open_evaluation_form = (e) => {
 				min_date: new Date(
 					frappe.datetime.add_days(frappe.datetime.get_today(), 1)
 				),
+				max_date: evaluation_end_date
+					? new Date(evaluation_end_date)
+					: "",
 				change: () => {
 					if (this.eval_form.get_value("date")) get_slots();
 				},

--- a/lms/www/batches/batch.py
+++ b/lms/www/batches/batch.py
@@ -43,6 +43,7 @@ def get_context(context):
 			"batch_details",
 			"published",
 			"allow_future",
+			"evaluation_end_date",
 		],
 		as_dict=True,
 	)


### PR DESCRIPTION
Moderators can now set an evaluation end date for batches. If this date is set then students will not be able to schedule evaluations after this date.

<img width="1043" alt="Screenshot 2023-11-29 at 5 09 36 PM" src="https://github.com/frappe/lms/assets/31363128/76360746-f27f-4e5a-acfd-e37a2020c9fc">

<img width="499" alt="Screenshot 2023-11-29 at 5 04 41 PM" src="https://github.com/frappe/lms/assets/31363128/17e10267-da16-4f66-ae16-cc58b1920ccf">
