### PR TITLE
feat: all day events

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.js
+++ b/lms/lms/doctype/lms_batch/lms_batch.js
@@ -28,6 +28,10 @@ frappe.ui.form.on("LMS Batch", {
 				},
 			};
 		});
+
+		if (frm.doc.timetable.length && !frm.doc.timetable_legends.length) {
+			set_default_legends(frm);
+		}
 	},
 
 	timetable_template: function (frm) {
@@ -123,6 +127,40 @@ const add_legend_rows = (frm, legends) => {
 		child.reference_doctype = row.reference_doctype;
 		child.label = row.label;
 		child.color = row.color;
+	});
+	frm.refresh_field("timetable_legends");
+	frm.save();
+};
+
+const set_default_legends = (frm) => {
+	const data = [
+		{
+			reference_doctype: "Course Lesson",
+			label: "Lesson",
+			color: "#449CF0",
+		},
+		{
+			reference_doctype: "LMS Quiz",
+			label: "LMS Quiz",
+			color: "#39E4A5",
+		},
+		{
+			reference_doctype: "LMS Assignment",
+			label: "LMS Assignment",
+			color: "#ECAD4B",
+		},
+		{
+			reference_doctype: "LMS Live Class",
+			label: "LMS Live Class",
+			color: "#bb8be8",
+		},
+	];
+
+	data.forEach((detail) => {
+		let child = frm.add_child("timetable_legends");
+		child.reference_doctype = detail.reference_doctype;
+		child.label = detail.label;
+		child.color = detail.color;
 	});
 	frm.refresh_field("timetable_legends");
 	frm.save();

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -2483,3 +2483,7 @@ select {
 .text-color {
 	color: var(--text-color);
 }
+
+.toastui-calendar-weekday-event-block {
+	box-shadow: none !important;
+}

--- a/lms/www/batches/batch.js
+++ b/lms/www/batches/batch.js
@@ -694,7 +694,11 @@ const get_calendar_options = (element, calendar_id) => {
 		template: {
 			time: function (event) {
 				let hide = event.raw.completed ? "" : "hide";
-				return `<div class="calendar-event-time">
+				return `<div class="calendar-event-time" title="${
+					event.title
+				} - ${frappe.datetime.get_time(
+					event.start.d.d
+				)} - ${frappe.datetime.get_time(event.end.d.d)}">
 						<img class='icon icon-sm pull-right ${hide}' src="/assets/lms/icons/check.svg">
 						<div> ${frappe.datetime.get_time(event.start.d.d)} -
 						${frappe.datetime.get_time(event.end.d.d)} </div>
@@ -739,6 +743,7 @@ const create_events = (calendar, events, calendar_id) => {
 };
 
 const format_time = (time) => {
+	if (!time) return "00:00:00";
 	let time_arr = time.split(":");
 	if (time_arr[0] < 10) time_arr[0] = "0" + time_arr[0];
 	return time_arr.join(":");

--- a/lms/www/batches/batch_details.py
+++ b/lms/www/batches/batch_details.py
@@ -33,6 +33,7 @@ def get_context(context):
 			"published",
 			"meta_image",
 			"batch_details_raw",
+			"evaluation_end_date",
 		],
 		as_dict=1,
 	)


### PR DESCRIPTION
Moderators can now add All Day events to the timetable. If you want to make an all-day event, don't set the start and end times for such events. 

<img width="1034" alt="Screenshot 2023-11-30 at 11 59 01 AM" src="https://github.com/frappe/lms/assets/31363128/0e5a9ff8-7ed3-45e9-b9e0-921d3b3c3065">

<img width="1367" alt="Screenshot 2023-11-30 at 11 59 34 AM" src="https://github.com/frappe/lms/assets/31363128/977b936b-f1e6-44f9-b36c-7dfc0a996196">
