### PR TITLE
fix: All day events style

### DIFF
--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -2387,6 +2387,7 @@ select {
 	border: 1px solid var(--gray-200) !important;
 	border-radius: var(--border-radius-md) !important;
 	background-color: var(--gray-100) !important;
+	overflow: auto;
 }
 
 .toastui-calendar-panel .toastui-calendar-day-names.toastui-calendar-week {

--- a/lms/www/batches/batch.js
+++ b/lms/www/batches/batch.js
@@ -692,6 +692,17 @@ const get_calendar_options = (element, calendar_id) => {
 			},
 		],
 		template: {
+			allday: function (event) {
+				let hide = event.raw.completed ? "" : "hide";
+				return `<div class="calendar-event-time" title="${
+					event.title
+				} - ${frappe.datetime.get_time(
+					event.start.d.d
+				)} - ${frappe.datetime.get_time(event.end.d.d)}">
+						<img class='icon icon-sm pull-right ${hide}' src="/assets/lms/icons/check.svg">
+						<div class="calendar-event-title"> ${event.title} </div>
+					</div>`;
+			},
 			time: function (event) {
 				let hide = event.raw.completed ? "" : "hide";
 				return `<div class="calendar-event-time" title="${
@@ -720,6 +731,7 @@ const create_events = (calendar, events, calendar_id) => {
 			start: `${event.date}T${format_time(event.start_time)}`,
 			end: `${event.date}T${format_time(event.end_time)}`,
 			isAllday: event.start_time ? false : true,
+			category: event.start_time ? "time" : "allday",
 			borderColor: clr,
 			backgroundColor: "var(--fg-color)",
 			customStyle: {
@@ -783,7 +795,7 @@ const add_links_to_events = (calendar) => {
 const scroll_to_date = (calendar, events) => {
 	if (
 		new Date() < new Date(events[0].date) ||
-		new Date() > new Date(events.slice(-1).date)
+		new Date() > new Date(events.slice(-1)[0].date)
 	) {
 		calendar.setDate(new Date(events[0].date));
 	}


### PR DESCRIPTION
## Before

The event title was not visible in the timetable for all-day events. Only start and end time was visible. This gave no idea to students and moderators about the activity unless they hovered over it.

![image](https://github.com/frappe/lms/assets/31363128/0332fe48-fb90-48e9-9ad6-2a573419265c)

## After

Now the title of the activity will be visible for all day events.

<img width="1422" alt="Screenshot 2023-12-07 at 3 59 30 PM" src="https://github.com/frappe/lms/assets/31363128/ed3f9219-17f9-4610-a480-c685d8681c39">

