### PR TITLE
fix: future date access on timetables for moderators

### DIFF
--- a/lms/www/batches/batch.html
+++ b/lms/www/batches/batch.html
@@ -638,7 +638,8 @@
 		frappe.boot.single_types = []
 		let courses = {{ course_list | json }};
 		const legends = {{ legends | json }};
-		const allow_future = {{ batch_info.allow_future }}
+		const allow_future = {{ batch_info.allow_future }};
+		const is_student = "{{ is_student or '' }}";
 		const evaluation_end_date = "{{ batch_info.evaluation_end_date if batch_info.evaluation_end_date else '' }}"
 	</script>
 

--- a/lms/www/batches/batch.js
+++ b/lms/www/batches/batch.js
@@ -765,13 +765,16 @@ const add_links_to_events = (calendar) => {
 	calendar.on("clickEvent", ({ event }) => {
 		let event_date = event.start.d.d;
 		event_date = moment(event_date).format("YYYY-MM-DD");
-
 		let current_date = moment().format("YYYY-MM-DD");
 
-		if (!moment(event_date).isSameOrBefore(current_date) && !allow_future)
+		if (
+			is_student &&
+			!moment(event_date).isSameOrBefore(current_date) &&
+			!allow_future
+		)
 			return;
 
-		if (event.raw.milestone) {
+		if (is_student && event.raw.milestone) {
 			frappe.call({
 				method: "lms.lms.doctype.lms_batch.lms_batch.is_milestone_complete",
 				args: {


### PR DESCRIPTION
## Issue

1. When Allow Future Dates were unchecked in a batch, even moderators and instructors were not allowed to access activities from future dates.
2. Milestones were being checked for moderators and instructors too.

## Fix

1. Now even if Allow Future Dates is unchecked, moderators will be allowed to access future activities.
2. Milestones will only be checked for students now.
