### PR TITLE
feat: day view for timetable on mobile

### DIFF
--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -16,6 +16,7 @@
   "portal_course_creation",
   "section_break_szgq",
   "send_calendar_invite_for_evaluations",
+  "show_day_view",
   "allow_student_progress",
   "column_break_2",
   "show_dashboard",
@@ -341,12 +342,18 @@
   {
    "fieldname": "column_break_uwsp",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_day_view",
+   "fieldtype": "Check",
+   "label": "Show Day View in Timetable"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-07 11:23:14.257687",
+ "modified": "2023-12-12 10:32:13.638368",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/public/css/style.css
+++ b/lms/public/css/style.css
@@ -2443,11 +2443,21 @@ select {
 }
 
 .calendar-legends {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	width: 50%;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	width: 75%;
 	margin: 0 auto 1rem;
+}
+
+@media (max-width: 767px) {
+	.calendar-legends {
+		grid-template-columns: repeat(2, 1fr);
+		width: 100%;
+	}
+
+	.legend-item {
+		margin-bottom: 0.5rem;
+	}
 }
 
 .batch-details {

--- a/lms/www/batches/batch.html
+++ b/lms/www/batches/batch.html
@@ -641,6 +641,7 @@
 		const allow_future = {{ batch_info.allow_future }};
 		const is_student = "{{ is_student or '' }}";
 		const evaluation_end_date = "{{ batch_info.evaluation_end_date if batch_info.evaluation_end_date else '' }}"
+		const show_day_view = {{ settings.show_day_view }};
 	</script>
 
 	<link rel="stylesheet" href="https://uicdn.toast.com/calendar/latest/toastui-calendar.min.css" />

--- a/lms/www/batches/batch.js
+++ b/lms/www/batches/batch.js
@@ -672,7 +672,7 @@ const get_calendar_options = (element, calendar_id) => {
 	const end_time = element.data("end");
 
 	return {
-		defaultView: "week",
+		defaultView: $(window).width() < 768 || show_day_view ? "day" : "week",
 		usageStatistics: false,
 		week: {
 			narrowWeekend: true,
@@ -805,22 +805,42 @@ const scroll_to_date = (calendar, events) => {
 };
 
 const set_calendar_range = (calendar, events) => {
-	let week_start = moment(calendar.getDateRangeStart().d.d);
-	let week_end = moment(calendar.getDateRangeEnd().d.d);
+	let day_view = $(window).width() < 768 || show_day_view ? true : false;
+	if (day_view) {
+		let calendar_date = moment(calendar.getDate().d.d).format(
+			"DD MMMM YYYY"
+		);
+		$(".calendar-range").text(`${calendar_date}`);
 
-	$(".calendar-range").text(
-		`${moment(week_start).format("DD MMMM YYYY")} - ${moment(
-			week_end
-		).format("DD MMMM YYYY")}`
-	);
+		if (moment(events[0].date).isSameOrBefore(moment(calendar)))
+			$("#prev-week").hide();
+		else $("#prev-week").show();
 
-	if (week_start.diff(moment(events[0].date), "days") <= 0)
-		$("#prev-week").hide();
-	else $("#prev-week").show();
+		if (
+			moment(calendar_date).isSameOrAfter(
+				moment(events.slice(-1)[0].date)
+			)
+		)
+			$("#next-week").hide();
+		else $("#next-week").show();
+	} else {
+		let week_start = moment(calendar.getDateRangeStart().d.d);
+		let week_end = moment(calendar.getDateRangeEnd().d.d);
 
-	if (week_end.diff(moment(events.slice(-1)[0].date), "days") > 0)
-		$("#next-week").hide();
-	else $("#next-week").show();
+		$(".calendar-range").text(
+			`${moment(week_start).format("DD MMMM YYYY")} - ${moment(
+				week_end
+			).format("DD MMMM YYYY")}`
+		);
+
+		if (week_start.diff(moment(events[0].date), "days") <= 0)
+			$("#prev-week").hide();
+		else $("#prev-week").show();
+
+		if (week_end.diff(moment(events.slice(-1)[0].date), "days") > 0)
+			$("#next-week").hide();
+		else $("#next-week").show();
+	}
 };
 
 const get_background_color = (doctype) => {


### PR DESCRIPTION
On smaller screen sizes, the timetable will have a day view now.

<img width="281" alt="Screenshot 2023-12-12 at 12 04 55 PM" src="https://github.com/frappe/lms/assets/31363128/04ed2f87-539f-467d-95fd-f5d169b9d327">

There is also a configuration in LMS Settings now where you can enable day view as default for all screens.

<img width="358" alt="Screenshot 2023-12-12 at 12 05 06 PM" src="https://github.com/frappe/lms/assets/31363128/b066d4e3-12c9-45eb-94c3-f85b1896f182">

If this is enabled the timetable will have a day view even on desktops.

<img width="1419" alt="Screenshot 2023-12-12 at 12 07 38 PM" src="https://github.com/frappe/lms/assets/31363128/25fb0c8b-cc9b-41f1-b64a-a6dccdfe72b8">