### PR TITLE
fix: evaluation fields

### DIFF
--- a/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
+++ b/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
@@ -47,12 +47,13 @@
    "fieldtype": "Rating",
    "in_list_view": 1,
    "label": "Rating",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.status != 'Pending' && doc.status != 'In Progress'"
   },
   {
    "fieldname": "summary",
    "fieldtype": "Small Text",
-   "label": "Summary"
+   "label": "Summary",
+   "mandatory_depends_on": "eval:doc.status != 'Pending' && doc.status != 'In Progress'"
   },
   {
    "fieldname": "date",
@@ -106,7 +107,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-26 19:44:43.594892",
+ "modified": "2023-12-18 20:03:27.040073",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Certificate Evaluation",

--- a/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.py
+++ b/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.py
@@ -8,7 +8,12 @@ from lms.lms.utils import has_course_moderator_role
 
 
 class LMSCertificateEvaluation(Document):
-	pass
+	def validate(self):
+		self.validate_rating()
+
+	def validate_rating(self):
+		if self.status not in ["Pending", "In Progress"] and self.rating == 0:
+			frappe.throw("Rating cannot be 0")
 
 
 def has_website_permission(doc, ptype, user, verbose=False):

--- a/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.py
+++ b/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from lms.lms.utils import has_course_moderator_role
@@ -13,7 +14,7 @@ class LMSCertificateEvaluation(Document):
 
 	def validate_rating(self):
 		if self.status not in ["Pending", "In Progress"] and self.rating == 0:
-			frappe.throw("Rating cannot be 0")
+			frappe.throw(_("Rating cannot be 0"))
 
 
 def has_website_permission(doc, ptype, user, verbose=False):


### PR DESCRIPTION
1. Rating field in evaluation doctype will only be mandatory if the status is Pass or Fail.
2. The summary field will also be mandatory now if the status is Pass or Fail.