### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,4 @@
 version: "3.7"
-name: lms
 services:
   mariadb:
     image: mariadb:10.6
@@ -7,14 +6,18 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --skip-character-set-client-handshake
-      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
+      # Removed the temporary fix as it might not be needed anymore or correct in new versions
     environment:
       MYSQL_ROOT_PASSWORD: 123
     volumes:
       - mariadb-data:/var/lib/mysql
+    networks:
+      - lms-network
 
   redis:
     image: redis:alpine
+    networks:
+      - lms-network
 
   frappe:
     image: frappe/bench:latest
@@ -25,8 +28,17 @@ services:
     volumes:
       - .:/workspace
     ports:
-      - 8000:8000
-      - 9000:9000
+      - "8000:8000"
+      - "9000:9000"
+    depends_on:
+      - mariadb
+      - redis
+    networks:
+      - lms-network
+
+networks:
+  lms-network:
+    driver: bridge
 
 volumes:
   mariadb-data:


### PR DESCRIPTION
With the latest version of "docker-compose", you get the following error using your file "docker-compose.yml".

![image](https://github.com/frappe/lms/assets/16117079/2bf03a5b-89d4-4751-aef1-ec7959cb8025)

I have update the file "docker-compose.yom" in order to deploy the software with Docker (and without any error).

## Changes and Additions:

- Removed the name field at the top as docker-compose doesn't support a name field at the root level.
- Quoted the port mappings in frappe service for consistency.
- Added a depends_on section under frappe to ensure it waits for mariadb and redis to be ready.
- Introduced a custom network lms-network to facilitate communication between the containers.
- Removed the --skip-innodb-read-only-compressed command from mariadb as it might not be relevant for newer versions and can cause issues. However, if you specifically need this for your setup, you should keep it.