### PR TITLE
fix: remove $ typos

### DIFF
--- a/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.json
+++ b/lms/lms/notification/certificate_request_reminder/certificate_request_reminder.json
@@ -11,7 +11,7 @@
  "event": "Days Before",
  "idx": 0,
  "is_standard": 1,
- "message": "{% set title = frappe.db.get_value(\"LMS Course\", doc.course, \"title\") %}\n\n<p> {{ _('Your evaluation for the course ${0} has been scheduled on ${1} at ${2}.').format(title, frappe.utils.format_date(doc.date, \"medium\"), frappe.utils.format_time(doc.start_time, \"short\")) }}</p>\n\n<p> {{ _(\"Please prepare well and be on time for the evaluations.\") }} </p>\n",
+ "message": "{% set title = frappe.db.get_value(\"LMS Course\", doc.course, \"title\") %}\n\n<p> {{ _('Your evaluation for the course {0} has been scheduled on {1} at {2}.').format(title, frappe.utils.format_date(doc.date, \"medium\"), frappe.utils.format_time(doc.start_time, \"short\")) }}</p>\n\n<p> {{ _(\"Please prepare well and be on time for the evaluations.\") }} </p>\n",
  "message_type": "HTML",
  "modified": "2023-11-29 17:26:53.355501",
  "modified_by": "Administrator",


### PR DESCRIPTION
Removes these:

![CleanShot 2024-01-22 at 10 28 23@2x](https://github.com/frappe/lms/assets/34810212/721e8fb8-004f-407e-8278-2e1ad9a2b7a2)
