### PR TITLE
feat: self enrolment in batches

### DIFF
--- a/lms/lms/doctype/batch_student/batch_student.py
+++ b/lms/lms/doctype/batch_student/batch_student.py
@@ -1,9 +1,19 @@
 # Copyright (c) 2022, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class BatchStudent(Document):
 	pass
+
+
+@frappe.whitelist()
+def enroll_batch(batch_name):
+	enrollment = frappe.new_doc("Batch Student")
+	enrollment.student = frappe.session.user
+	enrollment.parent = batch_name
+	enrollment.parentfield = "students"
+	enrollment.parenttype = "LMS Batch"
+	enrollment.save(ignore_permissions=True)

--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -15,6 +15,7 @@
   "start_time",
   "end_time",
   "published",
+  "allow_self_enrollment",
   "section_break_rgfj",
   "medium",
   "category",
@@ -293,11 +294,17 @@
    "fieldname": "amount_usd",
    "fieldtype": "Currency",
    "label": "Amount (USD)"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_self_enrollment",
+   "fieldtype": "Check",
+   "label": "Allow Self Enrollment"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-12-21 12:27:16.849362",
+ "modified": "2024-01-19 23:36:17.351413",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",
@@ -327,6 +334,15 @@
    "role": "Moderator",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "LMS Student",
+   "share": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -304,7 +304,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-01-19 23:36:17.351413",
+ "modified": "2024-01-22 10:42:42.872995",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",
@@ -334,15 +334,6 @@
    "role": "Moderator",
    "share": 1,
    "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "LMS Student",
-   "share": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/lms/www/batches/batch_details.html
+++ b/lms/www/batches/batch_details.html
@@ -146,6 +146,10 @@
                 href="/billing/batch/{{ batch_info.name }}">
                 {{ _("Register Now") }}
             </a>
+            {% elif batch_info.allow_self_enrollment %}
+            <button class="btn btn-primary wide-button enroll-batch">
+                {{ _("Enroll Now") }}
+            </button>
             {% else %}
             <div class="alert alert-info">
                 {{ _("To join this batch, please contact the Administrator.") }}

--- a/lms/www/batches/batch_details.js
+++ b/lms/www/batches/batch_details.js
@@ -12,6 +12,10 @@ frappe.ready(() => {
 	$(".btn-remove-course").click((e) => {
 		remove_course(e);
 	});
+
+	$(".enroll-batch").click((e) => {
+		enroll_batch(e);
+	});
 });
 
 const show_course_modal = (e) => {
@@ -52,6 +56,26 @@ const show_course_modal = (e) => {
 	setTimeout(() => {
 		$(".modal-body").css("min-height", "300px");
 	}, 1000);
+};
+
+const enroll_batch = (e) => {
+	let batch_name = $(".class-details").data("batch");
+	frappe.call({
+		method: "lms.lms.doctype.batch_student.batch_student.enroll_batch",
+		args: {
+			batch_name: batch_name,
+		},
+		callback(r) {
+			frappe.show_alert(
+				{
+					message: __("Successfully Enrolled"),
+					indicator: "green",
+				},
+				2000
+			);
+			window.location.href = `/batches/${batch_name}`;
+		},
+	});
 };
 
 const add_course = (values, course_name) => {

--- a/lms/www/batches/batch_details.py
+++ b/lms/www/batches/batch_details.py
@@ -35,6 +35,7 @@ def get_context(context):
 			"batch_details_raw",
 			"evaluation_end_date",
 			"amount_usd",
+			"allow_self_enrollment",
 		],
 		as_dict=1,
 	)


### PR DESCRIPTION
1. Moderators can now allow students to self-enroll themselves into unpaid batches.
2. Just enable the option Allow Self Enrollment for the batch.

<img width="1070" alt="Screenshot 2024-01-22 at 10 29 49 AM" src="https://github.com/frappe/lms/assets/31363128/73dff8ee-43b8-4bcc-b181-80e71ab3ba3f">

3. If this option is enabled, students will see a button **Enroll Now**, on the batch details page.
4. Clicking this button will enroll them into the batch.

<img width="401" alt="Screenshot 2024-01-22 at 10 34 10 AM" src="https://github.com/frappe/lms/assets/31363128/b8240742-b6f5-49a3-a3f2-4d9bbfde0426">
