### PR TITLE
fix: only show start date for single day batches

### DIFF
--- a/lms/www/batches/batch.html
+++ b/lms/www/batches/batch.html
@@ -49,11 +49,14 @@
 				<use href="#icon-calendar"></use>
 			</svg>
 			<span>
-				{{ frappe.utils.format_date(batch_info.start_date, "long") }} -
+				{{ frappe.utils.format_date(batch_info.start_date, "long") }}
 			</span>
+
+			{% if batch_info.start_date != batch_info.end_date %}
 			<span>
-				{{ frappe.utils.format_date(batch_info.end_date, "long") }}
+				- {{ frappe.utils.format_date(batch_info.end_date, "long") }}
 			</span>
+			{% endif %}
 		</div>
 
 		<span class="seperator"></span>

--- a/lms/www/batches/batch_details.html
+++ b/lms/www/batches/batch_details.html
@@ -57,11 +57,13 @@
                 <use href="#icon-calendar"></use>
             </svg>
             <span>
-                {{ frappe.utils.format_date(batch_info.start_date, "long") }} -
+                {{ frappe.utils.format_date(batch_info.start_date, "long") }}
             </span>
-            <span>
-                {{ frappe.utils.format_date(batch_info.end_date, "long") }}
-            </span>
+			{% if batch_info.start_date != batch_info.end_date %}
+			<span>
+				- {{ frappe.utils.format_date(batch_info.end_date, "long") }}
+			</span>
+			{% endif %}
         </div>
 
         {% if batch_info.start_time and batch_info.end_time %}
@@ -115,11 +117,13 @@
                 <use href="#icon-calendar"></use>
             </svg>
             <span>
-                {{ frappe.utils.format_date(batch_info.start_date, "long") }} -
+                {{ frappe.utils.format_date(batch_info.start_date, "long") }}
             </span>
-            <span>
-                {{ frappe.utils.format_date(batch_info.end_date, "long") }}
-            </span>
+			{% if batch_info.start_date != batch_info.end_date %}
+			<span>
+				- {{ frappe.utils.format_date(batch_info.end_date, "long") }}
+			</span>
+			{% endif %}
         </div>
 
         {% if batch_info.start_time and batch_info.end_time %}

--- a/lms/www/batches/index.html
+++ b/lms/www/batches/index.html
@@ -140,11 +140,13 @@
 				<use href="#icon-calendar"></use>
 			</svg>
 			<span>
-				{{ frappe.utils.format_date(batch.start_date, "medium") }} -
+				{{ frappe.utils.format_date(batch.start_date, "medium") }}
 			</span>
+			{% if batch.start_date != batch.end_date %}
 			<span>
-				{{ frappe.utils.format_date(batch.end_date, "medium") }}
+				- {{ frappe.utils.format_date(batch.end_date, "long") }}
 			</span>
+			{% endif %}
 		</div>
 
 		<div class="mb-2">


### PR DESCRIPTION
Closes #721 

![CleanShot 2024-01-22 at 10 49 21@2x](https://github.com/frappe/lms/assets/34810212/de8163eb-3966-41ce-ab73-2df7a8b832c8)


Also, while working on this I realise icon alignment is broken, but since the new revamp is coming, I let it be @pateljannat 