### PR TITLE
fix: no slots message

### DIFF
--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -27,7 +27,7 @@
 					</div>
 					<DatePicker v-model="evaluation.date" />
 				</div>
-				<div v-if="slots.data">
+				<div v-if="slots.data.length">
 					<div class="mb-1.5 text-sm text-gray-600">
 						{{ __('Select a slot') }}
 					</div>
@@ -45,6 +45,9 @@
 							</div>
 						</div>
 					</div>
+				</div>
+				<div v-else class="text-sm italic text-red-600">
+					{{ __('No slots available for this date.') }}
 				</div>
 			</div>
 		</template>


### PR DESCRIPTION
1. When there are it slots available on a day, it wasn't being indicated properly.
2. Now a proper message will be shows informing students that no slot is available in that day.

<img width="859" alt="Screenshot 2024-04-06 at 10 55 14 AM" src="https://github.com/frappe/lms/assets/31363128/5a03606d-d128-4878-82a0-1c080041a719">
