### PR TITLE
fix: check site conf before sending email

### DIFF
--- a/frontend/src/components/LessonPlugins.vue
+++ b/frontend/src/components/LessonPlugins.vue
@@ -3,12 +3,21 @@
 		{{ __('Components') }}
 	</div>
 	<div class="mt-5">
-		<div class="">
-			<div class="text-xs text-gray-600 mb-1">
-				{{ __('Select an Editor') }}
+		<Tooltip
+			:text="
+				__(
+					'Content such as quiz, video and image will be added in the editor you select.'
+				)
+			"
+			placement="bottom"
+		>
+			<div class="">
+				<div class="text-xs text-gray-600 mb-1">
+					{{ __('Select an Editor') }}
+				</div>
+				<Select v-model="currentEditor" :options="getEditorOptions()" />
 			</div>
-			<Select v-model="currentEditor" :options="getEditorOptions()" />
-		</div>
+		</Tooltip>
 		<div class="flex mt-4">
 			<Link
 				v-model="quiz"
@@ -63,7 +72,7 @@
 </template>
 <script setup>
 import Link from '@/components/Controls/Link.vue'
-import { FileUploader, Button, Select } from 'frappe-ui'
+import { FileUploader, Button, Select, Tooltip } from 'frappe-ui'
 import { Plus, FileText } from 'lucide-vue-next'
 import { ref, watch } from 'vue'
 

--- a/lms/job/doctype/lms_job_application/lms_job_application.py
+++ b/lms/job/doctype/lms_job_application/lms_job_application.py
@@ -14,7 +14,7 @@ class LMSJobApplication(Document):
 		outgoing_email_account = frappe.get_cached_value(
 			"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"
 		)
-		if outgoing_email_account:
+		if outgoing_email_account or frappe.conf.get("mail_login"):
 			self.send_email_to_employer()
 
 	def validate_duplicate(self):

--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -18,7 +18,7 @@ class LMSAssignmentSubmission(Document):
 			outgoing_email_account = frappe.get_cached_value(
 				"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"
 			)
-			if outgoing_email_account:
+			if outgoing_email_account or frappe.conf.get("mail_login"):
 				self.send_mail()
 
 	def validate_duplicates(self):

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -73,7 +73,9 @@ class LMSBatch(Document):
 			outgoing_email_account = frappe.get_cached_value(
 				"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"
 			)
-			if not student.confirmation_email_sent and outgoing_email_account:
+			if not student.confirmation_email_sent and (
+				outgoing_email_account or frappe.conf.get("mail_login")
+			):
 				self.send_mail(student)
 				student.confirmation_email_sent = 1
 

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -18,7 +18,7 @@ class LMSCertificate(Document):
 			outgoing_email_account = frappe.get_cached_value(
 				"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"
 			)
-			if outgoing_email_account:
+			if outgoing_email_account or frappe.conf.get("mail_login"):
 				self.send_mail()
 
 	def send_mail(self):


### PR DESCRIPTION
1. Before an email is sent when a certificate is created or when a student is added to a batch, the outgoing email account gets checked.
2. The email gets sent only if an outgoing email account exists.
3. This causes problems for sites that have email configured through site config.
4. So now before sending an email, site configuration will also be checked.