### PR TITLE
fix: editor holder not cleaned up

### DIFF
--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -245,6 +245,8 @@ const lesson = createResource({
 })
 
 const renderEditor = (holder, content) => {
+	// empty the holder
+	document.getElementById(holder).innerHTML = ''
 	return new EditorJS({
 		holder: holder,
 		tools: getEditorTools(),


### PR DESCRIPTION
Probably not the best fix, but works for now. EditorJS mounting etc. needs a refactor to be in the Vue world @pateljannat 