### PR TITLE
fix: title and tab button copy

### DIFF
--- a/frontend/src/pages/Courses.vue
+++ b/frontend/src/pages/Courses.vue
@@ -5,7 +5,7 @@
 		>
 			<Breadcrumbs
 				class="h-7"
-				:items="[{ label: __('All Courses'), route: { name: 'Courses' } }]"
+				:items="[{ label: __('Courses'), route: { name: 'Courses' } }]"
 			/>
 			<div class="flex">
 				<router-link
@@ -122,7 +122,7 @@ const courses = createListResource({
 const tabIndex = ref(0)
 const tabs = [
 	{
-		label: 'Live',
+		label: 'All',
 		courses: computed(() => courses.data?.live || []),
 		count: computed(() => courses.data?.live?.length),
 	},


### PR DESCRIPTION
Two problems with current copy: 

* "All Course" header is shown even when you switch to other tables, changes it to just Courses
* "Live" is internal terminology, "All" makes more sense

Before:
![CleanShot 2024-04-16 at 14 43 13@2x](https://github.com/frappe/lms/assets/34810212/0dcc4ac4-e0a1-4704-853b-3f15eccfd510)



After:
![CleanShot 2024-04-16 at 14 41 21@2x](https://github.com/frappe/lms/assets/34810212/ac83dff5-5ec2-40e2-9b9a-14ea27e30e55)
