### PR TITLE
feat: quiz shuffle

### DIFF
--- a/frontend/src/components/Modals/LiveClassModal.vue
+++ b/frontend/src/components/Modals/LiveClassModal.vue
@@ -17,78 +17,61 @@
 			<div class="flex flex-col gap-4">
 				<div class="grid grid-cols-2 gap-4">
 					<div>
-						<div class="mb-4">
-							<div class="mb-1.5 text-sm text-gray-600">
-								{{ __('Title') }}
-							</div>
-							<Input type="text" v-model="liveClass.title" />
-						</div>
-						<div class="mb-4">
-							<div class="mb-1.5 text-sm text-gray-600">
-								<Tooltip
-									class="flex items-center"
-									:text="
-										__(
-											'Time must be in 24 hour format (HH:mm). Example 11:30 or 22:00'
-										)
-									"
-								>
-									<span>
-										{{ __('Time') }}
-									</span>
-									<Info class="stroke-2 w-3 h-3 ml-1" />
-								</Tooltip>
-							</div>
-							<Input v-model="liveClass.time" />
-						</div>
-						<div>
-							<div class="mb-1.5 text-sm text-gray-600">
-								{{ __('Timezone') }}
-							</div>
-							<Select
-								v-model="liveClass.timezone"
-								:options="getTimezoneOptions()"
+						<FormControl
+							type="text"
+							v-model="liveClass.title"
+							:label="__('Title')"
+							class="mb-4"
+						/>
+						<Tooltip
+							:text="
+								__(
+									'Time must be in 24 hour format (HH:mm). Example 11:30 or 22:00'
+								)
+							"
+						>
+							<FormControl
+								v-model="liveClass.time"
+								type="time"
+								:label="__('Time')"
+								class="mb-4"
 							/>
-						</div>
+						</Tooltip>
+						<FormControl
+							v-model="liveClass.timezone"
+							type="select"
+							:options="getTimezoneOptions()"
+							:label="__('Timezone')"
+						/>
 					</div>
 					<div>
-						<div class="mb-4">
-							<div class="mb-1.5 text-sm text-gray-600">
-								{{ __('Date') }}
-							</div>
-							<DatePicker v-model="liveClass.date" inputClass="w-full" />
-						</div>
-						<div class="mb-4">
-							<div class="mb-1.5 text-sm text-gray-600">
-								<Tooltip
-									class="flex items-center"
-									:text="__('Duration of the live class in minutes')"
-								>
-									<span>
-										{{ __('Duration') }}
-									</span>
-									<Info class="stroke-2 w-3 h-3 ml-1" />
-								</Tooltip>
-							</div>
-							<Input type="number" v-model="liveClass.duration" />
-						</div>
-						<div>
-							<div class="mb-1.5 text-sm text-gray-600">
-								{{ __('Auto Recording') }}
-							</div>
-							<Select
-								v-model="liveClass.auto_recording"
-								:options="getRecordingOptions()"
+						<FormControl
+							v-model="liveClass.date"
+							type="date"
+							class="mb-4"
+							:label="__('Date')"
+						/>
+						<Tooltip :text="__('Duration of the live class in minutes')">
+							<FormControl
+								type="number"
+								v-model="liveClass.duration"
+								:label="__('Duration')"
+								class="mb-4"
 							/>
-						</div>
+						</Tooltip>
+						<FormControl
+							v-model="liveClass.auto_recording"
+							type="select"
+							:options="getRecordingOptions()"
+							:label="__('Auto Recording')"
+						/>
 					</div>
 				</div>
-				<div>
-					<div class="mb-1.5 text-sm text-gray-600">
-						{{ __('Description') }}
-					</div>
-					<Textarea v-model="liveClass.description" />
-				</div>
+				<FormControl
+					v-model="liveClass.description"
+					type="textarea"
+					:label="__('Description')"
+				/>
 			</div>
 		</template>
 	</Dialog>
@@ -102,6 +85,7 @@ import {
 	Dialog,
 	createResource,
 	Tooltip,
+	FormControl,
 } from 'frappe-ui'
 import { reactive, inject } from 'vue'
 import { getTimezones, createToast } from '@/utils/'

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -124,13 +124,16 @@
 									<MinusCircle v-else class="w-4 h-4" />
 								</div>
 							</div>
-							<span class="ml-2">
-								{{ questionDetails.data[`option_${index}`] }}
+							<span
+								class="ml-2"
+								v-html="questionDetails.data[`option_${index}`]"
+							>
 							</span>
 						</label>
 						<div
 							v-if="questionDetails.data[`explanation_${index}`]"
-							class="mt-2 text-sm hidden"
+							class="mt-2 text-xs"
+							v-show="showAnswers.length"
 						>
 							{{ questionDetails.data[`explanation_${index}`] }}
 						</div>
@@ -345,7 +348,8 @@ const checkAnswer = () => {
 		createToast({
 			title: 'Please select an option',
 			icon: 'alert-circle',
-			iconClasses: 'text-yellow-600 bg-yellow-100',
+			iconClasses: 'text-yellow-600 bg-yellow-100 rounded-full',
+			position: 'top-center',
 		})
 		return
 	}

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -247,6 +247,9 @@ const quiz = createResource({
 	cache: ['quiz', props.quizName],
 	auto: true,
 	onSuccess(data) {
+		if (data.shuffle_questions) {
+			data.questions = data.questions.sort(() => Math.random() - 0.5)
+		}
 		attempts.reload()
 		resetQuiz()
 	},

--- a/frontend/src/components/QuizBlock.vue
+++ b/frontend/src/components/QuizBlock.vue
@@ -23,4 +23,8 @@ const props = defineProps({
 		required: true,
 	},
 })
+
+const redirectToLogin = () => {
+	window.location.href = `/login`
+}
 </script>

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -184,7 +184,6 @@ def remove_assessment(assessment, parent):
 def create_live_class(
 	batch_name, title, duration, date, time, timezone, auto_recording, description=None
 ):
-	date = format_date(date, "yyyy-mm-dd", True)
 	frappe.only_for("Moderator")
 	payload = {
 		"topic": title,

--- a/lms/lms/doctype/lms_quiz/lms_quiz.json
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.json
@@ -8,14 +8,16 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
-  "show_answers",
+  "passing_percentage",
   "column_break_gaac",
   "max_attempts",
-  "show_submission_history",
-  "section_break_hsiv",
-  "passing_percentage",
-  "column_break_rocd",
   "total_marks",
+  "section_break_hsiv",
+  "show_answers",
+  "column_break_rocd",
+  "show_submission_history",
+  "column_break_dsup",
+  "shuffle_questions",
   "section_break_sbjx",
   "questions",
   "section_break_3",
@@ -97,7 +99,8 @@
   },
   {
    "fieldname": "section_break_hsiv",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Settings"
   },
   {
    "fieldname": "passing_percentage",
@@ -118,11 +121,21 @@
    "non_negative": 1,
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_dsup",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "shuffle_questions",
+   "fieldtype": "Check",
+   "label": "Shuffle Questions"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-27 13:04:00.785182",
+ "modified": "2024-04-24 12:37:20.578041",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Quiz",


### PR DESCRIPTION
1. You can now allow shuffling of quiz questions.
2. For this, check the Shuffle Quiz option when creating a quiz.

<img width="1326" alt="Screenshot 2024-04-25 at 12 29 02 PM" src="https://github.com/frappe/lms/assets/31363128/efb90186-e283-48b0-a4b5-a4c333d2031c">


3. When this option is enabled, quiz questions will appear in random order for each user.