### PR TITLE
fix: seo link redirections and guest certificate

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -146,9 +146,8 @@ website_redirects = [
 	{"source": "/update-profile", "target": "/edit-profile"},
 	{"source": "/courses", "target": "/lms/courses"},
 	{
-		"source": r"/courses/([^/]*)",
+		"source": r"^/courses/.*$",
 		"target": "/lms/courses",
-		"match_with_query_string": True,
 	},
 	{"source": "/batches", "target": "/lms/batches"},
 	{
@@ -232,7 +231,8 @@ jinja = {
 # ]
 
 has_website_permission = {
-	"LMS Certificate Evaluation": "lms.lms.doctype.lms_certificate_evaluation.lms_certificate_evaluation.has_website_permission"
+	"LMS Certificate Evaluation": "lms.lms.doctype.lms_certificate_evaluation.lms_certificate_evaluation.has_website_permission",
+	"LMS Certificate": "lms.lms.doctype.lms_certificate.lms_certificate.has_website_permission",
 }
 
 profile_mandatory_fields = [
@@ -270,6 +270,7 @@ lms_markdown_macro_renderers = {
 page_renderer = [
 	"lms.page_renderers.ProfileRedirectPage",
 	"lms.page_renderers.ProfilePage",
+	"lms.page_renderers.CoursePage",
 ]
 
 # set this to "/" to have profiles on the top-level

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -70,6 +70,12 @@ class LMSCertificate(Document):
 		)
 
 
+def has_website_permission(doc, ptype, user, verbose=False):
+	if ptype in ["read", "print"]:
+		return True
+	return False
+
+
 @frappe.whitelist()
 def create_certificate(course):
 	certificate = is_certified(course)

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -107,3 +107,34 @@ def render_portal_page(path, **kwargs):
 	frappe.form_dict.update(kwargs)
 	page = TemplatePage(path)
 	return page.render()
+
+
+class CoursePage(BaseRenderer):
+	def __init__(self, path, http_status_code):
+		super().__init__(path, http_status_code)
+		self.renderer = None
+
+	def can_render(self):
+		return self.path.startswith("course")
+
+	def render(self):
+		if "learn" in self.path:
+			prefix = self.path.split("/learn")[0]
+			course_name = prefix.split("/")[1]
+			lesson_index = self.path.split("/learn/")[1]
+			chapter_number = lesson_index.split(".")[0]
+			lesson_number = lesson_index.split(".")[1]
+
+			frappe.flags.redirect_location = (
+				f"/lms/courses/{course_name}/learn/{chapter_number}-{lesson_number}"
+			)
+			return RedirectPage(self.path).render()
+
+		elif len(self.path.split("/")) > 1:
+			course_name = self.path.split("/")[1]
+			frappe.flags.redirect_location = f"/lms/courses/{course_name}"
+			return RedirectPage(self.path).render()
+
+		else:
+			frappe.flags.redirect_location = "/lms/courses"
+			return RedirectPage(self.path).render()

--- a/lms/public/frontend/index.html
+++ b/lms/public/frontend/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="icon" href="/assets/lms/frontend/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Frappe UI App</title>
+		<title>Frappe Learning</title>
 		<meta name="title" content="{{ meta.title }}" />
 		<meta name="image" content="{{ meta.image }}" />
 		<meta name="description" content="{{ meta.description }}" />
@@ -15,10 +15,10 @@
 		<meta name="twitter:title" content="{{ meta.title }}" />
 		<meta name="twitter:image" content="{{ meta.image }}" />
 		<meta name="twitter:description" content="{{ meta.description }}" />
-		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-B0I4dIsL.js"></script>
-		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-BlL1CpdE.js">
-		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/frappe-ui-B1gEXx4C.css">
-		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-wBsCm0D8.css">
+		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-BIja_89l.js"></script>
+		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-Ccuocnz7.js">
+		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/frappe-ui-DzKBfka9.css">
+		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-DCVPIR2L.css">
 	</head>
 	<body>
 		<div id="app">


### PR DESCRIPTION
1. When Google searched Frappe School courses, the links from the search results were not working. Added redirection logic in page renderers.
2. The certificate PDF was not accessible to Guest users. Added website permission for this to work.