### PR TITLE
fix: quiz attempts load issue

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -253,8 +253,6 @@ const quiz = createResource({
 		if (data.shuffle_questions) {
 			data.questions = data.questions.sort(() => Math.random() - 0.5)
 		}
-		attempts.reload()
-		resetQuiz()
 	},
 })
 
@@ -285,6 +283,16 @@ const attempts = createResource({
 		})
 	},
 })
+
+watch(
+	() => quiz.data,
+	() => {
+		if (quiz.data) {
+			attempts.reload()
+			resetQuiz()
+		}
+	}
+)
 
 const quizSubmission = createResource({
 	url: 'lms.lms.doctype.lms_quiz.lms_quiz.quiz_summary',


### PR DESCRIPTION
Problem:

`attempts` resource was only getting reloaded onSuccess of quiz. But since `quiz` is cached, onSuccess does not run again on remount of the quiz (try switching between lessons). This results in max attempts exceeded message.

![CleanShot 2024-04-29 at 19 36 30@2x](https://github.com/frappe/lms/assets/34810212/f0f6499f-9674-4ae0-9bc7-fe9204b90275)

Solution: 
Reload attempts whenever quiz data changes