### PR TITLE
fix: lms api.py get_certificates api not whitelist 

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -376,6 +376,7 @@ def get_assigned_badges(member):
 		)
 	return assigned_badges
 
+
 @frappe.whitelist()
 def get_certificates(member):
 	"""Get certificates for a member."""

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -376,7 +376,7 @@ def get_assigned_badges(member):
 		)
 	return assigned_badges
 
-
+@frappe.whitelist()
 def get_certificates(member):
 	"""Get certificates for a member."""
 	return frappe.get_all(


### PR DESCRIPTION
In the LMS Develop branch Certified Participants page > Certificates Tab 
is not whitelisted.

![Screenshot from 2024-05-21 22-16-17](https://github.com/frappe/lms/assets/154776099/76cf2788-cfbd-4001-86f8-b46517fab3bb)
