### PR TITLE
fix: evaluation related issues

### DIFF
--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -116,7 +116,7 @@ function submitEvaluation(close) {
 			if (!evaluation.start_time) {
 				return 'Please select a slot.'
 			}
-			if (dayjs(evaluation.date).isSameOrBefore(dayjs(), 'day')) {
+			if (dayjs(evaluation.date).isBefore(dayjs(), 'day')) {
 				return 'Please select a future date.'
 			}
 			if (dayjs(evaluation.date).isAfter(dayjs(props.endDate), 'day')) {

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -84,7 +84,7 @@
 					type="date"
 					:label="__('From')"
 					v-model="from"
-					@change.stop="
+					@blur="
 						() => {
 							updateUnavailability.submit({
 								field: 'unavailable_from',
@@ -97,7 +97,7 @@
 					type="date"
 					:label="__('To')"
 					v-model="to"
-					@change.stop="
+					@blur="
 						() => {
 							updateUnavailability.submit({
 								field: 'unavailable_to',

--- a/lms/lms/doctype/course_evaluator/course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/course_evaluator.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from lms.lms.utils import get_evaluator
 from datetime import datetime
-from frappe.utils import get_time
+from frappe.utils import get_time, getdate
 
 
 class CourseEvaluator(Document):
@@ -18,7 +18,7 @@ class CourseEvaluator(Document):
 		if (
 			self.unavailable_from
 			and self.unavailable_to
-			and self.unavailable_from >= self.unavailable_to
+			and getdate(self.unavailable_from) >= getdate(self.unavailable_to)
 		):
 			frappe.throw(_("Unavailable From Date cannot be greater than Unavailable To Date"))
 


### PR DESCRIPTION
1. Learners were unable to schedule an evaluation for the current date even if the slot time has not yet passed.
2. Evaluators were getting an error when setting their unavailability from their profile.