### PR TITLE
fix: show loading indicator while live class creation

### DIFF
--- a/frontend/src/components/Modals/LiveClassModal.vue
+++ b/frontend/src/components/Modals/LiveClassModal.vue
@@ -153,7 +153,7 @@ const createLiveClass = createResource({
 })
 
 const submitLiveClass = (close) => {
-	createLiveClass.submit(liveClass, {
+	return createLiveClass.submit(liveClass, {
 		validate() {
 			if (!liveClass.title) {
 				return 'Please enter a title.'


### PR DESCRIPTION
FrappeUI's Dialog component automatically showa a loading indicator on Action if it is a promise. 