### PR TITLE
fix: event meeting generation

### DIFF
--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
@@ -14,6 +14,16 @@ frappe.ui.form.on("LMS Certificate Request", {
 				}
 			);
 		}
+		if (!frm.google_meet_link) {
+			frm.add_custom_button(__("Generate Google Meet Link"), () => {
+				frappe.call({
+					method: "lms.lms.doctype.lms_certificate_request.lms_certificate_request.setup_calendar_event",
+					args: {
+						eval: frm.doc,
+					},
+				});
+			});
+		}
 	},
 
 	onload: function (frm) {

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -15,6 +15,7 @@ from frappe.utils import (
 	get_time,
 )
 from lms.lms.utils import get_evaluator
+import json
 
 
 class LMSCertificateRequest(Document):
@@ -121,6 +122,9 @@ def schedule_evals():
 
 @frappe.whitelist()
 def setup_calendar_event(eval):
+	if isinstance(eval, str):
+		eval = frappe._dict(json.loads(eval))
+
 	calendar = frappe.db.get_value(
 		"Google Calendar", {"user": eval.evaluator, "enable": 1}, "name"
 	)

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -109,16 +109,17 @@ class LMSCertificateRequest(Document):
 
 def schedule_evals():
 	if frappe.db.get_single_value("LMS Settings", "send_calendar_invite_for_evaluations"):
-		one_hour_ago = add_to_date(get_datetime(), hours=-1)
+		timelapse = add_to_date(get_datetime(), hours=-5)
 		evals = frappe.get_all(
 			"LMS Certificate Request",
-			{"creation": [">=", one_hour_ago], "google_meet_link": ["is", "not set"]},
+			{"creation": [">=", timelapse], "google_meet_link": ["is", "not set"]},
 			["name", "member", "member_name", "evaluator", "date", "start_time", "end_time"],
 		)
 		for eval in evals:
 			setup_calendar_event(eval)
 
 
+@frappe.whitelist()
 def setup_calendar_event(eval):
 	calendar = frappe.db.get_value(
 		"Google Calendar", {"user": eval.evaluator, "enable": 1}, "name"


### PR DESCRIPTION
I have added a button on LMS Certificate Request to generate a Google Meet link. This button will only be visible if the Google Meet link is not present.

<img width="1426" alt="Screenshot 2024-06-12 at 10 47 00 AM" src="https://github.com/frappe/lms/assets/31363128/d7164aa4-b5bf-495c-8a35-823ec0be7d01">
