### PR TITLE
fix: better validation message on course creation

### DIFF
--- a/frontend/src/components/Controls/IconPicker.vue
+++ b/frontend/src/components/Controls/IconPicker.vue
@@ -60,7 +60,7 @@ const iconQuery = ref('')
 const selectedIcon = ref('')
 const search = ref(null)
 const emit = defineEmits(['update:modelValue', 'change'])
-console.log(icons)
+
 const iconArray = ref(
 	Object.keys(icons)
 		.sort(() => 0.5 - Math.random())
@@ -84,7 +84,6 @@ const props = defineProps({
 
 onMounted(() => {
 	selectedIcon.value = props.modelValue
-	console.log(search.value)
 })
 
 const setIcon = (icon, close) => {
@@ -111,9 +110,5 @@ const filteredIcons = computed(() => {
 
 const openPopover = (togglePopover) => {
 	togglePopover()
-	nextTick(() => {
-		/* search.value.focus() */
-		console.log(search.value.children)
-	})
 }
 </script>

--- a/frontend/src/pages/CreateCourse.vue
+++ b/frontend/src/pages/CreateCourse.vue
@@ -377,7 +377,7 @@ const submitCourse = () => {
 				})
 			},
 			onError(err) {
-				showToast(err)
+				showToast('Error', err.messages?.[0] || err, 'x')
 			},
 		})
 	}

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
@@ -14,7 +14,7 @@ frappe.ui.form.on("LMS Certificate Request", {
 				}
 			);
 		}
-		if (!frm.google_meet_link) {
+		if (!frm.doc.google_meet_link) {
 			frm.add_custom_button(__("Generate Google Meet Link"), () => {
 				frappe.call({
 					method: "lms.lms.doctype.lms_certificate_request.lms_certificate_request.setup_calendar_event",

--- a/lms/public/frontend/index.html
+++ b/lms/public/frontend/index.html
@@ -15,10 +15,10 @@
 		<meta name="twitter:title" content="{{ meta.title }}" />
 		<meta name="twitter:image" content="{{ meta.image }}" />
 		<meta name="twitter:description" content="{{ meta.description }}" />
-		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-Cn4HoVlw.js"></script>
-		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-C28JHUMc.js">
+		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-8W73ALq4.js"></script>
+		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-vM9kBbGH.js">
 		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/frappe-ui-DzKBfka9.css">
-		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-BUt7GESC.css">
+		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-CxRhs9Fi.css">
 	</head>
 	<body>
 		<div id="app">


### PR DESCRIPTION
The validation messages when creating a new course were not clear.

![image](https://github.com/frappe/lms/assets/31363128/b0f20d4b-9fcf-4ca8-9690-a8ad3d9751fa)

Made the message clear now

<img width="1434" alt="Screenshot 2024-06-12 at 11 43 48 AM" src="https://github.com/frappe/lms/assets/31363128/a1e7749e-8155-4d51-9547-bac2779350c5">
