### PR TITLE
feat: video and audio player

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -13,6 +13,6 @@ module.exports = defineConfig({
 		openMode: 0,
 	},
 	e2e: {
-		baseUrl: "http://pyp:8000",
+		baseUrl: "http://test_site_ui:8000",
 	},
 });

--- a/cypress/e2e/course_creation.cy.js
+++ b/cypress/e2e/course_creation.cy.js
@@ -113,15 +113,16 @@ describe("Course Creation", () => {
 		// View Lesson
 		cy.url().should("include", "/learn/1-1");
 		cy.get("div").contains("Test Lesson");
-		cy.get("div").contains(
-			"This is an extremely big paragraph that is meant to test the UI. This is a very long paragraph. It contains more than once sentence. Its meant to be this long as this is a UI test. Its unbearably long and I'm not sure why I'm typing this much. I'm just going to keep typing until I feel like its long enough. I think its long enough now. I'm going to stop typing now. "
-		);
 
 		cy.get("video")
 			.should("be.visible")
 			.children("source")
 			.invoke("attr", "src")
 			.should("include", "/files/Youtube");
+
+		cy.get("div").contains(
+			"This is an extremely big paragraph that is meant to test the UI. This is a very long paragraph. It contains more than once sentence. Its meant to be this long as this is a UI test. Its unbearably long and I'm not sure why I'm typing this much. I'm just going to keep typing until I feel like its long enough. I think its long enough now. I'm going to stop typing now."
+		);
 
 		// Add Discussion
 		cy.button("New Question").click();

--- a/cypress/e2e/course_creation.cy.js
+++ b/cypress/e2e/course_creation.cy.js
@@ -108,7 +108,7 @@ describe("Course Creation", () => {
 		cy.get("[id^=headlessui-disclosure-panel-").within(() => {
 			cy.get("div").contains("Test Lesson").click();
 		});
-		cy.wait(1000);
+		cy.wait(3000);
 
 		// View Lesson
 		cy.url().should("include", "/learn/1-1");

--- a/frontend/src/components/AudioBlock.vue
+++ b/frontend/src/components/AudioBlock.vue
@@ -1,19 +1,20 @@
 <template>
 	<div>
-		<audio width="100%" controls controlsList="nodownload" class="mb-4">
+		<!-- <audio width="100%" controls controlsList="nodownload" class="mb-4">
+			<source :src="encodeURI(file)" type="audio/mp3" />
+		</audio> -->
+		<audio @ended="handleAudioEnd" controlsList="nodownload" class="mb-4">
 			<source :src="encodeURI(file)" type="audio/mp3" />
 		</audio>
-		<audio width="100%" controlsList="nodownload" class="mb-4">
-			<source :src="encodeURI(file)" type="audio/mp3" />
-		</audio>
-		<div class="flex items-center space-x-4 p-2 shadow rounded-2xl">
+		<div
+			class="flex items-center space-x-2 shadow rounded-lg p-1 w-1/2 mx-auto"
+		>
 			<Button variant="ghost" @click="togglePlay">
 				<template #icon>
-					<Play v-if="!isPlaying" class="w-4 h-4 fill-gray-900" />
-					<Pause v-else class="w-4 h-4 fill-gray-900" />
+					<Play v-if="!isPlaying" class="w-4 h-4 text-gray-900" />
+					<Pause v-else class="w-4 h-4 text-gray-900" />
 				</template>
 			</Button>
-
 			<input
 				type="range"
 				min="0"
@@ -21,15 +22,15 @@
 				step="0.1"
 				v-model="currentTime"
 				@input="changeCurrentTime"
-				class="duration-slider"
+				class="duration-slider w-full h-1"
 			/>
-			<span class="text-xs text-gray-900 font-medium"
-				>{{ formatTime(currentTime) }} / {{ formatTime(duration) }}</span
-			>
+			<span class="text-xs text-gray-900 font-medium">
+				{{ formatTime(currentTime) }} / {{ formatTime(duration) }}
+			</span>
 			<Button variant="ghost" @click="toggleMute">
 				<template #icon>
-					<Volume2 v-if="!isMuted" class="w-4 h-4 fill-gray-900" />
-					<VolumeX v-else class="w-4 h-4 fill-gray-900" />
+					<Volume2 v-if="!isMuted" class="w-4 h-4 text-gray-900" />
+					<VolumeX v-else class="w-4 h-4 text-gray-900" />
 				</template>
 			</Button>
 		</div>
@@ -44,7 +45,6 @@ import { Button } from 'frappe-ui'
 const isPlaying = ref(false)
 const audio = ref(null)
 let isMuted = ref(false)
-let volume = ref(1)
 let currentTime = ref(0)
 let duration = ref(0)
 
@@ -60,7 +60,6 @@ onMounted(() => {
 		audio.value = document.querySelector('audio')
 		console.log(audio.value)
 		audio.value.onloadedmetadata = () => {
-			console.log(audio.value.duration)
 			duration.value = audio.value.duration
 		}
 		audio.value.ontimeupdate = () => {
@@ -88,6 +87,10 @@ const changeCurrentTime = () => {
 	audio.value.currentTime = currentTime.value
 }
 
+const handleAudioEnd = () => {
+	isPlaying.value = false
+}
+
 const formatTime = (time) => {
 	const minutes = Math.floor(time / 60)
 	const seconds = Math.floor(time % 60)
@@ -105,13 +108,30 @@ watch(isPlaying, (newVal) => {
 <style>
 .duration-slider {
 	flex: 1;
-	height: 0.25rem;
 	-webkit-appearance: none;
 	appearance: none;
 	background-color: theme('colors.gray.400');
+	cursor: pointer;
 }
 
-.duration-slider::-moz-range-track {
-	background: theme('colors.gray.900');
+.duration-slider::-webkit-slider-thumb {
+	height: 10px;
+	width: 10px;
+	-webkit-appearance: none;
+	background-color: theme('colors.gray.900');
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+	input[type='range'] {
+		overflow: hidden;
+		width: 150px;
+		-webkit-appearance: none;
+	}
+
+	input[type='range']::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		cursor: pointer;
+		box-shadow: -150px 0 0 150px theme('colors.gray.900');
+	}
 }
 </style>

--- a/frontend/src/components/AudioBlock.vue
+++ b/frontend/src/components/AudioBlock.vue
@@ -1,0 +1,117 @@
+<template>
+	<div>
+		<audio width="100%" controls controlsList="nodownload" class="mb-4">
+			<source :src="encodeURI(file)" type="audio/mp3" />
+		</audio>
+		<audio width="100%" controlsList="nodownload" class="mb-4">
+			<source :src="encodeURI(file)" type="audio/mp3" />
+		</audio>
+		<div class="flex items-center space-x-4 p-2 shadow rounded-2xl">
+			<Button variant="ghost" @click="togglePlay">
+				<template #icon>
+					<Play v-if="!isPlaying" class="w-4 h-4 fill-gray-900" />
+					<Pause v-else class="w-4 h-4 fill-gray-900" />
+				</template>
+			</Button>
+
+			<input
+				type="range"
+				min="0"
+				:max="duration"
+				step="0.1"
+				v-model="currentTime"
+				@input="changeCurrentTime"
+				class="duration-slider"
+			/>
+			<span class="text-xs text-gray-900 font-medium"
+				>{{ formatTime(currentTime) }} / {{ formatTime(duration) }}</span
+			>
+			<Button variant="ghost" @click="toggleMute">
+				<template #icon>
+					<Volume2 v-if="!isMuted" class="w-4 h-4 fill-gray-900" />
+					<VolumeX v-else class="w-4 h-4 fill-gray-900" />
+				</template>
+			</Button>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import { Play, Pause, Volume2, VolumeX } from 'lucide-vue-next'
+import { Button } from 'frappe-ui'
+
+const isPlaying = ref(false)
+const audio = ref(null)
+let isMuted = ref(false)
+let volume = ref(1)
+let currentTime = ref(0)
+let duration = ref(0)
+
+const props = defineProps({
+	file: {
+		type: String,
+		required: true,
+	},
+})
+
+onMounted(() => {
+	setTimeout(() => {
+		audio.value = document.querySelector('audio')
+		console.log(audio.value)
+		audio.value.onloadedmetadata = () => {
+			console.log(audio.value.duration)
+			duration.value = audio.value.duration
+		}
+		audio.value.ontimeupdate = () => {
+			currentTime.value = audio.value.currentTime
+		}
+	}, 0)
+})
+
+const togglePlay = () => {
+	if (audio.value.paused) {
+		audio.value.play()
+		isPlaying.value = true
+	} else {
+		audio.value.pause()
+		isPlaying.value = false
+	}
+}
+
+const toggleMute = () => {
+	audio.value.muted = !audio.value.muted
+	isMuted.value = audio.value.muted
+}
+
+const changeCurrentTime = () => {
+	audio.value.currentTime = currentTime.value
+}
+
+const formatTime = (time) => {
+	const minutes = Math.floor(time / 60)
+	const seconds = Math.floor(time % 60)
+	return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`
+}
+
+watch(isPlaying, (newVal) => {
+	if (newVal) {
+		audio.value.play()
+	} else {
+		audio.value.pause()
+	}
+})
+</script>
+<style>
+.duration-slider {
+	flex: 1;
+	height: 0.25rem;
+	-webkit-appearance: none;
+	appearance: none;
+	background-color: theme('colors.gray.400');
+}
+
+.duration-slider::-moz-range-track {
+	background: theme('colors.gray.900');
+}
+</style>

--- a/frontend/src/components/VideoBlock.vue
+++ b/frontend/src/components/VideoBlock.vue
@@ -1,0 +1,137 @@
+<template>
+	<div ref="videoContainer" class="video-block group relative">
+		<video @ended="videoEnded" class="rounded-lg">
+			<source :src="file" type="video/mp4" />
+		</video>
+		<div
+			class="flex items-center space-x-4 bg-gray-200 rounded-2xl p-0.5 absolute bottom-3 w-[98%] invisible group-hover:visible left-0 right-0 mx-auto"
+		>
+			<Button variant="ghost">
+				<template #icon>
+					<Play
+						v-if="!playing"
+						@click="playVideo"
+						class="w-4 h-4 fill-gray-900"
+					/>
+					<Pause v-else @click="pauseVideo" class="w-4 h-4 fill-gray-900" />
+				</template>
+			</Button>
+			<span class="text-xs font-medium">
+				{{ formatTime(currentTime) }} / {{ formatTime(duration) }}
+			</span>
+			<input
+				type="range"
+				min="0"
+				:max="duration"
+				step="0.1"
+				v-model="currentTime"
+				@input="changeTime"
+				class="duration-slider"
+			/>
+			<Button variant="ghost" @click="toggleMute">
+				<template #icon>
+					<Volume2 v-if="!muted" class="w-4 h-4 fill-gray-900" />
+					<VolumeX v-else class="w-4 h-4 fill-gray-900" />
+				</template>
+			</Button>
+			<Button variant="ghost" @click="toggleFullscreen">
+				<template #icon>
+					<Maximize class="w-4 h-4 fill-gray-900" />
+				</template>
+			</Button>
+		</div>
+	</div>
+</template>
+<script setup>
+import { ref, onMounted } from 'vue'
+import { Play, Pause, Maximize, Volume2, VolumeX } from 'lucide-vue-next'
+import { Button } from 'frappe-ui'
+
+const videoRef = ref(null)
+const videoContainer = ref(null)
+let playing = ref(false)
+let currentTime = ref(0)
+let duration = ref(0)
+let muted = ref(false)
+
+const props = defineProps({
+	file: {
+		type: String,
+		required: true,
+	},
+})
+
+onMounted(() => {
+	setTimeout(() => {
+		videoRef.value = document.querySelector('video')
+		videoRef.value.onloadedmetadata = loadedMetaData
+		videoRef.value.ontimeupdate = updateTime
+	}, 0)
+})
+
+const playVideo = () => {
+	videoRef.value.play()
+	playing.value = true
+}
+
+const pauseVideo = () => {
+	videoRef.value.pause()
+	playing.value = false
+}
+
+const videoEnded = () => {
+	playing.value = false
+}
+
+const toggleMute = () => {
+	videoRef.value.muted = !videoRef.value.muted
+	muted.value = videoRef.value.muted
+}
+
+const changeTime = () => {
+	videoRef.value.currentTime = currentTime.value
+}
+
+const loadedMetaData = () => {
+	duration.value = videoRef.value.duration
+}
+
+const updateTime = () => {
+	currentTime.value = videoRef.value.currentTime
+}
+
+const formatTime = (time) => {
+	const minutes = Math.floor(time / 60)
+	const seconds = Math.floor(time % 60)
+	return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`
+}
+
+const toggleFullscreen = () => {
+	if (document.fullscreenElement) {
+		document.exitFullscreen()
+	} else {
+		videoContainer.value.requestFullscreen()
+	}
+}
+</script>
+
+<style scoped>
+.video-block {
+	width: 100%;
+	max-width: 900px;
+	margin: 0 auto;
+}
+
+.video-block video {
+	width: 100%;
+	height: auto;
+}
+
+.duration-slider {
+	flex: 1;
+	height: 0.25rem;
+	-webkit-appearance: none;
+	appearance: none;
+	background-color: theme('colors.gray.400');
+}
+</style>

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -15,6 +15,7 @@ export const usersStore = defineStore('lms-users', () => {
 	const allUsers = createResource({
 		url: 'lms.lms.api.get_all_users',
 		cache: ['allUsers'],
+		auto: true,
 	})
 
 	return {

--- a/frontend/src/utils/customEmbed.js
+++ b/frontend/src/utils/customEmbed.js
@@ -1,0 +1,32 @@
+import Embed from '@editorjs/embed'
+import VideoBlock from '@/components/VideoBlock.vue'
+import { createApp } from 'vue'
+
+export class CustomEmbed extends Embed {
+	render() {
+		const container = super.render()
+		const { service, source, embed } = this.data
+
+		if (service === 'youtube' || service === 'vimeo') {
+			// Remove the iframe or existing embed content
+			container.innerHTML = ''
+
+			// Create a placeholder element for Vue component
+			const vueContainer = document.createElement('div')
+			vueContainer.setAttribute('data-service', service)
+			vueContainer.setAttribute('data-video-id', this.data.source)
+
+			// Append the Vue placeholder
+			container.appendChild(vueContainer)
+			console.log(source)
+			// Mount the Vue component (using a global Vue instance)
+			const app = createApp(VideoBlock, {
+				file: source,
+				type: 'video/youtube',
+			})
+			app.mount(vueContainer)
+		}
+
+		return container
+	}
+}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -4,12 +4,12 @@ import { Quiz } from '@/utils/quiz'
 import { Upload } from '@/utils/upload'
 import Header from '@editorjs/header'
 import Paragraph from '@editorjs/paragraph'
-import Embed from '@editorjs/embed'
 import { CodeBox } from '@/utils/code'
 import NestedList from '@editorjs/nested-list'
 import InlineCode from '@editorjs/inline-code'
-import { watch } from 'vue'
+import { watch, createApp } from 'vue'
 import dayjs from '@/utils/dayjs'
+import Embed from '@editorjs/embed'
 
 export function createToast(options) {
 	toast({
@@ -177,6 +177,20 @@ export function getEditorTools() {
 			},
 		},
 	}
+}
+
+function getVideoBlockHtml(medium) {
+	let regex
+	if (medium === 'youtube') {
+		regex =
+			/(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/
+		regex.exec(url)?.slice(1)
+	}
+	const wrapper = document.createElement('div')
+	const app = createApp(VideoBlock, {
+		file: file.file_url,
+	})
+	app.mount(wrapper)
 }
 
 export function getTimezones() {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -167,6 +167,7 @@ export function getEditorTools() {
 					youtube: true,
 					vimeo: true,
 					codepen: true,
+					aparat: true,
 					slides: {
 						regex: /https:\/\/docs\.google\.com\/presentation\/d\/e\/([A-Za-z0-9_-]+)\/pub/,
 						embedUrl:
@@ -177,20 +178,6 @@ export function getEditorTools() {
 			},
 		},
 	}
-}
-
-function getVideoBlockHtml(medium) {
-	let regex
-	if (medium === 'youtube') {
-		regex =
-			/(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/
-		regex.exec(url)?.slice(1)
-	}
-	const wrapper = document.createElement('div')
-	const app = createApp(VideoBlock, {
-		file: file.file_url,
-	})
-	app.mount(wrapper)
 }
 
 export function getTimezones() {

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -1,3 +1,7 @@
+import AudioBlock from '@/components/AudioBlock.vue'
+import VideoBlock from '@/components/VideoBlock.vue'
+import { createApp } from 'vue'
+
 export class Upload {
 	constructor({ data, api, readOnly }) {
 		this.data = data
@@ -10,19 +14,23 @@ export class Upload {
 
 	render() {
 		this.wrapper = document.createElement('div')
-		this.wrapper.innerHTML = this.renderUpload(this.data)
+		this.renderUpload(this.data)
 		return this.wrapper
 	}
 
 	renderUpload(file) {
 		if (this.isVideo(file.file_type)) {
-			return `<video controls width='100%' controlsList='nodownload' class="mb-4" oncontextmenu="return false;">
-				<source src=${encodeURI(file.file_url)} type='video/mp4'>
-			</video>`
+			const app = createApp(VideoBlock, {
+				file: file.file_url,
+			})
+			app.mount(this.wrapper)
+			return
 		} else if (this.isAudio(file.file_type)) {
-			return `<audio controls width='100%' controls controlsList='nodownload' class="mb-4">
-				<source src=${encodeURI(file.file_url)} type='audio/mp3'>
-			</audio>`
+			const app = createApp(AudioBlock, {
+				file: file.file_url,
+			})
+			app.mount(this.wrapper)
+			return
 		} else if (file.file_type == 'pdf') {
 			return `<iframe src="${encodeURI(
 				file.file_url

--- a/lms/public/frontend/index.html
+++ b/lms/public/frontend/index.html
@@ -15,10 +15,10 @@
 		<meta name="twitter:title" content="{{ meta.title }}" />
 		<meta name="twitter:image" content="{{ meta.image }}" />
 		<meta name="twitter:description" content="{{ meta.description }}" />
-		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-kSywU9PY.js"></script>
-		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-vM9kBbGH.js">
+		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-HOvpvn4K.js"></script>
+		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-0rNYcqgR.js">
 		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/frappe-ui-DzKBfka9.css">
-		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-CxRhs9Fi.css">
+		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-DOZMTxMe.css">
 	</head>
 	<body>
 		<div id="app">

--- a/lms/public/frontend/index.html
+++ b/lms/public/frontend/index.html
@@ -15,7 +15,7 @@
 		<meta name="twitter:title" content="{{ meta.title }}" />
 		<meta name="twitter:image" content="{{ meta.image }}" />
 		<meta name="twitter:description" content="{{ meta.description }}" />
-		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-HOvpvn4K.js"></script>
+		<script type="module" crossorigin src="/assets/lms/frontend/assets/index-Cjguiv45.js"></script>
 		<link rel="modulepreload" crossorigin href="/assets/lms/frontend/assets/frappe-ui-0rNYcqgR.js">
 		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/frappe-ui-DzKBfka9.css">
 		<link rel="stylesheet" crossorigin href="/assets/lms/frontend/assets/index-DOZMTxMe.css">


### PR DESCRIPTION
Audio and Video used the default HTML5 format. This was very inconsistent throughout browsers. 

**Chrome**
<img width="1423" alt="Screenshot 2024-06-20 at 4 56 11 PM" src="https://github.com/frappe/lms/assets/31363128/95133791-8609-4303-a619-4c8598e06d53">

**Firefox**
<img width="1426" alt="Screenshot 2024-06-20 at 4 56 28 PM" src="https://github.com/frappe/lms/assets/31363128/bb21445d-4296-46cc-be07-f22060095fec">

**Safari**
<img width="1428" alt="Screenshot 2024-06-20 at 4 57 36 PM" src="https://github.com/frappe/lms/assets/31363128/b69b6b66-7d9a-49d0-ae48-14ab6e5b301b">


Created components to make this consistent across browsers.

<img width="1423" alt="Screenshot 2024-06-20 at 5 42 07 PM" src="https://github.com/frappe/lms/assets/31363128/b5e05f49-b5b3-4d29-869f-4ea3864d9016">


https://github.com/frappe/lms/assets/31363128/9c7a6678-aa72-41cc-b85b-d98d18f75bb5




