### PR TITLE
feat: more embed sources for lesson components

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -168,11 +168,42 @@ export function getEditorTools() {
 					vimeo: true,
 					codepen: true,
 					aparat: true,
+					github: true,
 					slides: {
 						regex: /https:\/\/docs\.google\.com\/presentation\/d\/e\/([A-Za-z0-9_-]+)\/pub/,
 						embedUrl:
 							'https://docs.google.com/presentation/d/e/<%= remote_id %>/embed',
-						html: "<iframe style='width: 100%; height: 28rem;' frameborder='0' allowfullscreen='true'></iframe>",
+						html: "<iframe style='width: 100%; height: 30rem; border: 1px solid #D3D3D3; border-radius: 12px;' frameborder='0' allowfullscreen='true'></iframe>",
+					},
+					drive: {
+						regex: /https:\/\/drive\.google\.com\/file\/d\/([A-Za-z0-9_-]+)\/view(\?.+)?/,
+						embedUrl:
+							'https://drive.google.com/file/d/<%= remote_id %>/preview',
+						html: "<iframe style='width: 100%; height: 25rem; border: 1px solid #D3D3D3; border-radius: 12px;' frameborder='0' allowfullscreen='true'></iframe>",
+					},
+					docsPublic: {
+						regex: /https:\/\/docs\.google\.com\/document\/d\/([A-Za-z0-9_-]+)\/edit(\?.+)?/,
+						embedUrl:
+							'https://docs.google.com/document/d/<%= remote_id %>/preview',
+						html: "<iframe style='width: 100%; height: 40rem; border: 1px solid #D3D3D3; border-radius: 12px;' frameborder='0' allowfullscreen='true'></iframe>",
+					},
+					sheetsPublic: {
+						regex: /https:\/\/docs\.google\.com\/spreadsheets\/d\/([A-Za-z0-9_-]+)\/edit(\?.+)?/,
+						embedUrl:
+							'https://docs.google.com/spreadsheets/d/<%= remote_id %>/preview',
+						html: "<iframe style='width: 100%; height: 40rem; border: 1px solid #D3D3D3; border-radius: 12px;' frameborder='0' allowfullscreen='true'></iframe>",
+					},
+					slidesPublic: {
+						regex: /https:\/\/docs\.google\.com\/presentation\/d\/([A-Za-z0-9_-]+)\/edit(\?.+)?/,
+						embedUrl:
+							'https://docs.google.com/presentation/d/<%= remote_id %>/embed',
+						html: "<iframe style='width: 100%; height: 30rem; border: 1px solid #D3D3D3; border-radius: 12px;' frameborder='0' allowfullscreen='true'></iframe>",
+					},
+					codesandbox: {
+						regex: /^https:\/\/codesandbox\.io\/(?:embed\/)?([A-Za-z0-9_-]+)(?:\?[^\/]*)?$/,
+						embedUrl:
+							'https://codesandbox.io/embed/<%= remote_id %>?view=editor+%2B+preview&module=%2Findex.html',
+						html: "<iframe style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;' sandbox='allow-mods allow-forms allow-popups allow-scripts allow-same-origin' frameborder='0' allowfullscreen='true'></iframe>",
 					},
 				},
 			},


### PR DESCRIPTION
The following sources can now be embedded into lessons:

1. Videos from Google Drive: https://drive.google.com/file/d/some-id/view?usp=drive_link\

<img width="1427" alt="Screenshot 2024-06-27 at 12 42 17 PM" src="https://github.com/frappe/lms/assets/31363128/5710e0d7-3c03-4dda-86a5-90b4593443b6">

---

2. Google Docs: https://docs.google.com/document/d/some-id/edit?usp=sharing


<img width="1425" alt="Screenshot 2024-06-27 at 12 43 55 PM" src="https://github.com/frappe/lms/assets/31363128/59e22922-b848-4321-ae25-e543b500265a">

---

3. Google Sheets: https://docs.google.com/spreadsheets/d/some-id/edit?usp=sharing

<img width="1426" alt="Screenshot 2024-06-27 at 12 44 11 PM" src="https://github.com/frappe/lms/assets/31363128/a707db1a-24d0-4629-b3fa-c4a596d51396">

---

4. Google Slides: https://docs.google.com/presentation/d/some-id

<img width="1427" alt="Screenshot 2024-06-27 at 12 44 24 PM" src="https://github.com/frappe/lms/assets/31363128/9be513a9-7039-4498-9a55-ea9a0de5a381">

---

5. Codesandbox: https://codesandbox.io/embed/some-id?view=editor+%2B+preview&module=%2Findex.html

<img width="1421" alt="Screenshot 2024-06-27 at 12 44 39 PM" src="https://github.com/frappe/lms/assets/31363128/2f5a3f01-6f51-4fb6-9918-bcf97052ea3f">

---

6. Google Gist: https://gist.github.com/username/some-id

<img width="1428" alt="Screenshot 2024-06-27 at 12 44 51 PM" src="https://github.com/frappe/lms/assets/31363128/8c80753c-6483-427e-9241-4d9556572f5e">

NOTE: All the above URLs are just examples of the format. For google suite embeds if the user does not have permission to that document the content will not be visible to them.