### PR TITLE
feat: limit questions in quiz

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -270,6 +270,9 @@ const quiz = createResource({
 		if (data.shuffle_questions) {
 			data.questions = data.questions.sort(() => Math.random() - 0.5)
 		}
+		if (data.limit_questions_to) {
+			data.questions = data.questions.slice(0, data.limit_questions_to)
+		}
 	},
 })
 

--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -242,25 +242,6 @@ has_website_permission = {
 	"LMS Certificate": "lms.lms.doctype.lms_certificate.lms_certificate.has_website_permission",
 }
 
-profile_mandatory_fields = [
-	"first_name",
-	"last_name",
-	"user_image",
-	"bio",
-	"linkedin",
-	"education",
-	"skill",
-	"preferred_functions",
-	"preferred_industries",
-	"dream_companies",
-	"attire",
-	"collaboration",
-	"role",
-	"location_preference",
-	"time",
-	"company_type",
-]
-
 ## Markdown Macros for Lessons
 lms_markdown_macro_renderers = {
 	"Exercise": "lms.plugins.exercise_renderer",

--- a/lms/lms/doctype/lms_quiz/lms_quiz.json
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.json
@@ -8,10 +8,11 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
-  "passing_percentage",
-  "column_break_gaac",
   "max_attempts",
+  "limit_questions_to",
+  "column_break_gaac",
   "total_marks",
+  "passing_percentage",
   "section_break_hsiv",
   "show_answers",
   "column_break_rocd",
@@ -23,8 +24,7 @@
   "section_break_3",
   "lesson",
   "column_break_5",
-  "course",
-  "time"
+  "course"
  ],
  "fields": [
   {
@@ -53,13 +53,6 @@
    "fieldname": "max_attempts",
    "fieldtype": "Int",
    "label": "Max Attempts"
-  },
-  {
-   "default": "0",
-   "fieldname": "time",
-   "fieldtype": "Int",
-   "hidden": 1,
-   "label": "Time Per Question (in Seconds)"
   },
   {
    "fetch_from": "lesson.course",
@@ -131,11 +124,16 @@
    "fieldname": "shuffle_questions",
    "fieldtype": "Check",
    "label": "Shuffle Questions"
+  },
+  {
+   "fieldname": "limit_questions_to",
+   "fieldtype": "Int",
+   "label": "Limit Questions To"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-24 12:37:20.578041",
+ "modified": "2024-06-27 22:03:48.576489",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Quiz",

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -6,7 +6,6 @@
  "engine": "InnoDB",
  "field_order": [
   "default_home",
-  "force_profile_completion",
   "is_onboarding_complete",
   "column_break_zdel",
   "unsplash_access_key",
@@ -103,13 +102,6 @@
    "fieldname": "search_placeholder",
    "fieldtype": "Data",
    "label": "Course List Search Bar Placeholder"
-  },
-  {
-   "default": "0",
-   "fieldname": "force_profile_completion",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Force users to complete their Profile"
   },
   {
    "default": "0",
@@ -431,7 +423,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-31 20:17:07.362088",
+ "modified": "2024-06-27 21:57:02.193336",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -776,10 +776,6 @@ def get_lesson_count(course):
 	return lesson_count
 
 
-def check_profile_restriction():
-	return frappe.db.get_single_value("LMS Settings", "force_profile_completion")
-
-
 def get_restriction_details():
 	user = frappe.db.get_value(
 		"User", frappe.session.user, ["profile_complete", "username"], as_dict=True

--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -15,7 +15,6 @@ class CustomUser(User):
 	def validate(self):
 		super().validate()
 		self.validate_username_duplicates()
-		self.validate_completion()
 
 	def validate_username_duplicates(self):
 		while not self.username or self.username_exists():
@@ -37,19 +36,6 @@ class CustomUser(User):
 				unique_skills.append(skill.skill_name)
 			else:
 				frappe.throw(_("Skills must be unique"))
-
-	def validate_completion(self):
-		if frappe.db.get_single_value("LMS Settings", "force_profile_completion"):
-			all_fields_have_value = True
-			profile_mandatory_fields = frappe.get_hooks("profile_mandatory_fields")
-			docfields = frappe.get_meta(self.doctype).fields
-
-			for field in profile_mandatory_fields:
-				if not self.get(field):
-					all_fields_have_value = False
-					break
-
-			self.profile_complete = all_fields_have_value
 
 	def get_batch_count(self) -> int:
 		"""Returns the number of batches authored by this user."""

--- a/lms/plugins.py
+++ b/lms/plugins.py
@@ -91,17 +91,6 @@ class LiveCodeExtension(PageExtension):
 		return frappe.render_template("templates/livecode/extension_footer.html", context)
 
 
-def set_mandatory_fields_for_profile():
-	profile_form = frappe.get_doc("Web Form", "profile")
-	profile_mandatory_fields = frappe.get_hooks("profile_mandatory_fields")
-	for field in profile_form.web_form_fields:
-		field.reqd = 0
-		if field.fieldname in profile_mandatory_fields:
-			field.reqd = 1
-
-	profile_form.save()
-
-
 def quiz_renderer(quiz_name):
 	if frappe.session.user == "Guest":
 		return " <div class='alert alert-info'>" + _(


### PR DESCRIPTION
You can now limit the number of questions to be shown in a quiz. So if a quiz has 10 questions and you want the students to attempt only 5 questions, you can set it as the limit. Students will then only see the first 5 questions when attempting the quiz.

If the Shuffle Questions setting is also enabled then students will see random 5 questions from the total questions in the quiz. Also based on the limit, the total marks get calculated for the quiz.

<img width="1426" alt="Screenshot 2024-06-28 at 12 32 04 PM" src="https://github.com/frappe/lms/assets/31363128/e2e5f6db-ae30-46b6-8c52-ea418178d6a6">
