### PR TITLE
RTL Support

### DIFF
--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -50,11 +50,22 @@ export const sessionStore = defineStore('lms-session', () => {
 		},
 	})
 
+	const direction = createResource({
+		url: 'lms.lms.api.get_direction',
+		cache: 'direction',
+		auto: true,
+		onSuccess({direction}) {
+			const dir = direction === 'Right-to-left (RTL)' ? 'rtl' : 'ltr'
+			document.body.setAttribute('dir', dir)
+		},
+	})
+
 	return {
 		user,
 		isLoggedIn,
 		login,
 		logout,
 		branding,
+		direction
 	}
 })

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -54,7 +54,7 @@ export const sessionStore = defineStore('lms-session', () => {
 		url: 'lms.lms.api.get_direction',
 		cache: 'direction',
 		auto: true,
-		onSuccess({direction}) {
+		onSuccess({ direction }) {
 			const dir = direction === 'Right-to-left (RTL)' ? 'rtl' : 'ltr'
 			document.body.setAttribute('dir', dir)
 		},
@@ -66,6 +66,6 @@ export const sessionStore = defineStore('lms-session', () => {
 		login,
 		logout,
 		branding,
-		direction
+		direction,
 	}
 })

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -291,6 +291,7 @@ def get_branding():
 		"favicon": frappe.db.get_single_value("Website Settings", "favicon"),
 	}
 
+
 @frappe.whitelist(allow_guest=True)
 def get_direction():
 	"""Get direction (ltr/rtl)."""

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -291,6 +291,13 @@ def get_branding():
 		"favicon": frappe.db.get_single_value("Website Settings", "favicon"),
 	}
 
+@frappe.whitelist(allow_guest=True)
+def get_direction():
+	"""Get direction (ltr/rtl)."""
+	return {
+		"direction": frappe.db.get_single_value("LMS Settings", "direction"),
+	}
+
 
 @frappe.whitelist()
 def get_unsplash_photos(keyword=None):

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -8,6 +8,7 @@
   "default_home",
   "is_onboarding_complete",
   "column_break_zdel",
+  "direction",
   "unsplash_access_key",
   "livecode_url",
   "course_settings_section",
@@ -418,12 +419,19 @@
    "fieldtype": "Table",
    "label": "Sidebar Items",
    "options": "LMS Sidebar Item"
+  },
+  {
+   "default": "Left-to-right (LTR)",
+   "fieldname": "direction",
+   "fieldtype": "Select",
+   "label": "Direction",
+   "options": "Left-to-right (LTR)\nRight-to-left (RTL)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-27 21:57:02.193336",
+ "modified": "2024-07-01 21:00:26.887859",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",


### PR DESCRIPTION
RTL support for portal:

<img width="960" alt="image" src="https://github.com/frappe/lms/assets/37351104/c0be283e-e62a-4222-9403-cf0b9c019fe8">

Added a new setting for this in the lms settings:

<img width="960" alt="image" src="https://github.com/frappe/lms/assets/37351104/28c55892-e241-4adf-b3fe-2a1dcbcfdb45">

The CSS still needs to be worked on for RTL.

fix: #911 