### PR TITLE
fix: course cards home page rendering

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -179,6 +179,11 @@ jinja = {
 	"methods": [
 		"lms.lms.utils.get_signup_optin_checks",
 		"lms.lms.utils.get_tags",
+		"lms.lms.utils.get_lesson_count",
+		"lms.lms.utils.get_instructors",
+		"lms.lms.utils.get_lesson_index",
+		"lms.lms.utils.get_lesson_url",
+		"lms.page_renderers.get_profile_url",
 	],
 	"filters": [],
 }


### PR DESCRIPTION
Course cards fails to render on home page.

<img width="1440" alt="Screenshot 2024-08-05 at 2 04 22 PM" src="https://github.com/user-attachments/assets/6d05d537-21ef-4e77-9ae6-7cc042e4af5d">
