### PR TITLE
A Quiz Lesson does not update progress after 30 seconds

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -29,6 +29,11 @@
 					).format(quiz.data.time)
 				}}
 			</div>
+			<div class="leading-relaxed">
+				{{
+					__('After Submit a Quiz, please await 30 seconds to update a progress percentage!')
+				}}
+			</div>
 		</div>
 		<div v-if="activeQuestion == 0">
 			<div class="border text-center p-20 rounded-md">

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -290,6 +290,9 @@ const progress = createResource({
 	},
 	onSuccess(data) {
 		lessonProgress.value = data
+		if (data) {
+			clearInterval(timerInterval);
+		}
 	},
 })
 
@@ -335,14 +338,14 @@ watch(
 )
 
 const startTimer = () => {
-	timerInterval = setInterval(() => {
-		timer.value++
-		if (timer.value == 30) {
-			clearInterval(timerInterval)
-			markProgress()
-		}
-	}, 1000)
-}
+    timerInterval = setInterval(() => {
+        timer.value++
+		if (timer.value % 30 === 0) { // Check every 30 seconds
+            markProgress(); // Attempt to mark progress
+        }
+    }, 1000); // Timer increments every second
+};
+
 
 onBeforeUnmount(() => {
 	clearInterval(timerInterval)


### PR DESCRIPTION
Issue1: 
- In Case: A lesson contain Quiz, if student is not completed a quiz within 30 seconds then save_progress API will not be call anymore. So when student completed a quiz, a progress still dont be updated.
- Solution:  Retry save_progress each 30 seconds until student completed a quiz.

Issue2: 
- In case: A lesson contain Quiz, if student submit and completed a quiz, it need to await 30 seconds for a interval be called and update progress. If student refresh or quit a page, a progress dont be updated. 
- Solution:  Add more note "After Submit a Quiz, please await 30 seconds to update a progress percentage" for student need to wait 30 seconds after they completed a quiz.