### PR TITLE
fix: quiz submission report issue

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -439,7 +439,7 @@ const checkAnswer = () => {
 const addToLocalStorage = () => {
 	let quizData = JSON.parse(localStorage.getItem(quiz.data.title))
 	let questionData = {
-		question_index: activeQuestion.value,
+		question_name: currentQuestion.value,
 		answer: getAnswers().join(),
 		is_correct: showAnswers.filter((answer) => {
 			return answer != undefined

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -90,21 +90,19 @@ def quiz_summary(quiz, results):
 
 		question_details = frappe.db.get_value(
 			"LMS Quiz Question",
-			{"parent": quiz, "idx": result["question_index"]},
-			["question", "marks"],
+			{"parent": quiz, "question": result["question_name"]},
+			["question", "marks", "question_detail"],
 			as_dict=1,
 		)
 
 		result["question_name"] = question_details.question
-		result["question"] = frappe.db.get_value(
-			"LMS Question", question_details.question, "question"
-		)
+		result["question"] = question_details.question_detail
 		marks = question_details.marks if correct else 0
 
 		result["marks"] = marks
 		score += marks
 
-		del result["question_index"]
+		del result["question_name"]
 
 	quiz_details = frappe.db.get_value(
 		"LMS Quiz", quiz, ["total_marks", "passing_percentage", "lesson", "course"], as_dict=1
@@ -297,15 +295,6 @@ def check_choice_answers(question, answers):
 
 	question_details = frappe.db.get_value("LMS Question", question, fields, as_dict=1)
 
-	""" if question_details.multiple:
-		correct_answers = [ question_details[f"option_{num}"] for num in range(1,5) if question_details[f"is_correct_{num}"]]
-		print(answers)
-		for ans in correct_answers:
-			if ans not in answers:
-				is_correct.append(0)
-			else:
-				is_correct.append(1)
-	else: """
 	for num in range(1, 5):
 		if question_details[f"option_{num}"] in answers:
 			is_correct.append(question_details[f"is_correct_{num}"])


### PR DESCRIPTION
1. If the quiz had shuffle enabled, the quiz submission was showing wrong questions against user responses.

2. The user responses are all in the correct order as per the shuffle, but the questions are in the order that they were in the quiz. So the response does not match with the question.

<img width="1440" alt="Screenshot 2024-08-27 at 10 48 49 AM" src="https://github.com/user-attachments/assets/0570eca7-9b82-48bc-8a15-dc763fd234ad">

