### PR TITLE
fix(overrides): call parent's `after_insert()` as well

### DIFF
--- a/lms/overrides/user.py
+++ b/lms/overrides/user.py
@@ -17,6 +17,7 @@ class CustomUser(User):
 		self.validate_username_duplicates()
 
 	def after_insert(self):
+		super().after_insert()
 		self.add_roles("LMS Student")
 
 	def validate_username_duplicates(self):


### PR DESCRIPTION
Support ticket #20855, #20873

User's notifications settings get created in User after_insert hook, which isn't called in this case
