### PR TITLE
feat: quiz page

### DIFF
--- a/frontend/src/components/Assessments.vue
+++ b/frontend/src/components/Assessments.vue
@@ -11,25 +11,7 @@
 				:options="{
 					selectable: false,
 					showTooltip: false,
-					getRowRoute: (row) => {
-						if (row.submission) {
-							return {
-								name: 'AssignmentSubmission',
-								params: {
-									assignmentName: row.assessment_name,
-									submissionName: row.submission.name,
-								},
-							}
-						} else {
-							return {
-								name: 'AssignmentSubmission',
-								params: {
-									assignmentName: row.assessment_name,
-									submissionName: 'new',
-								},
-							}
-						}
-					},
+					getRowRoute: (row) => getRowRoute(row),
 				}"
 			>
 			</ListView>
@@ -73,6 +55,35 @@ const assessments = createResource({
 	},
 	auto: true,
 })
+
+const getRowRoute = (row) => {
+	if (row.assessment_type == 'LMS Assignment') {
+		if (row.submission) {
+			return {
+				name: 'AssignmentSubmission',
+				params: {
+					assignmentName: row.assessment_name,
+					submissionName: row.submission.name,
+				},
+			}
+		} else {
+			return {
+				name: 'AssignmentSubmission',
+				params: {
+					assignmentName: row.assessment_name,
+					submissionName: 'new',
+				},
+			}
+		}
+	} else {
+		return {
+			name: 'Quiz',
+			params: {
+				quizID: row.assessment_name,
+			},
+		}
+	}
+}
 
 const getAssessmentColumns = () => {
 	let columns = [

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -84,7 +84,7 @@
 						</div>
 					</div>
 					<div
-						class="text-gray-900 font-semibold mt-2"
+						class="text-gray-900 font-semibold mt-2 leading-5"
 						v-html="questionDetails.data.question"
 					></div>
 					<div v-if="questionDetails.data.type == 'Choices'" v-for="index in 4">

--- a/frontend/src/pages/QuizSubmission.vue
+++ b/frontend/src/pages/QuizSubmission.vue
@@ -1,0 +1,48 @@
+<template>
+	<header
+		class="sticky top-0 z-10 flex items-center justify-between border-b bg-white px-3 py-2.5 sm:px-5"
+	>
+		<Breadcrumbs :items="breadcrumbs" />
+	</header>
+	<div class="w-1/2 mx-auto py-10">
+		<Quiz :quizName="quizID" />
+	</div>
+</template>
+<script setup>
+import Quiz from '@/components/Quiz.vue'
+import { createResource, Breadcrumbs } from 'frappe-ui'
+import { computed, inject, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+
+const user = inject('$user')
+const router = useRouter()
+
+onMounted(() => {
+	if (!user.data) {
+		router.push({ name: 'Courses' })
+	}
+})
+
+const props = defineProps({
+	quizID: {
+		type: String,
+		required: true,
+	},
+})
+
+const title = createResource({
+	url: 'frappe.client.get_value',
+	params: {
+		doctype: 'LMS Quiz',
+		fieldname: 'title',
+		filters: {
+			name: props.quizID,
+		},
+	},
+	auto: true,
+})
+
+const breadcrumbs = computed(() => {
+	return [{ label: __('Quiz Submission') }, { label: title.data?.title }]
+})
+</script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -158,6 +158,12 @@ const routes = [
 		component: () => import('@/pages/QuizCreation.vue'),
 		props: true,
 	},
+	{
+		path: '/quiz/:quizID',
+		name: 'Quiz',
+		component: () => import('@/pages/QuizSubmission.vue'),
+		props: true,
+	},
 ]
 
 let router = createRouter({


### PR DESCRIPTION
1. Quizzes can now be a separate page. Moderators wanting to run quizzes independently can use this page and share the URL with the participants.
2. This page will also open up when a quiz is added as an assessment in any batch.

<img width="1440" alt="Screenshot 2024-09-17 at 10 26 24 AM" src="https://github.com/user-attachments/assets/c1ccffc1-7540-40f8-a4e4-b43ff3c5dbd9">
