### PR TITLE
fix: evaluation error message issue

### DIFF
--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -131,10 +131,16 @@ function submitEvaluation(close) {
 		},
 		onError(err) {
 			let message = err.messages?.[0] || err
-			let unavailabilityMessage = message.includes('unavailable')
+			let unavailabilityMessage
+
+			if (typeof message === 'string') {
+				unavailabilityMessage = message?.includes('unavailable')
+			} else {
+				unavailabilityMessage = false
+			}
 
 			createToast({
-				title: unavailabilityMessage ? 'Evaluator is Unavailable' : 'Error',
+				title: unavailabilityMessage ? __('Evaluator is Unavailable') : '',
 				text: message,
 				icon: unavailabilityMessage ? 'alert-circle' : 'x',
 				iconClasses: 'bg-yellow-600 text-white rounded-md p-px',


### PR DESCRIPTION
When a student tried scheduling an evaluation after the Evaluation End Date, the error message was not visible. There was an error in the console.

<img width="1440" alt="Screenshot 2024-09-25 at 11 10 51 AM" src="https://github.com/user-attachments/assets/55bcd4f8-edff-44d8-8c8d-418528e6cec6">
