### PR TITLE
fix: using google docs viewer to render pdf

### DIFF
--- a/frontend/src/components/Assessments.vue
+++ b/frontend/src/components/Assessments.vue
@@ -160,7 +160,7 @@ const getRowRoute = (row) => {
 		}
 	} else {
 		return {
-			name: 'Quiz',
+			name: 'QuizPage',
 			params: {
 				quizID: row.assessment_name,
 			},

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -37,7 +37,7 @@
 			<iframe
 				:src="getPDFSource(block)"
 				width="100%"
-				height="400"
+				height="700px"
 				frameborder="0"
 				allowfullscreen
 			></iframe>

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -56,9 +56,11 @@ export class Upload {
 			app.mount(this.wrapper)
 			return
 		} else if (file.file_type == 'PDF') {
-			this.wrapper.innerHTML = `<iframe src="${encodeURI(
+			this.wrapper.innerHTML = `<iframe src="https://docs.google.com/viewer?url=${
+				window.location.origin
+			}${encodeURI(
 				file.file_url
-			)}#toolbar=0" width='100%' height='700px' class="mb-4"></iframe>`
+			)}&embedded=true" width='100%' height='700px' class="mb-4" type="application/pdf"></iframe>`
 			return
 		} else {
 			this.wrapper.innerHTML = `<img class="mb-4" src=${encodeURI(

--- a/lms/lms/doctype/course_lesson/course_lesson.json
+++ b/lms/lms/doctype/course_lesson/course_lesson.json
@@ -55,6 +55,7 @@
    "fieldname": "title",
    "fieldtype": "Data",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Title",
    "reqd": 1
   },
@@ -161,7 +162,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-03 10:48:17.525859",
+ "modified": "2024-10-08 11:04:54.748773",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Course Lesson",


### PR DESCRIPTION
1. PDF rendering doesn't work on mobile as mobile browsers don't support the same.
2. This is an experiment to see if using google docs PDF viewer makes the content work in mobile.