### PR TITLE
fix: redirect to login before enrollment

### DIFF
--- a/frontend/src/components/BatchOverlay.vue
+++ b/frontend/src/components/BatchOverlay.vue
@@ -124,6 +124,9 @@ const enroll = createResource({
 })
 
 const enrollInBatch = () => {
+	if (!user.data) {
+		window.location.href = `/login?redirect-to=/batches/details/${props.batch.data.name}`
+	}
 	enroll.submit(
 		{},
 		{


### PR DESCRIPTION
1. During batch enrollment if a user is not logged in, redirect them to the login page.