### PR TITLE
fix: show only courses with evaluator for batch evaluation

### DIFF
--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -154,10 +154,12 @@ function submitEvaluation(close) {
 const getCourses = () => {
 	let courses = []
 	for (const course of props.courses) {
-		courses.push({
-			label: course.title,
-			value: course.course,
-		})
+		if (course.evaluator) {
+			courses.push({
+				label: course.title,
+				value: course.course,
+			})
+		}
 	}
 	return courses
 }

--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -83,6 +83,7 @@
 				v-model="instructors"
 				doctype="User"
 				:label="__('Instructors')"
+				:filters="{ ignore_user_type: 1 }"
 			/>
 			<div class="mb-4">
 				<FormControl

--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -152,6 +152,7 @@
 							v-model="instructors"
 							doctype="User"
 							:label="__('Instructors')"
+							:filters="{ ignore_user_type: 1 }"
 							:required="true"
 						/>
 					</div>

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1103,7 +1103,7 @@ def get_categorized_courses(courses):
 
 		categories = [live, enrolled, created]
 		for category in categories:
-			category.sort(key=lambda x: x.enrollments, reverse=True)
+			category.sort(key=lambda x: cint(x.enrollments), reverse=True)
 
 		live.sort(key=lambda x: x.featured, reverse=True)
 
@@ -1265,7 +1265,7 @@ def get_batch_details(batch):
 	batch_details.instructors = get_instructors(batch)
 
 	batch_details.courses = frappe.get_all(
-		"Batch Course", filters={"parent": batch}, fields=["course", "title"]
+		"Batch Course", filters={"parent": batch}, fields=["course", "title", "evaluator"]
 	)
 	batch_details.students = frappe.get_all(
 		"Batch Student", {"parent": batch}, pluck="student"


### PR DESCRIPTION
1. For a batch, multiple courses are linked.
2. You may not want to evaluate your students for all the courses.
3. So now, only courses that have an evaluator set in the batch will be available for evaluation.