### PR TITLE
feat: allow same date live class creation

### DIFF
--- a/frontend/src/components/Modals/LiveClassModal.vue
+++ b/frontend/src/components/Modals/LiveClassModal.vue
@@ -156,19 +156,19 @@ const submitLiveClass = (close) => {
 	return createLiveClass.submit(liveClass, {
 		validate() {
 			if (!liveClass.title) {
-				return 'Please enter a title.'
+				return __('Please enter a title.')
 			}
 			if (!liveClass.date) {
-				return 'Please select a date.'
+				return __('Please select a date.')
 			}
 			if (!liveClass.time) {
-				return 'Please select a time.'
+				return __('Please select a time.')
 			}
 			if (!liveClass.timezone) {
-				return 'Please select a timezone.'
+				return __('Please select a timezone.')
 			}
 			if (!valideTime()) {
-				return 'Please enter a valid time in the format HH:mm.'
+				return __('Please enter a valid time in the format HH:mm.')
 			}
 			const liveClassDateTime = dayjs(`${liveClass.date}T${liveClass.time}`).tz(
 				liveClass.timezone,
@@ -180,10 +180,10 @@ const submitLiveClass = (close) => {
 					'minute'
 				)
 			) {
-				return 'Please select a future date and time.'
+				return __('Please select a future date and time.')
 			}
 			if (!liveClass.duration) {
-				return 'Please select a duration.'
+				return __('Please select a duration.')
 			}
 		},
 		onSuccess() {

--- a/frontend/src/components/Modals/LiveClassModal.vue
+++ b/frontend/src/components/Modals/LiveClassModal.vue
@@ -161,20 +161,29 @@ const submitLiveClass = (close) => {
 			if (!liveClass.date) {
 				return 'Please select a date.'
 			}
-			if (dayjs(liveClass.date).isSameOrBefore(dayjs(), 'day')) {
-				return 'Please select a future date.'
-			}
 			if (!liveClass.time) {
 				return 'Please select a time.'
+			}
+			if (!liveClass.timezone) {
+				return 'Please select a timezone.'
 			}
 			if (!valideTime()) {
 				return 'Please enter a valid time in the format HH:mm.'
 			}
+			const liveClassDateTime = dayjs(`${liveClass.date}T${liveClass.time}`).tz(
+				liveClass.timezone,
+				true
+			)
+			if (
+				liveClassDateTime.isSameOrBefore(
+					dayjs().tz(liveClass.timezone, false),
+					'minute'
+				)
+			) {
+				return 'Please select a future date and time.'
+			}
 			if (!liveClass.duration) {
 				return 'Please select a duration.'
-			}
-			if (!liveClass.timezone) {
-				return 'Please select a timezone.'
 			}
 		},
 		onSuccess() {

--- a/frontend/src/utils/dayjs.js
+++ b/frontend/src/utils/dayjs.js
@@ -5,6 +5,8 @@ import updateLocale from 'dayjs/esm/plugin/updateLocale'
 import isToday from 'dayjs/esm/plugin/isToday'
 import isSameOrBefore from 'dayjs/esm/plugin/isSameOrBefore'
 import isSameOrAfter from 'dayjs/esm/plugin/isSameOrAfter'
+import utc from 'dayjs/esm/plugin/utc'
+import timezone from 'dayjs/esm/plugin/timezone'
 
 dayjs.extend(updateLocale)
 dayjs.extend(relativeTime)
@@ -12,5 +14,7 @@ dayjs.extend(localizedFormat)
 dayjs.extend(isToday)
 dayjs.extend(isSameOrBefore)
 dayjs.extend(isSameOrAfter)
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 export default dayjs


### PR DESCRIPTION
Closes #1063 

## Reason of PR
- Allow users to create live classes on the same date with a future time, ensuring that the class time is validated relative to the selected timezone.

## Changes in PR
- Imported `timezone` and `utc` plugins from `dayjs` to handle timezone conversions and comparisons.
- Updated course time validation to ensure the class time is in the future based on the selected timezone, rather than comparing it with the system's local time.