### PR TITLE
feat: show student course and assessment progress on batch page

### DIFF
--- a/frontend/src/components/Assessments.vue
+++ b/frontend/src/components/Assessments.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<div class="flex items-center justify-between">
-			<div class="text-lg font-semibold mb-4">
+		<div class="flex items-center justify-between mb-4">
+			<div class="text-lg font-semibold">
 				{{ __('Assessments') }}
 			</div>
 			<Button v-if="canSeeAddButton()" @click="showModal = true">
@@ -38,7 +38,10 @@
 					<ListRow :row="row" v-for="row in assessments.data">
 						<template #default="{ column, item }">
 							<ListRowItem :item="row[column.key]" :align="column.align">
-								<div>
+								<div v-if="column.key == 'assessment_type'">
+									{{ row[column.key] == 'LMS Quiz' ? 'Quiz' : 'Assignment' }}
+								</div>
+								<div v-else>
 									{{ row[column.key] }}
 								</div>
 							</ListRowItem>
@@ -177,10 +180,12 @@ const getAssessmentColumns = () => {
 		{
 			label: 'Assessment',
 			key: 'title',
+			width: '30rem',
 		},
 		{
 			label: 'Type',
 			key: 'assessment_type',
+			width: '10rem',
 		},
 	]
 
@@ -189,6 +194,7 @@ const getAssessmentColumns = () => {
 			label: 'Status/Score',
 			key: 'status',
 			align: 'center',
+			width: '10rem',
 		})
 	}
 	return columns

--- a/frontend/src/components/BatchCourses.vue
+++ b/frontend/src/components/BatchCourses.vue
@@ -110,6 +110,7 @@ const openCourseModal = () => {
 }
 
 const getCoursesColumns = () => {
+	console.log(courses.data)
 	return [
 		{
 			label: 'Title',
@@ -118,13 +119,13 @@ const getCoursesColumns = () => {
 		},
 		{
 			label: 'Lessons',
-			key: 'lesson_count',
+			key: 'lessons',
 			align: 'right',
 		},
 		{
 			label: 'Enrollments',
 			align: 'right',
-			key: 'enrollment_count',
+			key: 'enrollments',
 		},
 	]
 }

--- a/frontend/src/components/BatchCourses.vue
+++ b/frontend/src/components/BatchCourses.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<div class="flex items-center justify-between mb-4">
-			<div class="text-xl font-semibold">
+			<div class="text-lg font-semibold">
 				{{ __('Courses') }}
 			</div>
 			<Button v-if="canSeeAddButton()" @click="openCourseModal()">
@@ -110,7 +110,6 @@ const openCourseModal = () => {
 }
 
 const getCoursesColumns = () => {
-	console.log(courses.data)
 	return [
 		{
 			label: 'Title',

--- a/frontend/src/components/BatchStudents.vue
+++ b/frontend/src/components/BatchStudents.vue
@@ -18,7 +18,11 @@
 			<ListHeader
 				class="mb-2 grid items-center space-x-4 rounded bg-gray-100 p-2"
 			>
-				<ListHeaderItem :item="item" v-for="item in getStudentColumns()">
+				<ListHeaderItem
+					:item="item"
+					v-for="item in getStudentColumns()"
+					:title="item.label"
+				>
 					<template #prefix="{ item }">
 						<FeatherIcon
 							v-if="item.icon"
@@ -46,15 +50,18 @@
 								{{ row[column.key] }}
 							</div>
 							<div v-else-if="column.icon == 'book-open'">
-								{{ Math.ceil(row.courses[column.key]) }}
+								{{ Math.ceil(row.courses[column.key]) }}%
 							</div>
-							<Badge
-								v-else-if="column.icon == 'help-circle'"
-								:theme="getStatusTheme(row.assessments[column.key])"
-								class="text-xs"
-							>
-								{{ row.assessments[column.key] }}
-							</Badge>
+							<div v-else-if="column.icon == 'help-circle'">
+								<Badge
+									v-if="isAssignment(row.assessments[column.key])"
+									:theme="getStatusTheme(row.assessments[column.key])"
+									class="text-xs"
+								>
+									{{ row.assessments[column.key] }}
+								</Badge>
+								<div v-else>{{ parseInt(row.assessments[column.key]) }}%</div>
+							</div>
 						</ListRowItem>
 					</template>
 				</ListRow>
@@ -125,30 +132,32 @@ const getStudentColumns = () => {
 		{
 			label: 'Full Name',
 			key: 'full_name',
-			width: 1,
+			width: '10rem',
 		},
 	]
 
 	if (students.data?.[0].courses) {
 		Object.keys(students.data?.[0].courses).forEach((course) => {
 			columns.push({
-				label: `${course} (%)`,
+				label: course,
 				key: course,
-				width: 1,
+				width: '10rem',
 				icon: 'book-open',
 				align: 'center',
 			})
 		})
 	}
-
+	console.log(students.data?.[0].assessments)
 	if (students.data?.[0].assessments) {
 		Object.keys(students.data?.[0].assessments).forEach((assessment) => {
 			columns.push({
 				label: assessment,
 				key: assessment,
-				width: 1,
+				width: '10rem',
 				icon: 'help-circle',
-				align: 'left',
+				align: isAssignment(students.data?.[0].assessments[assessment])
+					? 'left'
+					: 'center',
 			})
 		})
 	}
@@ -192,5 +201,9 @@ const getStatusTheme = (status) => {
 	} else {
 		return 'red'
 	}
+}
+
+const isAssignment = (value) => {
+	return isNaN(value)
 }
 </script>

--- a/frontend/src/components/BatchStudents.vue
+++ b/frontend/src/components/BatchStudents.vue
@@ -1,12 +1,14 @@
 <template>
-	<Button class="float-right mb-3" @click="openStudentModal()">
-		<template #prefix>
-			<Plus class="h-4 w-4" />
-		</template>
-		{{ __('Add') }}
-	</Button>
-	<div class="text-lg font-semibold mb-4">
-		{{ __('Students') }}
+	<div class="flex items-center justify-between mb-4">
+		<div class="text-lg font-semibold">
+			{{ __('Students') }}
+		</div>
+		<Button @click="openStudentModal()">
+			<template #prefix>
+				<Plus class="h-4 w-4" />
+			</template>
+			{{ __('Add') }}
+		</Button>
 	</div>
 	<div v-if="students.data?.length">
 		<ListView
@@ -147,7 +149,7 @@ const getStudentColumns = () => {
 			})
 		})
 	}
-	console.log(students.data?.[0].assessments)
+
 	if (students.data?.[0].assessments) {
 		Object.keys(students.data?.[0].assessments).forEach((assessment) => {
 			columns.push({

--- a/frontend/src/components/Modals/StudentModal.vue
+++ b/frontend/src/components/Modals/StudentModal.vue
@@ -28,6 +28,7 @@
 import { Dialog, createResource } from 'frappe-ui'
 import { ref } from 'vue'
 import Link from '@/components/Controls/Link.vue'
+import { showToast } from '@/utils'
 
 const students = defineModel('reloadStudents')
 const student = ref()
@@ -61,8 +62,11 @@ const addStudent = (close) => {
 		{
 			onSuccess() {
 				students.value.reload()
-				close()
 				student.value = null
+				close()
+			},
+			onError(err) {
+				showToast(__('Error'), __(err.messages?.[0] || err), 'x')
 			},
 		}
 	)

--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -252,7 +252,7 @@ import {
 } from 'frappe-ui'
 import Link from '@/components/Controls/Link.vue'
 import { useRouter } from 'vue-router'
-import { showToast } from '../utils'
+import { showToast } from '@/utils'
 import { Image } from 'lucide-vue-next'
 import { capture } from '@/telemetry'
 import MultiSelect from '@/components/Controls/MultiSelect.vue'
@@ -345,6 +345,10 @@ const batchDetail = createResource({
 				data.instructors.forEach((instructor) => {
 					instructors.value.push(instructor.instructor)
 				})
+			} else if (['start_time', 'end_time'].includes(key)) {
+				let [hours, minutes, seconds] = data[key].split(':')
+				hours = hours.length == 1 ? '0' + hours : hours
+				batch[key] = `${hours}:${minutes}`
 			} else if (Object.hasOwn(batch, key)) batch[key] = data[key]
 		})
 		let checkboxes = ['published', 'paid_batch', 'allow_self_enrollment']

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1475,7 +1475,9 @@ def get_batch_students(batch):
 
 		""" Iterate through assessments and track their progress """
 		for assessment in assessments:
-			title = frappe.db.get_value("LMS Assignment", assessment.assessment_name, "title")
+			title = frappe.db.get_value(
+				assessment.assessment_type, assessment.assessment_name, "title"
+			)
 			status = has_submitted_assessment(
 				assessment.assessment_name, assessment.assessment_type, student.student
 			)
@@ -1502,7 +1504,7 @@ def has_submitted_assessment(assessment, assessment_type, member=None):
 	elif assessment_type == "LMS Quiz":
 		doctype = "LMS Quiz Submission"
 		docfield = "quiz"
-		fields = ["score"]
+		fields = ["percentage"]
 		not_attempted = 0
 
 	filters = {}


### PR DESCRIPTION
On the batch page, Moderators and Evaluators will now be able to see the progress students have made in the courses and assessments linked to that batch.

<img width="1440" alt="Screenshot 2024-12-13 at 11 48 46 AM" src="https://github.com/user-attachments/assets/984410f9-0955-4e8c-8d2c-e8795bc5eef2" />
