### PR TITLE
fix: delete quiz and submission before deleting course

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -841,8 +841,6 @@ def delete_course(course):
 			frappe.delete_doc("Lesson Reference", lesson)
 
 		for lesson in lessons:
-			frappe.db.delete("LMS Course Progress", {"lesson": lesson})
-
 			topics = frappe.get_all(
 				"Discussion Topic",
 				{"reference_doctype": "Course Lesson", "reference_docname": lesson},
@@ -862,6 +860,9 @@ def delete_course(course):
 	for chapter in chapters:
 		frappe.delete_doc("Course Chapter", chapter)
 
+	frappe.db.delete("LMS Course Progress", {"course": course})
+	frappe.db.delete("LMS Quiz", {"course": course})
+	frappe.db.delete("LMS Quiz Submission", {"course": course})
 	frappe.db.delete("LMS Enrollment", {"course": course})
 	frappe.delete_doc("LMS Course", course)
 

--- a/lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py
+++ b/lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py
@@ -17,6 +17,7 @@ class LMSQuizSubmission(Document):
 		self.notify_member()
 
 	def validate_marks(self):
+		self.score = 0
 		for row in self.result:
 			if cint(row.marks) > cint(row.marks_out_of):
 				frappe.throw(


### PR DESCRIPTION
1. Delete the linked quiz and its submission before deleting a course.
2. Reset the submission score to 0 before recalculating.