### PR TITLE
fix: markdown parser link issue

### DIFF
--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -132,7 +132,7 @@ const renderEditor = (holder) => {
 		holder: holder,
 		tools: getEditorTools(true),
 		autofocus: true,
-		defaultBlock: 'markdownParser',
+		defaultBlock: 'markdown',
 	})
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -2,7 +2,7 @@ import { toast } from 'frappe-ui'
 import { useTimeAgo } from '@vueuse/core'
 import { Quiz } from '@/utils/quiz'
 import { Upload } from '@/utils/upload'
-import { MarkdownParser } from '@/utils/markdownParser'
+import { Markdown } from '@/utils/markdownParser'
 import Header from '@editorjs/header'
 import Paragraph from '@editorjs/paragraph'
 import { CodeBox } from '@/utils/code'
@@ -156,12 +156,12 @@ export function getEditorTools() {
 		},
 		quiz: Quiz,
 		upload: Upload,
-		markdownParser: MarkdownParser,
+		markdown: Markdown,
 		image: SimpleImage,
 		table: Table,
 		paragraph: {
 			class: Paragraph,
-			inlineToolbar: false,
+			inlineToolbar: true,
 			config: {
 				preserveBlank: true,
 			},
@@ -187,7 +187,7 @@ export function getEditorTools() {
 		},
 		embed: {
 			class: Embed,
-			inlineToolbar: true,
+			inlineToolbar: false,
 			config: {
 				services: {
 					youtube: {

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -1,4 +1,4 @@
-export class MarkdownParser {
+export class Markdown {
 	constructor({ data, api, readOnly, config }) {
 		this.api = api
 		this.data = data || {}
@@ -65,6 +65,8 @@ export class MarkdownParser {
 		} else if (previousLine && this.hasLink(previousLine)) {
 			const { text, url } = this.extractLink(previousLine)
 			const anchorTag = `<a href="${url}" target="_blank">${text}</a>`
+			console.log(previousLine.replace(/\[.+?\]\(.+?\)/, anchorTag))
+			debugger
 			this.convertBlock('paragraph', {
 				text: previousLine.replace(/\[.+?\]\(.+?\)/, anchorTag),
 			})
@@ -149,4 +151,4 @@ export class MarkdownParser {
 	}
 }
 
-export default MarkdownParser
+export default Markdown


### PR DESCRIPTION
1. Markdown links were not working. Enabled inlineToolbar for Paragraph plugin to fix the issue.