### PR TITLE
refactor: changed batch naming to be a slug of the title

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -2,7 +2,6 @@
  "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
- "autoname": "format: CLS-{#####}",
  "creation": "2022-11-09 16:14:05.876933",
  "default_view": "List",
  "doctype": "DocType",
@@ -330,11 +329,10 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-18 16:28:41.336928",
+ "modified": "2025-01-17 10:23:10.580311",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",
- "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -16,6 +16,7 @@ from lms.lms.utils import (
 	get_quiz_details,
 	get_assignment_details,
 	update_payment_record,
+	generate_slug,
 )
 from frappe.email.doctype.email_template.email_template import get_email_template
 
@@ -35,6 +36,10 @@ class LMSBatch(Document):
 		self.send_confirmation_mail()
 		self.validate_evaluation_end_date()
 		self.add_students_to_live_class()
+
+	def autoname(self):
+		if not self.name:
+			self.name = generate_slug(self.title, "LMS Batch")
 
 	def validate_batch_end_date(self):
 		if self.end_date < self.start_date:

--- a/lms/lms/doctype/lms_course/lms_course.py
+++ b/lms/lms/doctype/lms_course/lms_course.py
@@ -93,10 +93,7 @@ class LMSCourse(Document):
 
 	def autoname(self):
 		if not self.name:
-			title = self.title
-			if self.title == "New Course":
-				title = self.title + str(random.randint(0, 99))
-			self.name = generate_slug(title, "LMS Course")
+			self.name = generate_slug(self.title, "LMS Course")
 
 	def __repr__(self):
 		return f"<Course#{self.name}>"


### PR DESCRIPTION
Previously, batch names were in the format of CLS-####. This was not URL-friendly. This PR changes the batch name to a slug. For example, if a batch's title is Framework March 2025, then the batch's name would be framework-march-2025. This would give some context of the batch when the URL is shared.

<img width="1440" alt="Screenshot 2025-01-17 at 10 39 53 AM" src="https://github.com/user-attachments/assets/126f164b-43ea-4f4f-bee4-8d184b1e2536" />

Closes #733 

