### PR TITLE
feat: configuration to allow guest access

### DIFF
--- a/frontend/src/components/Modals/ChapterModal.vue
+++ b/frontend/src/components/Modals/ChapterModal.vue
@@ -145,9 +145,9 @@ const addChapter = async (close) => {
 					{
 						onSuccess(data) {
 							cleanChapter()
-							if (!settingsStore.onboardingDetails.data?.is_onboarded) {
+							/* if (!settingsStore.onboardingDetails.data?.is_onboarded) {
 								settingsStore.onboardingDetails.reload()
-							}
+							} */
 							outline.value.reload()
 							showToast(
 								__('Success'),

--- a/frontend/src/components/Modals/Settings.vue
+++ b/frontend/src/components/Modals/Settings.vue
@@ -119,6 +119,13 @@ const tabsStructure = computed(() => {
 							type: 'checkbox',
 						},
 						{
+							label: 'Allow Guest Access',
+							name: 'allow_guest_access',
+							description:
+								'If enabled, users can access the course and batch lists without logging in.',
+							type: 'checkbox',
+						},
+						{
 							label: 'Send calendar invite for evaluations',
 							name: 'send_calendar_invite_for_evaluations',
 							description:

--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -435,9 +435,9 @@ const submitCourse = () => {
 			onSuccess(data) {
 				capture('course_created')
 				showToast('Success', 'Course created successfully', 'check')
-				if (!settingsStore.onboardingDetails.data?.is_onboarded) {
+				/* if (!settingsStore.onboardingDetails.data?.is_onboarded) {
 					settingsStore.onboardingDetails.reload()
-				}
+				} */
 				router.push({
 					name: 'CourseForm',
 					params: { courseName: data.name },

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -396,9 +396,9 @@ const createNewLesson = () => {
 						onSuccess() {
 							capture('lesson_created')
 							showToast('Success', 'Lesson created successfully', 'check')
-							if (!settingsStore.onboardingDetails.data?.is_onboarded) {
+							/* if (!settingsStore.onboardingDetails.data?.is_onboarded) {
 								settingsStore.onboardingDetails.reload()
-							}
+							} */
 							lessonDetails.reload()
 						},
 					}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { usersStore } from './stores/user'
 import { sessionStore } from './stores/session'
+import { useSettings } from './stores/settings'
 
 let defaultRoute = '/courses'
 const routes = [
@@ -218,7 +219,8 @@ let router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
 	const { userResource } = usersStore()
-	let { isLoggedIn } = sessionStore()
+	const { isLoggedIn } = sessionStore()
+	const { allowGuestAccess } = useSettings()
 
 	try {
 		if (isLoggedIn) {
@@ -226,6 +228,14 @@ router.beforeEach(async (to, from, next) => {
 		}
 	} catch (error) {
 		isLoggedIn = false
+	}
+
+	if (!isLoggedIn) {
+		await allowGuestAccess.promise
+		if (!allowGuestAccess.data) {
+			window.location.href = '/login'
+			return
+		}
 	}
 	return next()
 })

--- a/frontend/src/stores/settings.js
+++ b/frontend/src/stores/settings.js
@@ -7,6 +7,7 @@ export const useSettings = defineStore('settings', () => {
 	const { isLoggedIn } = sessionStore()
 	const isSettingsOpen = ref(false)
 	const activeTab = ref(null)
+
 	const learningPaths = createResource({
 		url: 'frappe.client.get_single_value',
 		makeParams(values) {
@@ -19,16 +20,22 @@ export const useSettings = defineStore('settings', () => {
 		cache: ['learningPaths'],
 	})
 
-	const onboardingDetails = createResource({
+	const allowGuestAccess = createResource({
+		url: 'lms.lms.api.is_guest_allowed',
+		auto: true,
+		cache: ['allowGuestAccess'],
+	})
+
+	/* const onboardingDetails = createResource({
 		url: 'lms.lms.utils.is_onboarding_complete',
 		auto: isLoggedIn ? true : false,
 		cache: ['onboardingDetails'],
-	})
+	}) */
 
 	return {
 		isSettingsOpen,
 		activeTab,
 		learningPaths,
-		onboardingDetails,
+		allowGuestAccess,
 	}
 })

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -409,7 +409,7 @@ def get_certified_participants(filters=None, start=0, page_length=30, search=Non
 	return participants
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_certification_categories():
 	categories = []
 	docs = frappe.get_all(
@@ -1220,3 +1220,8 @@ def get_notifications(filters):
 		notification.update(from_user_details)
 
 	return notifications
+
+
+@frappe.whitelist(allow_guest=True)
+def is_guest_allowed():
+	return frappe.get_cached_value("LMS Settings", None, "allow_guest_access")

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -10,6 +10,7 @@
   "send_calendar_invite_for_evaluations",
   "is_onboarding_complete",
   "column_break_zdel",
+  "allow_guest_access",
   "enable_learning_paths",
   "unsplash_access_key",
   "livecode_url",
@@ -351,12 +352,18 @@
    "fieldname": "general_tab",
    "fieldtype": "Tab Break",
    "label": "General"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_guest_access",
+   "fieldtype": "Check",
+   "label": "Allow Guest Access"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-20 11:55:05.358421",
+ "modified": "2025-02-06 11:42:29.803207",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -97,3 +97,4 @@ lms.patches.v2_0.delete_web_forms
 lms.patches.v2_0.update_desk_access_for_lms_roles
 lms.patches.v2_0.update_quiz_submission_data
 lms.patches.v2_0.convert_quiz_duration_to_minutes
+lms.patches.v2_0.allow_guest_access #05-02-2025

--- a/lms/patches/v2_0/allow_guest_access.py
+++ b/lms/patches/v2_0/allow_guest_access.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.db.set_single_value("LMS Settings", "allow_guest_access", 1)


### PR DESCRIPTION
1. Some of the pages of the system are accessible to Guest users as well, like course and batch list, etc.
2. Some organizations that create content for a very specific audience may not want to show even these details to guest users.
3. So now, admins of the system can configure if they want to allow guest users to access the system. This would be enabled by default but can be turned off from the Settings dialog.

<img width="1440" alt="Screenshot 2025-02-06 at 12 15 35 PM" src="https://github.com/user-attachments/assets/814e73a6-99ad-4115-9f52-5ae6085936eb" />

Closes #490
Closes #1023 