### PR TITLE
feat: batch specific email templates

### DIFF
--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -13,15 +13,14 @@
 				<div class="text-lg font-semibold mb-4">
 					{{ __('Details') }}
 				</div>
-				<div class="grid grid-cols-2 gap-10 mb-4 space-y-2">
-					<div>
-						<FormControl
-							v-model="batch.title"
-							:label="__('Title')"
-							:required="true"
-						/>
-					</div>
-					<div class="flex flex-col space-y-2">
+				<div class="space-y-4 mb-4">
+					<FormControl
+						v-model="batch.title"
+						:label="__('Title')"
+						:required="true"
+						class="w-full"
+					/>
+					<div class="flex items-center space-x-5">
 						<FormControl
 							v-model="batch.published"
 							type="checkbox"
@@ -90,30 +89,8 @@
 				:required="true"
 				:filters="{ ignore_user_type: 1 }"
 			/>
-			<div class="mb-4">
-				<FormControl
-					v-model="batch.description"
-					:label="__('Description')"
-					type="textarea"
-					class="my-4"
-					:placeholder="__('Short description of the batch')"
-					:required="true"
-				/>
-				<div>
-					<label class="block text-sm text-ink-gray-5 mb-1">
-						{{ __('Batch Details') }}
-						<span class="text-ink-red-3">*</span>
-					</label>
-					<TextEditor
-						:content="batch.batch_details"
-						@change="(val) => (batch.batch_details = val)"
-						:editable="true"
-						:fixedMenu="true"
-						editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] mb-4"
-					/>
-				</div>
-			</div>
-			<div class="mb-4">
+
+			<div class="my-10">
 				<div class="text-lg font-semibold mb-4">
 					{{ __('Date and Time') }}
 				</div>
@@ -133,6 +110,14 @@
 							class="mb-4"
 							:required="true"
 						/>
+						<FormControl
+							v-model="batch.timezone"
+							:label="__('Timezone')"
+							type="text"
+							:placeholder="__('Example: IST (+5:30)')"
+							class="mb-4"
+							:required="true"
+						/>
 					</div>
 					<div>
 						<FormControl
@@ -149,18 +134,11 @@
 							class="mb-4"
 							:required="true"
 						/>
-						<FormControl
-							v-model="batch.timezone"
-							:label="__('Timezone')"
-							type="text"
-							:placeholder="__('Example: IST (+5:30)')"
-							class="mb-4"
-							:required="true"
-						/>
 					</div>
 				</div>
 			</div>
-			<div class="mb-4">
+
+			<div class="mb-10">
 				<div class="text-lg font-semibold mb-4">
 					{{ __('Settings') }}
 				</div>
@@ -178,6 +156,11 @@
 							:label="__('Evaluation End Date')"
 							type="date"
 							class="mb-4"
+						/>
+						<Link
+							doctype="Email Template"
+							:label="__('Email Template')"
+							v-model="batch.confirmation_email_template"
 						/>
 					</div>
 					<div>
@@ -230,6 +213,33 @@
 					/>
 				</div>
 			</div>
+
+			<div class="my-10">
+				<div class="text-lg font-semibold mb-4">
+					{{ __('Description') }}
+				</div>
+				<FormControl
+					v-model="batch.description"
+					:label="__('Short Description')"
+					type="textarea"
+					class="my-4"
+					:placeholder="__('Short description of the batch')"
+					:required="true"
+				/>
+				<div>
+					<label class="block text-sm text-ink-gray-5 mb-1">
+						{{ __('Batch Details') }}
+						<span class="text-ink-red-3">*</span>
+					</label>
+					<TextEditor
+						:content="batch.batch_details"
+						@change="(val) => (batch.batch_details = val)"
+						:editable="true"
+						:fixedMenu="true"
+						editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] mb-4"
+					/>
+				</div>
+			</div>
 		</div>
 	</div>
 </template>
@@ -278,6 +288,7 @@ const batch = reactive({
 	end_time: '',
 	timezone: '',
 	evaluation_end_date: '',
+	confirmation_email_template: '',
 	seat_count: '',
 	medium: '',
 	category: '',

--- a/lms/lms/doctype/lms_batch/lms_batch.json
+++ b/lms/lms/doctype/lms_batch/lms_batch.json
@@ -17,16 +17,17 @@
   "start_time",
   "end_time",
   "timezone",
-  "section_break_rgfj",
-  "medium",
-  "category",
-  "column_break_flwy",
-  "seat_count",
-  "evaluation_end_date",
   "section_break_6",
   "description",
   "column_break_hlqw",
   "instructors",
+  "section_break_rgfj",
+  "medium",
+  "category",
+  "confirmation_email_template",
+  "column_break_flwy",
+  "seat_count",
+  "evaluation_end_date",
   "meta_image",
   "section_break_khcn",
   "batch_details",
@@ -318,6 +319,12 @@
   {
    "fieldname": "section_break_khcn",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "confirmation_email_template",
+   "fieldtype": "Link",
+   "label": "Confirmation Email Template",
+   "options": "Email Template"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -335,7 +342,7 @@
    "link_fieldname": "batch_name"
   }
  ],
- "modified": "2025-02-12 11:59:35.312487",
+ "modified": "2025-02-17 17:48:12.949392",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Batch",

--- a/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
+++ b/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
@@ -79,13 +79,20 @@ def send_mail(doc):
 	batch = frappe.db.get_value(
 		"LMS Batch",
 		doc.batch,
-		["name", "title", "start_date", "start_time", "medium"],
+		[
+			"name",
+			"title",
+			"start_date",
+			"start_time",
+			"medium",
+			"confirmation_email_template",
+		],
 		as_dict=1,
 	)
 
 	subject = _("Enrollment Confirmation for {0}").format(batch.title)
 	template = "batch_confirmation"
-	custom_template = frappe.db.get_single_value(
+	custom_template = batch.confirmation_email_template or frappe.db.get_single_value(
 		"LMS Settings", "batch_confirmation_template"
 	)
 


### PR DESCRIPTION
1. Previously, when a student gets enrolled in a batch, the system sends a standard email confirming their enrollment. 
2. Admins can override this by creating a new email template and linking it to the Batch Confirmation Template field in LMS Settings.
3. But what if admins want to send different emails for different batches?
4. To solve this problem, now each batch has a Confirmation Email Template field. If a template is added here, this template will be used for this batch.

<img width="1440" alt="Screenshot 2025-02-17 at 6 21 49 PM" src="https://github.com/user-attachments/assets/073430e2-9cfb-4cc0-be66-9121a12d79b5" />
