### PR TITLE
feat: cancel evaluations

### DIFF
--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -9,7 +9,7 @@
 			</Button>
 		</div>
 		<div v-if="upcoming_evals.data?.length">
-			<div class="grid grid-cols-2 gap-4">
+			<div class="grid grid-cols-3 gap-4">
 				<div v-for="evl in upcoming_evals.data">
 					<div class="border rounded-md p-3">
 						<div class="font-semibold mb-3">
@@ -28,10 +28,32 @@
 							</span>
 						</div>
 						<div class="flex items-center">
-							<UserCog2 class="w-4 h-4 stroke-1.5" />
-							<span class="ml-2 font-medium">
+							<GraduationCap class="w-4 h-4 stroke-1.5" />
+							<span class="ml-2">
 								{{ evl.evaluator_name }}
 							</span>
+						</div>
+						<div class="flex items-center justify-between space-x-2 mt-4">
+							<Button
+								v-if="evl.google_meet_link"
+								@click="openEvalCall(evl)"
+								class="w-full"
+							>
+								<template #prefix>
+									<HeadsetIcon class="w-4 h-4 stroke-1.5" />
+								</template>
+								{{ __('Join Call') }}
+							</Button>
+							<Button
+								v-if="evl.date > dayjs().format()"
+								@click="cancelEvaluation(evl)"
+								class="w-full"
+							>
+								<template #prefix>
+									<Ban class="w-4 h-4 stroke-1.5" />
+								</template>
+								{{ __('Cancel') }}
+							</Button>
 						</div>
 					</div>
 				</div>
@@ -50,15 +72,23 @@
 	/>
 </template>
 <script setup>
-import { Calendar, Clock, UserCog2 } from 'lucide-vue-next'
-import { inject, ref } from 'vue'
+import {
+	Ban,
+	Calendar,
+	Clock,
+	GraduationCap,
+	HeadsetIcon,
+} from 'lucide-vue-next'
+import { inject, ref, getCurrentInstance } from 'vue'
 import { formatTime } from '../utils'
-import { Button, createResource } from 'frappe-ui'
+import { Button, createResource, call } from 'frappe-ui'
 import EvaluationModal from '@/components/Modals/EvaluationModal.vue'
 
 const dayjs = inject('$dayjs')
 const user = inject('$user')
 const showEvalModal = ref(false)
+const app = getCurrentInstance()
+const { $dialog } = app.appContext.config.globalProperties
 
 const props = defineProps({
 	batch: {
@@ -87,5 +117,33 @@ const upcoming_evals = createResource({
 
 function openEvalModal() {
 	showEvalModal.value = true
+}
+
+const openEvalCall = (evl) => {
+	window.open(evl.google_meet_link, '_blank')
+}
+
+const cancelEvaluation = (evl) => {
+	$dialog({
+		title: __('Cancel this evaluation?'),
+		message: __(
+			'Are you sure you want to cancel this evaluation? This action cannot be undone.'
+		),
+		actions: [
+			{
+				label: __('Cancel'),
+				theme: 'red',
+				variant: 'solid',
+				onClick(close) {
+					call('lms.lms.api.cancel_evaluation', { evaluation: evl }).then(
+						() => {
+							upcoming_evals.reload()
+						}
+					)
+					close()
+				},
+			},
+		],
+	})
 }
 </script>

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
@@ -24,7 +24,8 @@
   "google_meet_link",
   "column_break_ddyh",
   "start_time",
-  "end_time"
+  "end_time",
+  "status"
  ],
  "fields": [
   {
@@ -144,11 +145,19 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Batch Title"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Upcoming\nCompleted\nCancelled",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-11 11:19:44.669132",
+ "modified": "2025-02-19 17:20:02.526294",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Certificate Request",
@@ -204,6 +213,19 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
+ "states": [
+  {
+   "color": "Blue",
+   "title": "Upcoming"
+  },
+  {
+   "color": "Green",
+   "title": "Completed"
+  },
+  {
+   "color": "Red",
+   "title": "Cancelled"
+  }
+ ],
  "title_field": "member_name"
 }

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -874,8 +874,18 @@ def get_upcoming_evals(student, courses):
 			"member": student,
 			"course": ["in", courses],
 			"date": [">=", frappe.utils.nowdate()],
+			"status": "Upcoming",
 		},
-		["date", "start_time", "course", "evaluator", "google_meet_link"],
+		[
+			"name",
+			"date",
+			"start_time",
+			"course",
+			"evaluator",
+			"google_meet_link",
+			"member",
+			"member_name",
+		],
 		order_by="date",
 	)
 

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -101,3 +101,4 @@ lms.patches.v2_0.allow_guest_access #05-02-2025
 lms.patches.v2_0.migrate_batch_student_data #10-02-2025
 lms.patches.v2_0.delete_old_enrollment_doctypes
 lms.patches.v2_0.delete_unused_custom_fields
+lms.patches.v2_0.update_certificate_request_status

--- a/lms/patches/v2_0/update_certificate_request_status.py
+++ b/lms/patches/v2_0/update_certificate_request_status.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.utils import getdate
+
+
+def execute():
+	evaluations = frappe.get_all("LMS Certificate Request", fields=["name", "date"])
+
+	for evaluation in evaluations:
+		if evaluation.date > getdate():
+			frappe.db.set_value("LMS Certificate Request", evaluation.name, "status", "Upcoming")
+		else:
+			frappe.db.set_value(
+				"LMS Certificate Request", evaluation.name, "status", "Completed"
+			)


### PR DESCRIPTION
Students can now cancel an evaluation from the portal. They can do so till a day before the evaluation is scheduled.

<img width="1440" alt="Screenshot 2025-02-19 at 10 23 23 PM" src="https://github.com/user-attachments/assets/553e07be-e789-404e-989e-b434d5a39492" />
