### PR TITLE
feat: mark evaluation requests as complete

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -112,6 +112,7 @@ scheduler_events = {
 	"hourly": [
 		"lms.lms.doctype.lms_certificate_request.lms_certificate_request.schedule_evals",
 		"lms.lms.api.update_course_statistics",
+		"lms.lms.doctype.lms_certificate_request.lms_certificate_request.mark_eval_as_completed",
 	],
 	"daily": [
 		"lms.job.doctype.job_opportunity.job_opportunity.update_job_openings",

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -254,3 +254,20 @@ def create_lms_certificate_evaluation(source_name, target_doc=None):
 		target_doc,
 	)
 	return doc
+
+
+def mark_eval_as_completed():
+	requests = frappe.get_all(
+		"LMS Certificate Request",
+		{
+			"status": "Upcoming",
+			"date": ["<=", getdate()],
+		},
+		["name", "end_time", "date"],
+	)
+
+	for req in requests:
+		if req.date < getdate():
+			frappe.db.set_value("LMS Certificate Request", req.name, "status", "Completed")
+		elif req.date == getdate() and get_time(req.end_time) < get_time(nowtime()):
+			frappe.db.set_value("LMS Certificate Request", req.name, "status", "Completed")


### PR DESCRIPTION
There will be a Scheduler Event that runs every hour. It will check for all upcoming evaluation requests that have ended and mark its status as Completed.