### PR TITLE
fix: don't send payment reminder if member has already paid later

### DIFF
--- a/lms/lms/doctype/lms_payment/lms_payment.py
+++ b/lms/lms/doctype/lms_payment/lms_payment.py
@@ -33,7 +33,22 @@ def send_payment_reminder():
 	)
 
 	for payment in incomplete_payments:
+		if has_paid_later(payment):
+			continue
+
 		send_mail(payment)
+
+
+def has_paid_later(payment):
+	return frappe.db.exists(
+		"LMS Payment",
+		{
+			"member": payment.member,
+			"payment_received": 1,
+			"payment_for_document": payment.payment_for_document,
+			"payment_for_document_type": payment.payment_for_document_type,
+		},
+	)
 
 
 def send_mail(payment):


### PR DESCRIPTION
## Issue

1. If a student does not complete their payment, but later comes back and completes the payment then, payment reminders are being sent to them too.

## Fix

Don't send payment reminders if the student completes the payment later.