### PR TITLE
fix: allow scheduling evals if future eval has been cancelled

### DIFF
--- a/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.js
+++ b/lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on("LMS Certificate Evaluation", {
 	refresh: function (frm) {
 		if (!frm.is_new() && frm.doc.status == "Pass") {
-			frm.add_custom_button(__("Create LMS Certificate"), () => {
+			frm.add_custom_button(__("Create Certificate"), () => {
 				frappe.model.open_mapped_doc({
 					method: "lms.lms.doctype.lms_certificate_evaluation.lms_certificate_evaluation.create_lms_certificate",
 					frm: frm,

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
@@ -4,15 +4,12 @@
 frappe.ui.form.on("LMS Certificate Request", {
 	refresh: function (frm) {
 		if (!frm.is_new() && frm.doc.status == "Upcoming") {
-			frm.add_custom_button(
-				__("Create LMS Certificate Evaluation"),
-				() => {
-					frappe.model.open_mapped_doc({
-						method: "lms.lms.doctype.lms_certificate_request.lms_certificate_request.create_lms_certificate_evaluation",
-						frm: frm,
-					});
-				}
-			);
+			frm.add_custom_button(__("Conduct Evaluation"), () => {
+				frappe.model.open_mapped_doc({
+					method: "lms.lms.doctype.lms_certificate_request.lms_certificate_request.create_lms_certificate_evaluation",
+					frm: frm,
+				});
+			});
 		}
 		if (!frm.doc.google_meet_link && frm.doc.status == "Upcoming") {
 			frm.add_custom_button(__("Generate Google Meet Link"), () => {

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("LMS Certificate Request", {
 	refresh: function (frm) {
-		if (!frm.is_new()) {
+		if (!frm.is_new() && frm.doc.status == "Upcoming") {
 			frm.add_custom_button(
 				__("Create LMS Certificate Evaluation"),
 				() => {
@@ -14,7 +14,7 @@ frappe.ui.form.on("LMS Certificate Request", {
 				}
 			);
 		}
-		if (!frm.doc.google_meet_link) {
+		if (!frm.doc.google_meet_link && frm.doc.status == "Upcoming") {
 			frm.add_custom_button(__("Generate Google Meet Link"), () => {
 				frappe.call({
 					method: "lms.lms.doctype.lms_certificate_request.lms_certificate_request.setup_calendar_event",

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -77,6 +77,7 @@ class LMSCertificateRequest(Document):
 				"member": self.member,
 				"course": self.course,
 				"name": ["!=", self.name],
+				"status": "Upcoming",
 			},
 			["date", "start_time", "course"],
 		)
@@ -150,7 +151,11 @@ def schedule_evals():
 		timelapse = add_to_date(get_datetime(), hours=-5)
 		evals = frappe.get_all(
 			"LMS Certificate Request",
-			{"creation": [">=", timelapse], "google_meet_link": ["is", "not set"]},
+			{
+				"creation": [">=", timelapse],
+				"google_meet_link": ["is", "not set"],
+				"status": "Upcoming",
+			},
 			["name", "member", "member_name", "evaluator", "date", "start_time", "end_time"],
 		)
 		for eval in evals:


### PR DESCRIPTION
## Issue

If a student has canceled an evaluation and was later trying to reschedule, they received a validation message stating that they already have an eval scheduled in the future, even though that eval has been canceled.

![image](https://github.com/user-attachments/assets/e00ebc15-23d9-4233-83a3-20d2ba65b902)

## Fix

1. Only consider evals with the status Upcoming when validating for already scheduled evals.
2. Don't show buttons to Generate Meet Link and Conduct Eval from the desk form.