### PR TITLE
fix: check enrollment on course certification page

### DIFF
--- a/frontend/src/pages/CourseCertification.vue
+++ b/frontend/src/pages/CourseCertification.vue
@@ -37,6 +37,7 @@
 <script setup>
 import { computed, inject, onMounted, ref } from 'vue'
 import { Breadcrumbs, call, createResource } from 'frappe-ui'
+import { useRouter } from 'vue-router'
 import UpcomingEvaluations from '@/components/UpcomingEvaluations.vue'
 
 const courseTitle = ref(null)
@@ -44,6 +45,7 @@ const evaluator = ref(null)
 const courses = ref([])
 const user = inject('$user')
 const dayjs = inject('$dayjs')
+const router = useRouter()
 
 const props = defineProps({
 	courseName: {
@@ -53,6 +55,7 @@ const props = defineProps({
 })
 
 onMounted(() => {
+	fetchEnrollmentDetails()
 	fetchCourseDetails()
 })
 
@@ -66,9 +69,22 @@ const certificate = createResource({
 		},
 		fieldname: ['name', 'template', 'issue_date'],
 	},
-	auto: true,
 	cache: [user.data?.name, props.courseName],
 })
+
+const fetchEnrollmentDetails = () => {
+	call('frappe.client.get_value', {
+		doctype: 'LMS Enrollment',
+		filters: { member: user.data?.name, course: props.courseName },
+		fieldname: ['purchased_certificate'],
+	}).then((data) => {
+		if (data.purchased_certificate) {
+			certificate.reload()
+		} else {
+			router.push({ name: 'CourseDetail', params: { courseName: props.courseName } })
+		}
+	})
+}
 
 const fetchCourseDetails = () => {
 	call('frappe.client.get_value', {

--- a/frontend/src/pages/CourseCertification.vue
+++ b/frontend/src/pages/CourseCertification.vue
@@ -81,7 +81,10 @@ const fetchEnrollmentDetails = () => {
 		if (data.purchased_certificate) {
 			certificate.reload()
 		} else {
-			router.push({ name: 'CourseDetail', params: { courseName: props.courseName } })
+			router.push({
+				name: 'CourseDetail',
+				params: { courseName: props.courseName },
+			})
 		}
 	})
 }

--- a/frontend/src/pages/Courses.vue
+++ b/frontend/src/pages/Courses.vue
@@ -283,7 +283,7 @@ const courseType = computed(() => {
 	]
 	if (user.data?.is_student) {
 		types.push({ label: __('Enrolled'), value: 'Enrolled' })
-	} 
+	}
 	if (user.data?.is_moderator || user.data?.is_instructor) {
 		types.push({ label: __('Created'), value: 'Created' })
 	}

--- a/frontend/src/pages/Courses.vue
+++ b/frontend/src/pages/Courses.vue
@@ -283,7 +283,8 @@ const courseType = computed(() => {
 	]
 	if (user.data?.is_student) {
 		types.push({ label: __('Enrolled'), value: 'Enrolled' })
-	} else {
+	} 
+	if (user.data?.is_moderator || user.data?.is_instructor) {
 		types.push({ label: __('Created'), value: 'Created' })
 	}
 	return types

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -113,37 +113,6 @@ def render_portal_page(path, **kwargs):
 	return page.render()
 
 
-class CoursePage(BaseRenderer):
-	def __init__(self, path, http_status_code):
-		super().__init__(path, http_status_code)
-		self.renderer = None
-
-	def can_render(self):
-		return self.path.startswith("course")
-
-	def render(self):
-		if "learn" in self.path:
-			prefix = self.path.split("/learn")[0]
-			course_name = prefix.split("/")[1]
-			lesson_index = self.path.split("/learn/")[1]
-			chapter_number = lesson_index.split(".")[0]
-			lesson_number = lesson_index.split(".")[1]
-
-			frappe.flags.redirect_location = (
-				f"/lms/courses/{course_name}/learn/{chapter_number}-{lesson_number}"
-			)
-			return RedirectPage(self.path).render()
-
-		elif len(self.path.split("/")) > 1:
-			course_name = self.path.split("/")[1]
-			frappe.flags.redirect_location = f"/lms/courses/{course_name}"
-			return RedirectPage(self.path).render()
-
-		else:
-			frappe.flags.redirect_location = "/lms/courses"
-			return RedirectPage(self.path).render()
-
-
 class SCORMRenderer(BaseRenderer):
 	def can_render(self):
 		return "scorm/" in self.path


### PR DESCRIPTION
1. Course Certification page now checks if the student's enrollment has certification purchased with it. If not, they get redirected to the course list.

2. On the course list page, it was checked if the user has a student role, they were shown the Enrolled tab, or else they were shown the Created tab. With most first time admins who had all roles assigned to them including moderator and student role only saw the Enrolled tab, as they had the student role. The Created tab was not visible to them. So when creating the first course, if the course was not published they were not able to see the course on the course list in the portal. This was reported by 2-3 people. So now the else condition has been removed and instead it checks if the student has a Moderator or Instructor role, the Created tab is shown to them.