### PR TITLE
fix: save lesson details in quiz

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -23,6 +23,7 @@ declare module 'vue' {
     BatchCourses: typeof import('./src/components/BatchCourses.vue')['default']
     BatchDashboard: typeof import('./src/components/BatchDashboard.vue')['default']
     BatchFeedback: typeof import('./src/components/BatchFeedback.vue')['default']
+    BatchIcon: typeof import('./src/components/Icons/BatchIcon.vue')['default']
     BatchOverlay: typeof import('./src/components/BatchOverlay.vue')['default']
     BatchStudentProgress: typeof import('./src/components/Modals/BatchStudentProgress.vue')['default']
     BatchStudents: typeof import('./src/components/BatchStudents.vue')['default']

--- a/frontend/src/components/Modals/Question.vue
+++ b/frontend/src/components/Modals/Question.vue
@@ -119,7 +119,7 @@ const { updateOnboardingStep } = useOnboarding('learning')
 
 const existingQuestion = reactive({
 	question: '',
-	marks: 0,
+	marks: 1,
 })
 const question = reactive({
 	question: '',

--- a/lms/lms/doctype/lms_quiz/lms_quiz.json
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.json
@@ -136,9 +136,15 @@
    "label": "Duration (in minutes)"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2025-01-06 11:02:09.749207",
+ "links": [
+  {
+   "link_doctype": "LMS Quiz Submission",
+   "link_fieldname": "quiz"
+  }
+ ],
+ "modified": "2025-04-07 15:03:48.525458",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Quiz",
@@ -190,6 +196,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -11,8 +11,6 @@ from fuzzywuzzy import fuzz
 from lms.lms.doctype.course_lesson.course_lesson import save_progress
 from lms.lms.utils import (
 	generate_slug,
-	has_course_moderator_role,
-	has_course_instructor_role,
 )
 from binascii import Error as BinasciiError
 from frappe.utils.file_manager import safe_b64decode


### PR DESCRIPTION
### Issue
When a quiz was added to a lesson, lesson details were not saved in the quiz. Because of this, the lesson was not marked complete, as its details were missing from the quiz.

### Fix
Lesson details are now being saved in the quiz, when it is added to a lesson.