### PR TITLE
fix: hide start learning button if self enrollment is disabled

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -48,12 +48,13 @@
 					</span>
 				</Button>
 			</router-link>
-			<div
+			<Badge
 				v-else-if="course.data.disable_self_learning"
-				class="bg-surface-blue-2 text-blue-900 text-sm rounded-md py-1 px-3"
+				theme="blue"
+				size="lg"
 			>
 				{{ __('Contact the Administrator to enroll for this course.') }}
-			</div>
+			</Badge>
 			<Button
 				v-else
 				@click="enrollStudent()"
@@ -140,7 +141,7 @@
 <script setup>
 import { BookOpen, Users, Star, GraduationCap } from 'lucide-vue-next'
 import { computed, inject } from 'vue'
-import { Button, createResource, Tooltip } from 'frappe-ui'
+import { Badge, Button, createResource } from 'frappe-ui'
 import { showToast, formatAmount } from '@/utils/'
 import { capture } from '@/telemetry'
 import { useRouter } from 'vue-router'

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -31,9 +31,21 @@
 							)
 						}}
 					</div>
-					<Button v-if="user.data" @click="enrollStudent()" variant="solid">
+					<Button
+						v-if="user.data && !lesson.data.disable_self_learning"
+						@click="enrollStudent()"
+						variant="solid"
+					>
 						{{ __('Start Learning') }}
 					</Button>
+					<Badge
+						theme="blue"
+						size="lg"
+						v-else-if="lesson.data.disable_self_learning"
+						class="mt-2"
+					>
+						{{ __('Contact the Administrator to enroll for this course.') }}
+					</Badge>
 					<Button v-else @click="redirectToLogin()">
 						<template #prefix>
 							<LogIn class="w-4 h-4 stroke-1" />
@@ -254,6 +266,7 @@
 <script setup>
 import {
 	createResource,
+	Badge,
 	Breadcrumbs,
 	Button,
 	Tooltip,

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1271,7 +1271,10 @@ def get_lesson(course, chapter, lesson):
 
 	membership = get_membership(course)
 	course_info = frappe.db.get_value(
-		"LMS Course", course, ["title", "paid_certificate"], as_dict=1
+		"LMS Course",
+		course,
+		["title", "paid_certificate", "disable_self_learning"],
+		as_dict=1,
 	)
 
 	if (
@@ -1284,6 +1287,7 @@ def get_lesson(course, chapter, lesson):
 			"no_preview": 1,
 			"title": lesson_details.title,
 			"course_title": course_info.title,
+			"disable_self_learning": course_info.disable_self_learning,
 		}
 
 	lesson_details = frappe.db.get_value(
@@ -1324,6 +1328,7 @@ def get_lesson(course, chapter, lesson):
 	lesson_details.instructors = get_instructors("LMS Course", course)
 	lesson_details.course_title = course_info.title
 	lesson_details.paid_certificate = course_info.paid_certificate
+	lesson_details.disable_self_learning = course_info.disable_self_learning
 	return lesson_details
 
 


### PR DESCRIPTION
Students were able to enroll for a course even if self-enrollment was disabled. This was because the Start Learning button was still shown in the Lesson.