### PR TITLE
fix: plyr will now work on all videos of a lesson

### DIFF
--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -334,7 +334,6 @@ const props = defineProps({
 
 onMounted(() => {
 	startTimer()
-	enablePlyr()
 	document.addEventListener('fullscreenchange', attachFullscreenEvent)
 })
 
@@ -473,6 +472,7 @@ watch(
 	() => lesson.data,
 	(data) => {
 		setupLesson(data)
+		enablePlyr()
 	}
 )
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -531,26 +531,28 @@ export const enablePlyr = () => {
 		const videoElement = document.getElementsByClassName('video-player')
 		if (videoElement.length === 0) return
 
-		const src = videoElement[0].getAttribute('src')
-		if (src) {
-			let videoID = src.split('/').pop()
-			videoElement[0].setAttribute('data-plyr-embed-id', videoID)
-		}
-		new Plyr('.video-player', {
-			youtube: {
-				noCookie: true,
-			},
-			controls: [
-				'play-large',
-				'play',
-				'progress',
-				'current-time',
-				'mute',
-				'volume',
-				'fullscreen',
-			],
-		})
-	}, 500)
+		Array.from(videoElement).forEach((video) => {
+			const src = video.getAttribute('src')
+			if (src) {
+				let videoID = src.split('/').pop()
+				video.setAttribute('data-plyr-embed-id', videoID)
+			}
+			new Plyr(video, {
+				youtube: {
+					noCookie: true,
+				},
+				controls: [
+					'play-large',
+					'play',
+					'progress',
+					'current-time',
+					'mute',
+					'volume',
+					'fullscreen',
+				],
+			})
+		}, 500)
+	})
 }
 
 export const openSettings = (category, close) => {


### PR DESCRIPTION
Now that we use Plyr on top of YouTube and Vimeo embeds, this was working well for one video, but if a lesson has more than one video, only one video was visible.

This PR makes Plyr work for all embeds in a lesson.