### PR TITLE
fix: Edit profile escape html

### DIFF
--- a/frontend/src/components/Modals/EditProfile.vue
+++ b/frontend/src/components/Modals/EditProfile.vue
@@ -97,7 +97,7 @@ import {
 } from 'frappe-ui'
 import { reactive, watch } from 'vue'
 import { FileText, X } from 'lucide-vue-next'
-import { getFileSize, escapeHTML } from '@/utils'
+import { getFileSize } from '@/utils'
 
 const reloadProfile = defineModel('reloadProfile')
 
@@ -132,7 +132,7 @@ const imageResource = createResource({
 const updateProfile = createResource({
 	url: 'frappe.client.set_value',
 	makeParams(values) {
-		profile.bio = escapeHTML(profile.bio)
+		profile.bio = profile.bio
 		return {
 			doctype: 'User',
 			name: props.profile.data.name,

--- a/frontend/src/components/Modals/EditProfile.vue
+++ b/frontend/src/components/Modals/EditProfile.vue
@@ -132,7 +132,6 @@ const imageResource = createResource({
 const updateProfile = createResource({
 	url: 'frappe.client.set_value',
 	makeParams(values) {
-		profile.bio = profile.bio
 		return {
 			doctype: 'User',
 			name: props.profile.data.name,


### PR DESCRIPTION
This pr contains following :- 
1. Fix html render issue in profile > about 

## Issue

Currently about section of the profile does not show bio correctly

https://github.com/user-attachments/assets/a74d9121-4d0c-4804-af82-e9e4e0210e83

A simple fix is to remove the escapeHtml when saving

<img width="398" alt="Screenshot 2025-05-28 at 1 59 23 PM" src="https://github.com/user-attachments/assets/c11335da-7f01-4b82-978f-74dfa36ab1d1" />

Since **Tiptap** automatically outputs safe HTML we don't need to use **escapeHtml**, below are the screenshots if user tries to use **JS** 

## Output in console

<img width="744" alt="Screenshot 2025-05-28 at 1 56 23 PM" src="https://github.com/user-attachments/assets/9b2c1613-dc15-4846-8326-8993775cd5d3" />

## Output in ui

<img width="296" alt="Screenshot 2025-05-28 at 1 56 46 PM" src="https://github.com/user-attachments/assets/b9883fc0-45aa-4c9b-9326-3862ffca911d" />

