### PR TITLE
fix: dont allow enrollment if self learning is disabled from api

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -146,7 +146,7 @@
 <script setup>
 import { BookOpen, Users, Star, GraduationCap } from 'lucide-vue-next'
 import { computed, inject } from 'vue'
-import { Badge, Button, createResource, toast } from 'frappe-ui'
+import { Badge, Button, call, createResource, toast } from 'frappe-ui'
 import { formatAmount } from '@/utils/'
 import { capture } from '@/telemetry'
 import { useRouter } from 'vue-router'
@@ -175,15 +175,11 @@ function enrollStudent() {
 		toast.success(__('You need to login first to enroll for this course'))
 		setTimeout(() => {
 			window.location.href = `/login?redirect-to=${window.location.pathname}`
-		}, 1000)
+		}, 500)
 	} else {
-		const enrollStudentResource = createResource({
-			url: 'lms.lms.doctype.lms_enrollment.lms_enrollment.create_membership',
+		call('lms.lms.doctype.lms_enrollment.lms_enrollment.create_membership', {
+			course: props.course.data.name,
 		})
-		enrollStudentResource
-			.submit({
-				course: props.course.data.name,
-			})
 			.then(() => {
 				capture('enrolled_in_course', {
 					course: props.course.data.name,
@@ -198,7 +194,11 @@ function enrollStudent() {
 							lessonNumber: 1,
 						},
 					})
-				}, 2000)
+				}, 1000)
+			})
+			.catch((err) => {
+				toast.warning(__(err.messages?.[0] || err))
+				console.error(err)
 			})
 	}
 }

--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -84,7 +84,11 @@ class LMSEnrollment(Document):
 def create_membership(
 	course, batch=None, member=None, member_type="Student", role="Member"
 ):
-	frappe.get_doc(
+	if frappe.db.get_value("LMS Course", course, "disable_self_learning"):
+		return False
+
+	enrollment = frappe.new_doc("LMS Enrollment")
+	enrollment.update(
 		{
 			"doctype": "LMS Enrollment",
 			"batch_old": batch,
@@ -93,8 +97,9 @@ def create_membership(
 			"member_type": member_type,
 			"member": member or frappe.session.user,
 		}
-	).save(ignore_permissions=True)
-	return "OK"
+	)
+	enrollment.insert()
+	return enrollment
 
 
 @frappe.whitelist()

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -961,15 +961,6 @@ def apply_gst(amount, country=None):
 	return amount, gst_applied
 
 
-def create_membership(course, payment):
-	membership = frappe.new_doc("LMS Enrollment")
-	membership.update(
-		{"member": frappe.session.user, "course": course, "payment": payment.name}
-	)
-	membership.save(ignore_permissions=True)
-	return f"/lms/courses/{course}/learn/1-1"
-
-
 def get_current_exchange_rate(source, target="USD"):
 	url = f"https://api.frankfurter.app/latest?from={source}&to={target}"
 


### PR DESCRIPTION
The API that enrolls students in a course now checks if the course allows self learning.