### PR TITLE
fix: misc evaluation issues

### DIFF
--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -76,8 +76,8 @@
 						</Button>
 					</div>
 				</div>
-				<Tabs :tabs="tabs" v-model="tabIndex" class="border-l w-1/2">
-					<template #default="{ tab }">
+				<Tabs :tabs="tabs" as="div" v-model="tabIndex" class="border-l w-1/2">
+					<template #tab-panel="{ tab }">
 						<div
 							v-if="tab.label == 'Evaluation'"
 							class="flex flex-col space-y-4 p-5"

--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -5,10 +5,7 @@
 				{{ __('Upcoming Evaluations') }}
 			</div>
 			<Button
-				v-if="
-					!upcoming_evals.data?.length ||
-					upcoming_evals.length == courses.length
-				"
+				v-if="upcoming_evals.data?.length != evaluationCourses.length"
 				@click="openEvalModal"
 			>
 				{{ __('Schedule Evaluation') }}
@@ -118,7 +115,7 @@ import {
 	HeadsetIcon,
 	EllipsisVertical,
 } from 'lucide-vue-next'
-import { inject, ref, getCurrentInstance } from 'vue'
+import { inject, ref, getCurrentInstance, computed } from 'vue'
 import { formatTime } from '../utils'
 import { Button, createResource, call } from 'frappe-ui'
 import EvaluationModal from '@/components/Modals/EvaluationModal.vue'
@@ -162,6 +159,12 @@ function openEvalModal() {
 const openEvalCall = (evl) => {
 	window.open(evl.google_meet_link, '_blank')
 }
+
+const evaluationCourses = computed(() => {
+	return props.courses.filter((course) => {
+		return course.evaluator != ''
+	})
+})
 
 const cancelEvaluation = (evl) => {
 	$dialog({

--- a/frontend/src/pages/Batch.vue
+++ b/frontend/src/pages/Batch.vue
@@ -124,7 +124,7 @@
 						:endDate="batch.data.end_date"
 						class="mb-3"
 					/>
-					<div class="flex items-center mb-4 text-ink-gray-7">
+					<div class="flex items-center mb-3 text-ink-gray-7">
 						<Clock class="h-4 w-4 stroke-1.5 mr-2" />
 						<span>
 							{{ formatTime(batch.data.start_time) }} -
@@ -133,7 +133,7 @@
 					</div>
 					<div
 						v-if="batch.data.timezone"
-						class="flex items-center mb-4 text-ink-gray-7"
+						class="flex items-center mb-3 text-ink-gray-7"
 					>
 						<Globe class="h-4 w-4 stroke-1.5 mr-2" />
 						<span>

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -22,6 +22,7 @@
 		<div
 			v-if="notifications?.length"
 			v-for="log in notifications"
+			:key="log.name"
 			class="flex items-center py-2 justify-between"
 		>
 			<div class="flex items-center">
@@ -32,22 +33,20 @@
 				<Link
 					v-if="log.link"
 					:to="log.link"
-					@click="markAsRead.submit({ name: log.name })"
+					@click="(e) => handleMarkAsRead(e, log.name)"
 					class="text-ink-gray-5 font-medium text-sm hover:text-ink-gray-7"
 				>
 					{{ __('View') }}
 				</Link>
-				<Tooltip :text="__('Mark as read')">
-					<Button
-						variant="ghost"
-						v-if="!log.read"
-						@click="markAsRead.submit({ name: log.name })"
-					>
-						<template #icon>
-							<X class="h-4 w-4 text-ink-gray-7 stroke-1.5" />
-						</template>
-					</Button>
-				</Tooltip>
+				<Button
+					variant="ghost"
+					v-if="!log.read"
+					@click.stop="(e) => handleMarkAsRead(e, log.name)"
+				>
+					<template #icon>
+						<X class="h-4 w-4 text-ink-gray-7 stroke-1.5" />
+					</template>
+				</Button>
 			</div>
 		</div>
 		<div v-else class="text-ink-gray-5">
@@ -64,7 +63,6 @@ import {
 	Link,
 	TabButtons,
 	Button,
-	Tooltip,
 	usePageMeta,
 } from 'frappe-ui'
 import { sessionStore } from '../stores/session'
@@ -134,6 +132,10 @@ const markAllAsRead = createResource({
 		readNotifications.reload()
 	},
 })
+
+const handleMarkAsRead = (e, logName) => {
+	markAsRead.submit({ name: logName })
+}
 
 onUnmounted(() => {
 	socket.off('publish_lms_notifications')

--- a/frontend/src/pages/ProfileEvaluationSchedule.vue
+++ b/frontend/src/pages/ProfileEvaluationSchedule.vue
@@ -58,6 +58,7 @@ const evaluations = createListResource({
 	doctype: 'LMS Certificate Request',
 	filters: {
 		evaluator: user.data?.name,
+		status: ['!=', 'Cancelled'],
 	},
 	fields: [
 		'name',

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -87,8 +87,7 @@ class LMSCertificateRequest(Document):
 				req.date == getdate(self.date)
 				or getdate() < getdate(req.date)
 				or (
-					getdate() == getdate(req.date)
-					and getdate(self.start_time) < getdate(req.start_time)
+					getdate() == getdate(req.date) and get_time(nowtime()) < get_time(req.start_time)
 				)
 			):
 				course_title = frappe.db.get_value("LMS Course", req.course, "title")


### PR DESCRIPTION
1. Don't show cancelled requests on the evaluator's calendar.
2. Show Schedule Evaluation button if the number of upcoming evaluations is not equal to the number of courses that need evaluations.