### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Replace the following parameters with your values:
 
 The script will set up a production-ready instance of Frappe Learning with all the necessary configurations in about 5 minutes.
 
+**Note:** To avoid a `404 Page Not Found` error:
+- If hosting on a **public server**, make sure your DNS **A record** points to your server's IP.
+- If hosting **locally**, map your domain to `127.0.0.1` in your `/etc/hosts` file:
+
 ## Development Setup
 
 ### Docker


### PR DESCRIPTION
While reviewing the deployment process for self-hosting Frappe Learning, I noticed that some users were encountering a 404 Page Not Found error after running the install script. This is a common issue caused by missing or incorrect DNS or /etc/hosts configuration.

To address this, I’ve added a clear and concise "Note" section under the deployment instructions in the README to guide users on:

Setting up a DNS A record when hosting on a public server.

Modifying the /etc/hosts file for local development.