### PR TITLE
fix: page length issue on course list

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -978,7 +978,7 @@ def change_currency(amount, currency, country=None):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_courses(filters=None, start=0, page_length=20):
+def get_courses(filters=None, start=0):
 	"""Returns the list of courses."""
 
 	if not filters:
@@ -994,8 +994,8 @@ def get_courses(filters=None, start=0, page_length=20):
 		or_filters=or_filters,
 		order_by="enrollments desc",
 		start=start,
-		page_length=page_length,
 	)
+
 	if show_featured:
 		courses = get_featured_courses(filters, or_filters, fields) + courses
 

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -2096,7 +2096,7 @@ def enroll_in_program_course(program, course):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_batches(filters=None, start=0, page_length=20, order_by="start_date"):
+def get_batches(filters=None, start=0, order_by="start_date"):
 	if not filters:
 		filters = {}
 
@@ -2129,7 +2129,6 @@ def get_batches(filters=None, start=0, page_length=20, order_by="start_date"):
 		],
 		order_by=order_by,
 		start=start,
-		page_length=page_length,
 	)
 
 	batches = filter_batches_based_on_start_time(batches, filters)


### PR DESCRIPTION
The course and Batch lists were only fetching 20 records, even though the page length was being passed as 30. The default parameter of page length was set as 20 and it was overriding the value passed from frontend