### PR TITLE
fix: when logo is updated from brand settings, update the login logo too

### DIFF
--- a/frontend/src/components/Settings/BrandSettings.vue
+++ b/frontend/src/components/Settings/BrandSettings.vue
@@ -64,7 +64,7 @@ const saveSettings = createResource({
 
 const update = () => {
 	let fieldsToSave = {}
-	let imageFields = ['favicon', 'banner_image', 'footer_logo']
+	let imageFields = ['favicon', 'banner_image']
 	props.fields.forEach((f) => {
 		if (imageFields.includes(f.name)) {
 			fieldsToSave[f.name] = f.value ? f.value.file_url : null
@@ -72,6 +72,8 @@ const update = () => {
 			fieldsToSave[f.name] = f.value
 		}
 	})
+
+	fieldsToSave['app_logo'] = fieldsToSave['banner_image']
 	saveSettings.submit(
 		{
 			fields: fieldsToSave,

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
@@ -286,6 +286,9 @@ watch(
 )
 
 const loadFalcon = () => {
+	if (livecodeURL.data) {
+		falconURL.value = livecodeURL.data
+	}
 	return new Promise((resolve, reject) => {
 		const script = document.createElement('script')
 		script.src = `${falconURL.value}static/livecode.js`

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
@@ -150,6 +150,7 @@ const exercises = createListResource({
 	cache: ['programmingExercises'],
 	fields: ['name', 'title', 'language', 'problem_statement'],
 	auto: true,
+	orderBy: 'modified desc',
 })
 
 usePageMeta(() => {


### PR DESCRIPTION
1. When the logo is updated from brand settings, the login logo is not getting updated. This PR fixes that.
2. Livecode URL will now be picked from settings if set.