### PR TITLE
fix: ensure tags wrap correctly to prevent overflow and breaking of layout

### DIFF
--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -67,7 +67,11 @@
 									<FormControl
 										v-model="newTag"
 										:placeholder="__('Add a keyword and then press enter')"
-										:class="['w-full', 'flex-1', { 'mt-2': course.tags?.length }]"
+										:class="[
+											'w-full',
+											'flex-1',
+											{ 'mt-2': course.tags?.length },
+										]"
 										@keyup.enter="updateTags()"
 										id="tags"
 									/>

--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -50,22 +50,24 @@
 								<div class="mb-1.5 text-xs text-ink-gray-5">
 									{{ __('Tags') }}
 								</div>
-								<div class="flex items-center">
-									<div
-										v-if="course.tags"
-										v-for="tag in course.tags?.split(', ')"
-										class="flex items-center bg-surface-gray-2 text-ink-gray-7 p-2 rounded-md mr-2"
-									>
-										{{ tag }}
-										<X
-											class="stroke-1.5 w-3 h-3 ml-2 cursor-pointer"
-											@click="removeTag(tag)"
-										/>
+								<div>
+									<div class="flex items-center flex-wrap gap-2">
+										<div
+											v-if="course.tags"
+											v-for="tag in course.tags?.split(', ')"
+											class="flex items-center bg-surface-gray-2 text-ink-gray-7 p-2 rounded-md"
+										>
+											{{ tag }}
+											<X
+												class="stroke-1.5 w-3 h-3 ml-2 cursor-pointer"
+												@click="removeTag(tag)"
+											/>
+										</div>
 									</div>
 									<FormControl
 										v-model="newTag"
 										:placeholder="__('Add a keyword and then press enter')"
-										class="w-full"
+										:class="['w-full', 'flex-1', { 'mt-2': course.tags?.length }]"
 										@keyup.enter="updateTags()"
 										id="tags"
 									/>


### PR DESCRIPTION
I noticed that while creating a new course, if you add multiple tags the tags would overflow out of the container. And you could not click the close (x) button on these overflowing tags. (see image below)

![Screenshot 2025-07-03 231159](https://github.com/user-attachments/assets/3348a765-1d9d-48ce-b657-5b21635c40c2)

I have updated it so the tags wrap neatly and don't break the layout.

![Screenshot 2025-07-03 234315](https://github.com/user-attachments/assets/5f59663d-b240-4406-86cb-47ea4713f1a2)
