### PR TITLE
fix: Changed image extension validation to MIME type validation

### DIFF
--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -209,7 +209,7 @@
 									v-slot="{ file, progress, uploading, openFileSelector }"
 								>
 									<div class="flex items-center">
-										<div class="border rounded-md w-fit py-5 px-20">
+										<div class="border rounded-md w-fit py-5 px-20 cursor-pointer" @click="openFileSelector">
 											<Image class="size-5 stroke-1 text-ink-gray-7" />
 										</div>
 										<div class="ml-4">
@@ -540,9 +540,10 @@ const removeImage = () => {
 }
 
 const validateFile = (file) => {
-	let extension = file.name.split('.').pop().toLowerCase()
-	if (!['jpg', 'jpeg', 'png'].includes(extension)) {
-		return 'Only image file is allowed.'
+	if (!file.type.startsWith('image/')) {
+		const errorMessage = __('Only image file is allowed.')
+		toast.error(errorMessage)
+		return errorMessage
 	}
 }
 

--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -209,7 +209,10 @@
 									v-slot="{ file, progress, uploading, openFileSelector }"
 								>
 									<div class="flex items-center">
-										<div class="border rounded-md w-fit py-5 px-20 cursor-pointer" @click="openFileSelector">
+										<div
+											class="border rounded-md w-fit py-5 px-20 cursor-pointer"
+											@click="openFileSelector"
+										>
 											<Image class="size-5 stroke-1 text-ink-gray-7" />
 										</div>
 										<div class="ml-4">
@@ -323,7 +326,12 @@ import { useOnboarding } from 'frappe-ui/frappe'
 import { sessionStore } from '../stores/session'
 import MultiSelect from '@/components/Controls/MultiSelect.vue'
 import Link from '@/components/Controls/Link.vue'
-import { openSettings, getMetaInfo, updateMetaInfo } from '@/utils'
+import {
+	openSettings,
+	getMetaInfo,
+	updateMetaInfo,
+	validateFile,
+} from '@/utils'
 
 const router = useRouter()
 const user = inject('$user')
@@ -537,14 +545,6 @@ const saveImage = (file) => {
 
 const removeImage = () => {
 	batch.image = null
-}
-
-const validateFile = (file) => {
-	if (!file.type.startsWith('image/')) {
-		const errorMessage = __('Only image file is allowed.')
-		toast.error(errorMessage)
-		return errorMessage
-	}
 }
 
 const breadcrumbs = computed(() => {

--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -100,7 +100,10 @@
 										v-slot="{ file, progress, uploading, openFileSelector }"
 									>
 										<div class="flex items-center">
-											<div class="border rounded-md w-fit py-5 px-20 cursor-pointer" @click="openFileSelector">
+											<div
+												class="border rounded-md w-fit py-5 px-20 cursor-pointer"
+												@click="openFileSelector"
+											>
 												<Image class="size-5 stroke-1 text-ink-gray-7" />
 											</div>
 											<div class="ml-4">
@@ -324,7 +327,12 @@ import { useRouter } from 'vue-router'
 import { capture, startRecording, stopRecording } from '@/telemetry'
 import { useOnboarding } from 'frappe-ui/frappe'
 import { sessionStore } from '../stores/session'
-import { openSettings, getMetaInfo, updateMetaInfo } from '@/utils'
+import {
+	openSettings,
+	getMetaInfo,
+	updateMetaInfo,
+	validateFile,
+} from '@/utils'
 import Link from '@/components/Controls/Link.vue'
 import CourseOutline from '@/components/CourseOutline.vue'
 import MultiSelect from '@/components/Controls/MultiSelect.vue'
@@ -590,14 +598,6 @@ watch(
 		}
 	}
 )
-
-const validateFile = (file) => {
-	if (!file.type.startsWith('image/')) {
-		const errorMessage = __('Only image file is allowed.')
-		toast.error(errorMessage)
-		return errorMessage
-	}
-}
 
 const updateTags = () => {
 	if (newTag.value) {

--- a/frontend/src/pages/CourseForm.vue
+++ b/frontend/src/pages/CourseForm.vue
@@ -100,7 +100,7 @@
 										v-slot="{ file, progress, uploading, openFileSelector }"
 									>
 										<div class="flex items-center">
-											<div class="border rounded-md w-fit py-5 px-20">
+											<div class="border rounded-md w-fit py-5 px-20 cursor-pointer" @click="openFileSelector">
 												<Image class="size-5 stroke-1 text-ink-gray-7" />
 											</div>
 											<div class="ml-4">
@@ -592,9 +592,10 @@ watch(
 )
 
 const validateFile = (file) => {
-	let extension = file.name.split('.').pop().toLowerCase()
-	if (!['jpg', 'jpeg', 'png', 'webp'].includes(extension)) {
-		return __('Only image file is allowed.')
+	if (!file.type.startsWith('image/')) {
+		const errorMessage = __('Only image file is allowed.')
+		toast.error(errorMessage)
+		return errorMessage
 	}
 }
 

--- a/frontend/src/pages/JobForm.vue
+++ b/frontend/src/pages/JobForm.vue
@@ -294,9 +294,10 @@ const removeImage = () => {
 }
 
 const validateFile = (file) => {
-	let extension = file.name.split('.').pop().toLowerCase()
-	if (!['jpg', 'jpeg', 'png'].includes(extension)) {
-		return 'Only image file is allowed.'
+	if (!file.type.startsWith('image/')) {
+		const errorMessage = __('Only image file is allowed.')
+		toast.error(errorMessage)
+		return errorMessage
 	}
 }
 

--- a/frontend/src/pages/JobForm.vue
+++ b/frontend/src/pages/JobForm.vue
@@ -151,7 +151,7 @@ import { computed, onMounted, reactive, inject } from 'vue'
 import { FileText, X } from 'lucide-vue-next'
 import { sessionStore } from '@/stores/session'
 import { useRouter } from 'vue-router'
-import { getFileSize } from '@/utils'
+import { getFileSize, validateFile } from '@/utils'
 
 const user = inject('$user')
 const router = useRouter()
@@ -291,14 +291,6 @@ const saveImage = (file) => {
 
 const removeImage = () => {
 	job.image = null
-}
-
-const validateFile = (file) => {
-	if (!file.type.startsWith('image/')) {
-		const errorMessage = __('Only image file is allowed.')
-		toast.error(errorMessage)
-		return errorMessage
-	}
 }
 
 const jobTypes = computed(() => {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -497,10 +497,13 @@ export function singularize(word) {
 	)
 }
 
-export const validateFile = (file) => {
-	let extension = file.name.split('.').pop().toLowerCase()
-	if (!['jpg', 'jpeg', 'png', 'webp'].includes(extension)) {
-		return __('Only image file is allowed.')
+export const validateFile = (file, showToast = true) => {
+	if (!file.type.startsWith('image/')) {
+		const errorMessage = __('Only image file is allowed.')
+		if (showToast) {
+			toast.error(errorMessage)
+		}
+		return errorMessage
 	}
 }
 


### PR DESCRIPTION
While creating a new course, batch or job, I was not able to upload certain photos whenever an image upload was required. This was because the image validation function checks for the file extension and only allows 3 extensions - jpg, jpeg, png. This is quite restrictive and does not allow for many other image types such as svg, tiff, bmp, webp, avif etc. 

Also, file extensions can be spoofed so it is not very secure. A better way would be to check for MIME type. So I have changed the validation to MIME type validation which is more secure and incorporates all types of image files.

Also made a UI change so the user can now click on empty image card to open the Image selector dialog box.

https://github.com/user-attachments/assets/a90148fd-89ac-4d9f-a459-e69a0f5c275d


