### PR TITLE
feat: allow students to un-enroll from course if progress < 100

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -89,6 +89,20 @@
 					{{ __('Get Certificate') }}
 				</Button>
 				<Button
+					v-if="!user.data?.is_moderator && !is_instructor() && course.data.membership"
+					@click="unEnrollStudent(course)"
+					variant="outline"
+					class="w-full mt-2"
+					size="md"
+				>
+					<template #prefix>
+						<LogOut class="size-4 stroke-1.5" />
+					</template>
+					<span>
+						{{ __('Un-enroll from course') }}
+					</span>
+				</Button>
+				<Button
 					v-if="user.data?.is_moderator || is_instructor()"
 					class="w-full mt-2"
 					size="md"
@@ -181,6 +195,7 @@ import {
 	CreditCard,
 	GraduationCap,
 	Pencil,
+	LogOut,
 	Star,
 	TrendingUp,
 	Users,
@@ -243,6 +258,24 @@ function enrollStudent() {
 				console.error(err)
 			})
 	}
+}
+
+function unEnrollStudent(course) {
+	if (!user.data || !course?.data?.name) return;
+	
+	call('lms.lms.doctype.lms_enrollment.lms_enrollment.remove_membership', {
+		course: props.course.data.name,
+		member: user.data.name,
+	})
+	.then(() => {
+		toast.success(__('You have been Un-enrolled successfully.'))
+		setTimeout(() => {
+			window.location.reload()
+		}, 1000)
+	}).catch((err) => {
+		toast.warning(__(err.messages?.[0] || err))
+		console.error(err)
+	});
 }
 
 const is_instructor = () => {


### PR DESCRIPTION
### Feature: Allow Students to Un-Enroll from Course

This PR introduces the ability for learners to un-enroll from a course **only if they haven't completed it yet (progress < 100)**.
---
### Key Changes

- Added a Vue-based button with `LogOut` icon to trigger un-enrollment.
- Added backend `remove_membership` method in `lms_enrollment.py`:
  - Removes `LMS Enrollment` record for the given member and course.
  - Only removes if progress is **not 100** (i.e., not completed).
  - Updates course statistics after removal.
- Vue logic blocks moderators/instructors from seeing un-enroll button.
- Added unit test `test_remove_membership_unenrolls_student`.

---
### Validations

- Students **cannot un-enroll** after completing a course.
- Permission ignored only for deletion (intentional system-level logic).
- Clean UX with appropriate button states and server response messages.

---
### How to test

1. Enroll a test user in a course with progress < 100.
2. Visit the course card as that user.
3. Click **Un-enroll**.
4. Confirm the record is removed in the _LMS Enrollment_ doctype and course statistics are updated in the _LMS Course_ doctype.

---
### Screenshots
<img width="349" height="255" alt="Screenshot from 2025-07-13 23-01-47" src="https://github.com/user-attachments/assets/63b9f92a-0253-499c-8207-c0c2b54c39da" />
