### PR TITLE
fix: play embed videos on Lesson Form

### DIFF
--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -714,17 +714,6 @@ iframe {
 	width: 100%;
 }
 
-.cdx-block.embed-tool::after {
-	content: '';
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	background: transparent;
-	z-index: 1000;
-}
-
 :root {
 	--plyr-range-fill-background: white;
 	--plyr-video-control-background-hover: transparent;


### PR DESCRIPTION
Videos that were embedded on the Lesson from YouTube or Vimeo were playing on the Lesson page, but when the lesson was being edited, instructors were unable to play the video from the Lesson Form.

An invisible overlay on top of the videos was causing this issue, which has now been removed.