### PR TITLE
fix: vimeo video embed with plyr

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -551,11 +551,10 @@ export const enablePlyr = async () => {
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const setupPlyrForVideo = (video, players) => {
-	const src = video.getAttribute('src') || video.getAttribute('data-src')
+	const src = video.getAttribute('src')
 
 	if (src) {
 		const videoID = extractYouTubeId(src)
-		video.setAttribute('data-plyr-provider', 'youtube')
 		video.setAttribute('data-plyr-embed-id', videoID)
 	}
 


### PR DESCRIPTION
Vimeo videos had stopped working because a recent change was considering all embeds as YouTube. Removed the line of code that was setting `data-plyr-provider` as `youtube` for all sources.