### PR TITLE
fix: progress timer in lessons

### DIFF
--- a/.github/workflows/make_release_pr.yml
+++ b/.github/workflows/make_release_pr.yml
@@ -1,7 +1,7 @@
 name: Create weekly release
 on:
   schedule:
-    - cron: '30 4 15 * *'
+    - cron: '30 3 * * 3'
   workflow_dispatch:
 
 jobs:

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -604,7 +604,7 @@ const updateVideoTime = (video) => {
 }
 
 const startTimer = () => {
-	timerInterval = setInterval(() => {
+	let timerInterval = setInterval(() => {
 		timer.value++
 		if (timer.value == 30) {
 			clearInterval(timerInterval)


### PR DESCRIPTION
The progress timer that marks lesson progress after 30 seconds was not working.