### PR TITLE
fix(ui): correct mislabeled subtitle in statistics

### DIFF
--- a/frontend/src/pages/Statistics.vue
+++ b/frontend/src/pages/Statistics.vue
@@ -54,7 +54,7 @@
 						:config="{
 							data: signupsChart.data,
 							title: 'Signups',
-							subtitle: 'Signups per month',
+							subtitle: 'Signups per day',
 							xAxis: {
 								key: 'date',
 								type: 'time',
@@ -74,7 +74,7 @@
 						:config="{
 							data: enrollmentChart.data,
 							title: 'Enrollments',
-							subtitle: 'Enrollments per month',
+							subtitle: 'Enrollments per day',
 							xAxis: {
 								key: 'date',
 								type: 'time',
@@ -96,7 +96,7 @@
 						:config="{
 							data: certification.data,
 							title: 'Certifications',
-							subtitle: 'Certifications per month',
+							subtitle: 'Certifications per day',
 							xAxis: {
 								key: 'date',
 								type: 'time',


### PR DESCRIPTION
This PR fixes a mislabeled subtitle in the statistics section of the LMS app.

Corrected the UI text 

Earlier It was - 


https://github.com/user-attachments/assets/3ff04445-c100-43c1-887e-13738fc83a37

Now Changed to - 

<img width="1854" height="952" alt="image" src="https://github.com/user-attachments/assets/edad1d59-fdba-4906-8cc0-f320d70e2550" />


