### PR TITLE
fix: mobile responsive live class card

### DIFF
--- a/frontend/src/components/LiveClass.vue
+++ b/frontend/src/components/LiveClass.vue
@@ -22,7 +22,7 @@
 			</span>
 		</Button>
 	</div>
-	<div v-if="liveClasses.data?.length" class="grid grid-cols-3 gap-5 mt-5">
+	<div v-if="liveClasses.data?.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 mt-5">
 		<div
 			v-for="cls in liveClasses.data"
 			class="flex flex-col border rounded-md h-full text-ink-gray-7 hover:border-outline-gray-3 p-3"


### PR DESCRIPTION
Improved the Live Class component to be mobile responsive.


Earlier-

![IMG-20250828-WA0005 (1)](https://github.com/user-attachments/assets/220dc2e5-1bcc-4da7-9c17-61035165c1cc)


NOW- 

<img width="384" height="827" alt="Screenshot from 2025-08-29 18-36-36" src="https://github.com/user-attachments/assets/20d10f85-a625-4de7-ba21-60d1ffbce1ea" />





