### PR TITLE
fix(ui): make install prompt message mobile responsive

### DIFF
--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -20,10 +20,10 @@
 		</template>
 	</Dialog>
 
-	<Popover :show="iosInstallMessage" placement="bottom">
+	<Popover :show="iosInstallMessage" placement="top">
 		<template #body>
 			<div
-				class="mx-2 mt-[calc(100vh-15rem)] flex flex-col gap-3 rounded bg-blue-100 py-5 drop-shadow-xl"
+				class="fixed bottom-[4rem] left-1/2 -translate-x-1/2 z-20 w-[90%] flex flex-col gap-3 rounded bg-blue-100 py-5 drop-shadow-xl"
 			>
 				<div
 					class="mb-1 flex flex-row items-center justify-between px-3 text-center"


### PR DESCRIPTION
Earlier iosInstallMessage on mobile was not set properly it takes too much space on bottom 

https://github.com/user-attachments/assets/0f6c1fbc-bab3-4d9e-b28d-b95ae6f8388c


Now fixed the styling issue it is now sticked above bottom bar


https://github.com/user-attachments/assets/90e20977-e8e2-4772-91ce-f3f4b8c28ac9


