### PR TITLE
fix: make text visible in dark theme

### DIFF
--- a/frontend/src/pages/Home/Home.vue
+++ b/frontend/src/pages/Home/Home.vue
@@ -7,7 +7,7 @@
 	<div class="w-full px-5 pt-5 pb-10">
 		<div class="flex items-center justify-between">
 			<div class="space-y-2">
-				<div class="text-xl font-bold">
+				<div class="text-xl font-bold text-ink-gray-9">
 					{{ __('Hey') }}, {{ user.data?.full_name }} 👋
 				</div>
 				<div class="text-lg text-ink-gray-6">

--- a/frontend/src/pages/Home/StudentHome.vue
+++ b/frontend/src/pages/Home/StudentHome.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div v-if="myCourses.data?.length" class="mt-10">
 			<div class="flex items-center justify-between mb-3">
-				<span class="font-semibold text-lg">
+				<span class="font-semibold text-lg text-ink-gray-9">
 					{{
 						myCourses.data[0].membership
 							? __('My Courses')
@@ -34,7 +34,7 @@
 
 		<div v-if="myBatches.data?.length" class="mt-10">
 			<div class="flex items-center justify-between mb-3">
-				<span class="font-semibold text-lg">
+				<span class="font-semibold text-lg text-ink-gray-9">
 					{{
 						myBatches.data?.[0].students.includes(user.data?.name)
 							? __('My Batches')
@@ -67,7 +67,7 @@
 		<div class="grid grid-cols-2 gap-5 mt-10">
 			<UpcomingEvaluations :forHome="true" />
 			<div v-if="myLiveClasses.data?.length">
-				<div class="font-semibold text-lg mb-3">
+				<div class="font-semibold text-lg mb-3 text-ink-gray-9">
 					{{ __('Upcoming Live Classes') }}
 				</div>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-5">

--- a/frontend/src/pages/Home/StudentHome.vue
+++ b/frontend/src/pages/Home/StudentHome.vue
@@ -46,7 +46,7 @@
 						name: 'Batches',
 					}"
 				>
-					<span class="flex items-center space-x- 1 text-ink-gray-5 text-xs">
+					<span class="flex items-center space-x-1 text-ink-gray-5 text-xs">
 						<span>
 							{{ __('See all') }}
 						</span>

--- a/frontend/src/pages/Programs/ProgramForm.vue
+++ b/frontend/src/pages/Programs/ProgramForm.vue
@@ -45,7 +45,7 @@
 
 				<div class="pb-5">
 					<div class="flex items-center justify-between mt-5 mb-4">
-						<div class="text-lg font-semibold">
+						<div class="text-lg font-semibold text-ink-gray-9">
 							{{ __('Courses') }}
 						</div>
 						<Button @click="openForm('course')">
@@ -106,7 +106,7 @@
 
 				<div>
 					<div class="flex items-center justify-between mt-5 mb-4">
-						<div class="text-lg font-semibold">
+						<div class="text-lg font-semibold text-ink-gray-9">
 							{{ __('Members') }}
 						</div>
 


### PR DESCRIPTION
Text disappears in dark theme. Added text colors to fix it.

### before
<img width="1420" height="1016" alt="before" src="https://github.com/user-attachments/assets/70289f7c-3722-41b0-bc0b-d61e4f800a86" />

<img width="1350" height="834" alt="before p" src="https://github.com/user-attachments/assets/a3094b70-81fe-44b1-88d5-2e17e2df028a" />

### after
<img width="1498" height="1020" alt="after" src="https://github.com/user-attachments/assets/ef0a8ef0-e921-4cf3-949e-ccdac729926c" />

<img width="1360" height="848" alt="after p" src="https://github.com/user-attachments/assets/06d54050-92f3-414e-9bbb-acef323fd6f2" />


closes: #1744 