### PR TITLE
feat: contact us

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -375,6 +375,18 @@ const addPrograms = async () => {
 	})
 }
 
+const addContactUsDetails = () => {
+	if (settingsStore.contactUsEmail?.data || settingsStore.contactUsURL?.data) {
+		sidebarLinks.value.push({
+			label: 'Contact Us',
+			icon: settingsStore.contactUsURL?.data ? 'Headset' : 'Mail',
+			to: settingsStore.contactUsURL?.data
+				? settingsStore.contactUsURL.data
+				: `mailto:${settingsStore.contactUsEmail?.data}`,
+		})
+	}
+}
+
 const checkIfCanAddProgram = async () => {
 	if (isModerator.value || isInstructor.value) {
 		return true
@@ -645,6 +657,7 @@ const setUpOnboarding = () => {
 }
 
 watch(userResource, () => {
+	addContactUsDetails()
 	if (userResource.data) {
 		isModerator.value = userResource.data.is_moderator
 		isInstructor.value = userResource.data.is_instructor

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -336,8 +336,8 @@ const tabsStructure = computed(() => {
 							type: 'checkbox',
 						},
 						{
-							label: 'Certified Members',
-							name: 'certified_members',
+							label: 'Certifications',
+							name: 'certifications',
 							type: 'checkbox',
 						},
 						{

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -161,6 +161,26 @@ const tabsStructure = computed(() => {
 						},
 					],
 				},
+				{
+					label: 'Contact Us',
+					icon: 'Phone',
+					fields: [
+						{
+							label: 'Email',
+							name: 'contact_us_email',
+							type: 'text',
+							description:
+								'Users can reach out to this email for support or inquiries.',
+						},
+						{
+							label: 'URL',
+							name: 'contact_us_url',
+							type: 'text',
+							description:
+								'Users can reach out to this URL for support or inquiries.',
+						},
+					],
+				},
 			],
 		},
 		{

--- a/frontend/src/components/SidebarLink.vue
+++ b/frontend/src/components/SidebarLink.vue
@@ -88,6 +88,13 @@ function handleClick() {
 	if (router.hasRoute(props.link.to)) {
 		router.push({ name: props.link.to })
 	} else if (props.link.to) {
+		if (
+			props.link.to.startsWith('http') ||
+			props.link.to.startsWith('mailto:')
+		) {
+			window.open(props.link.to, '_blank')
+			return
+		}
 		window.location.href = `/${props.link.to}`
 	}
 }

--- a/frontend/src/stores/settings.js
+++ b/frontend/src/stores/settings.js
@@ -21,6 +21,20 @@ export const useSettings = defineStore('settings', () => {
 		cache: ['preventSkippingVideos'],
 	})
 
+	const contactUsEmail = createResource({
+		url: 'lms.lms.api.get_lms_setting',
+		params: { field: 'contact_us_email' },
+		auto: true,
+		cache: ['contactUsEmail'],
+	})
+
+	const contactUsURL = createResource({
+		url: 'lms.lms.api.get_lms_setting',
+		params: { field: 'contact_us_url' },
+		auto: true,
+		cache: ['contactUsURL'],
+	})
+
 	const sidebarSettings = createResource({
 		url: 'lms.lms.api.get_sidebar_settings',
 		cache: 'Sidebar Settings',
@@ -32,6 +46,8 @@ export const useSettings = defineStore('settings', () => {
 		activeTab,
 		allowGuestAccess,
 		preventSkippingVideos,
+		contactUsEmail,
+		contactUsURL,
 		sidebarSettings,
 	}
 })

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -422,7 +422,7 @@ export function getSidebarLinks() {
 			activeFor: ['Batches', 'BatchDetail', 'Batch', 'BatchForm'],
 		},
 		{
-			label: 'Certified Members',
+			label: 'Certifications',
 			icon: 'GraduationCap',
 			to: 'CertifiedParticipants',
 			activeFor: ['CertifiedParticipants'],

--- a/lms/job/doctype/job_opportunity/job_opportunity.py
+++ b/lms/job/doctype/job_opportunity/job_opportunity.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_months, get_link_to_form, getdate
+from frappe.utils import add_months, get_link_to_form, getdate, validate_url
 from frappe.utils.user import get_system_managers
 
 from lms.lms.utils import generate_slug, validate_image
@@ -16,7 +16,7 @@ class JobOpportunity(Document):
 		self.company_logo = validate_image(self.company_logo)
 
 	def validate_urls(self):
-		frappe.utils.validate_url(self.company_website, True)
+		validate_url(self.company_website, True)
 
 	def autoname(self):
 		if not self.name:

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -507,7 +507,7 @@ def get_sidebar_settings():
 	items = [
 		"courses",
 		"batches",
-		"certified_members",
+		"certifications",
 		"jobs",
 		"statistics",
 		"notifications",

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -35,8 +35,8 @@
   "items_in_sidebar_section",
   "courses",
   "batches",
-  "certified_participants",
   "certified_members",
+  "certifications",
   "programming_exercises",
   "column_break_exdz",
   "jobs",
@@ -281,13 +281,6 @@
   },
   {
    "default": "1",
-   "fieldname": "certified_participants",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Certified Participants"
-  },
-  {
-   "default": "1",
    "fieldname": "jobs",
    "fieldtype": "Check",
    "label": "Jobs"
@@ -403,6 +396,7 @@
    "default": "0",
    "fieldname": "certified_members",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Certified Members"
   },
   {
@@ -439,13 +433,19 @@
    "fieldname": "contact_us_url",
    "fieldtype": "Data",
    "label": "Contact Us URL"
+  },
+  {
+   "default": "0",
+   "fieldname": "certifications",
+   "fieldtype": "Check",
+   "label": "Certifications"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-03 17:41:30.904723",
+ "modified": "2025-10-06 10:27:41.117864",
  "modified_by": "sayali@frappe.io",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -67,7 +67,11 @@
   "meta_description",
   "meta_image",
   "column_break_xijv",
-  "meta_keywords"
+  "meta_keywords",
+  "contact_us_tab",
+  "contact_us_email",
+  "column_break_gcgv",
+  "contact_us_url"
  ],
  "fields": [
   {
@@ -416,13 +420,32 @@
    "fieldname": "programming_exercises",
    "fieldtype": "Check",
    "label": "Programming Exercises"
+  },
+  {
+   "fieldname": "contact_us_tab",
+   "fieldtype": "Tab Break",
+   "label": "Contact Us"
+  },
+  {
+   "fieldname": "contact_us_email",
+   "fieldtype": "Data",
+   "label": "Contact Us Email"
+  },
+  {
+   "fieldname": "column_break_gcgv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "contact_us_url",
+   "fieldtype": "Data",
+   "label": "Contact Us URL"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-12 16:47:49.983018",
+ "modified": "2025-10-03 17:41:30.904723",
  "modified_by": "sayali@frappe.io",
  "module": "LMS",
  "name": "LMS Settings",

--- a/lms/lms/doctype/lms_settings/lms_settings.py
+++ b/lms/lms/doctype/lms_settings/lms_settings.py
@@ -4,13 +4,14 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import get_url_to_list
+from frappe.utils import get_url_to_list, validate_email_address, validate_url
 
 
 class LMSSettings(Document):
 	def validate(self):
 		self.validate_google_settings()
 		self.validate_signup()
+		self.validate_contact_us_details()
 
 	def validate_google_settings(self):
 		if self.send_calendar_invite_for_evaluations:
@@ -44,6 +45,12 @@ class LMSSettings(Document):
 	def validate_signup(self):
 		if self.has_value_changed("disable_signup"):
 			frappe.db.set_single_value("Website Settings", "disable_signup", self.disable_signup)
+
+	def validate_contact_us_details(self):
+		if self.contact_us_email and not validate_email_address(self.contact_us_email):
+			frappe.throw(_("Please enter a valid Contact Us Email."))
+		if self.contact_us_url and not validate_url(self.contact_us_url, True):
+			frappe.throw(_("Please enter a valid Contact Us URL."))
 
 
 @frappe.whitelist()

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -112,3 +112,4 @@ lms.patches.v2_0.move_batch_instructors_to_evaluators
 lms.patches.v2_0.enable_programming_exercises_in_sidebar
 lms.patches.v2_0.count_in_program
 lms.patches.v2_0.fix_scorm_lesson_reference_idx #02-09-2025
+lms.patches.v2_0.certified_members_to_certifications #05-10-2025

--- a/lms/patches/v2_0/certified_members_to_certifications.py
+++ b/lms/patches/v2_0/certified_members_to_certifications.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	show_certifications = frappe.db.get_single_value("LMS Settings", "certified_members")
+
+	if show_certifications:
+		frappe.db.set_single_value("LMS Settings", "certifications", 1)


### PR DESCRIPTION
Admins can now add a Contact Us link to the sidebar for settings. This can be an email address on click of which the email pop-up opens, or it can be a link to a separate page that opens in a new tab.

<img width="1552" height="1012" alt="Screenshot 2025-10-06 at 10 58 01 AM" src="https://github.com/user-attachments/assets/6dec591c-161c-438b-8bed-add1d85b064c" />

<img width="1552" height="1012" alt="Screenshot 2025-10-06 at 10 56 31 AM" src="https://github.com/user-attachments/assets/68ce7a58-6eb8-4a4a-bd79-3881a908d8d7" />
