### PR TITLE
fix: live class issues

### DIFF
--- a/frontend/src/components/LiveClass.vue
+++ b/frontend/src/components/LiveClass.vue
@@ -54,8 +54,8 @@
 				<div class="flex items-center space-x-2">
 					<Clock class="w-4 h-4 stroke-1.5" />
 					<span>
-						{{ formatTime(cls.time) }} -
-						{{ dayjs(getClassEnd(cls)).format('HH:mm A') }}
+						{{ dayjs(getClassStart(cls)).format('hh:mm A') }} -
+						{{ dayjs(getClassEnd(cls)).format('hh:mm A') }}
 					</span>
 				</div>
 				<div
@@ -181,8 +181,12 @@ const canAccessClass = (cls) => {
 	return true
 }
 
+const getClassStart = (cls) => {
+	return new Date(`${cls.date}T${cls.time}`)
+}
+
 const getClassEnd = (cls) => {
-	const classStart = new Date(`${cls.date}T${cls.time}`)
+	const classStart = getClassStart(cls)
 	return new Date(classStart.getTime() + cls.duration * 60000)
 }
 

--- a/lms/lms/doctype/lms_live_class/lms_live_class.py
+++ b/lms/lms/doctype/lms_live_class/lms_live_class.py
@@ -38,8 +38,12 @@ class LMSLiveClass(Document):
 
 	def add_event_participants(self, event, calendar):
 		participants = frappe.get_all("LMS Batch Enrollment", {"batch": self.batch_name}, pluck="member")
+		instructors = frappe.get_all("Course Instructor", {"parent": self.batch_name}, pluck="instructor")
 
 		participants.append(frappe.session.user)
+		participants.extend(instructors)
+		participants = list(set(participants))
+
 		for participant in participants:
 			frappe.get_doc(
 				{


### PR DESCRIPTION
1. Fixed the time display in the live class card.
2. Include all instructors as live class participants.