### PR TITLE
fix: scroll issue in settings

### DIFF
--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -2,7 +2,9 @@
 	<Dialog v-model="show" :options="{ size: '5xl' }">
 		<template #body>
 			<div class="flex h-[calc(100vh_-_8rem)]">
-				<div class="flex w-52 shrink-0 flex-col bg-surface-gray-2 p-2">
+				<div
+					class="flex w-52 shrink-0 flex-col bg-surface-gray-2 p-2 overflow-y-auto"
+				>
 					<h1 class="mb-3 px-2 pt-2 text-lg font-semibold text-ink-gray-9">
 						{{ __('Settings') }}
 					</h1>


### PR DESCRIPTION
**Before:**
As you can see in the video, when I scroll to the bottom using the mouse, it doesn’t work
I have to use the tab key to navigate to the bottom.

https://github.com/user-attachments/assets/80cc17cd-e0e6-40f3-ade5-8532d6920fb8

**After:**

https://github.com/user-attachments/assets/6f90ba9f-a7e3-4dcc-b8f8-e7da0b1632b5


