### PR TITLE
fix: update font color in dark mode for My Notes

### DIFF
--- a/frontend/src/components/Notes/Notes.vue
+++ b/frontend/src/components/Notes/Notes.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="text-lg font-semibold mb-4">
+	<div class="text-lg font-semibold mb-4 text-ink-gray-9">
 		{{ __('My Notes') }}
 	</div>
 	<TextEditor


### PR DESCRIPTION
Closes https://github.com/frappe/lms/issues/1789

**Before:**
<img width="1341" height="607" alt="image" src="https://github.com/user-attachments/assets/6e42db94-727a-4198-82b2-b255833854aa" />

<img width="1342" height="619" alt="image" src="https://github.com/user-attachments/assets/196f4958-d61b-4ff8-80f7-303a140b40c2" />

**After:**

<img width="1365" height="626" alt="image" src="https://github.com/user-attachments/assets/35b6120d-ae05-4d7e-89da-60b7e1dc4831" />
