### PR TITLE
fix: enrollment in restricted courses by admin

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -220,8 +220,12 @@ function enrollStudent() {
 			window.location.href = `/login?redirect-to=${window.location.pathname}`
 		}, 500)
 	} else {
-		call('lms.lms.doctype.lms_enrollment.lms_enrollment.create_membership', {
-			course: props.course.data.name,
+		call('frappe.client.insert', {
+			doc: {
+				doctype: 'LMS Enrollment',
+				course: props.course.data.name,
+				member: user.data.name,
+			},
 		})
 			.then(() => {
 				capture('enrolled_in_course', {


### PR DESCRIPTION
There was a recent validation added before enrollment which checked various conditions. This was preventing even admins from enrolling students in courses that had self learning disabled. Fixed the issue and now admins would be able to enroll students in such courses.