### PR TITLE
fix: skip closed jobs API call for guest users

### DIFF
--- a/frontend/src/pages/Jobs.vue
+++ b/frontend/src/pages/Jobs.vue
@@ -137,6 +137,10 @@ const isModerator = computed(() => {
 })
 
 const getClosedJobCount = () => {
+	if (!user.data?.name) {
+		return
+	}
+
 	const filters = {
 		status: 'Closed',
 	}


### PR DESCRIPTION

**Issue:** Skip getClosedJobCount API call for unauthenticated users to avoid `frappe.client.get_count` is not whitelisted error in browser console.

<img width="1365" height="766" alt="image" src="https://github.com/user-attachments/assets/eed58914-9bcf-4844-bb84-f605fe9534bf" />
