### PR TITLE
feat: Add option to hide quiz summary after submission

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -260,7 +260,7 @@
 					)
 				}}
 			</div>
-			<div v-else class="text-ink-gray-7">
+			<div v-else-if="quiz.data.show_quiz_summary" class="text-ink-gray-7">
 				{{
 					__(
 						'You got {0}% correct answers with a score of {1} out of {2}'
@@ -268,6 +268,15 @@
 						Math.ceil(quizSubmission.data.percentage),
 						quizSubmission.data.score,
 						quizSubmission.data.score_out_of
+					)
+				}}
+			</div>
+			<div v-else
+				class="leading-5 text-ink-gray-7"
+			>
+				{{
+					__(
+						"Your submission has been successfully saved."
 					)
 				}}
 			</div>

--- a/frontend/src/pages/QuizForm.vue
+++ b/frontend/src/pages/QuizForm.vue
@@ -97,6 +97,11 @@
 						type="checkbox"
 						:label="__('Show Submission History')"
 					/>
+					<FormControl
+						v-model="quizDetails.doc.show_quiz_summary"
+						type="checkbox"
+						:label="__('Show Quiz Summary')"
+					/>
 				</div>
 				<div class="flex flex-col space-y-5">
 					<FormControl

--- a/lms/lms/doctype/lms_quiz/lms_quiz.json
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.json
@@ -11,6 +11,7 @@
   "max_attempts",
   "show_answers",
   "show_submission_history",
+  "show_quiz_summary",
   "column_break_gaac",
   "total_marks",
   "passing_percentage",
@@ -149,6 +150,12 @@
    "fieldname": "marks_to_cut",
    "fieldtype": "Int",
    "label": "Marks To Cut"
+  },
+  {
+   "default": "1",
+   "fieldname": "show_quiz_summary",
+   "fieldtype": "Check",
+   "label": "Show Quiz Summary"
   }
  ],
  "grid_page_length": 50,
@@ -159,8 +166,8 @@
    "link_fieldname": "quiz"
   }
  ],
- "modified": "2025-06-27 20:00:15.660323",
- "modified_by": "sayali@frappe.io",
+ "modified": "2025-12-24 12:45:22.209334",
+ "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Quiz",
  "owner": "Administrator",


### PR DESCRIPTION
## Description

This PR adds a new `show_quiz_summary` feature that allows quiz creators to control whether students see their detailed quiz results (score and percentage) after completing a quiz. This is useful in cases where instructors want to hide the summary, such as when they want to review submissions first or maintain quiz integrity.

## Motivation

In some educational scenarios, quiz creators may want to hide the quiz summary from students immediately after submission. This could be for:
- Maintaining quiz integrity and preventing answer sharing
- Allowing instructors to review submissions before revealing results
- Creating a more controlled assessment environment
- Supporting different assessment strategies

## Implementation

Added conditional rendering logic in the quiz submission summary section that checks the `show_quiz_summary` setting:

1. **Open-ended quizzes**: Always display message that instructor will review (unchanged behavior)
2. **Quizzes with `show_quiz_summary` enabled**: Display detailed summary with score and percentage (e.g., "You got 85% correct answers with a score of 17 out of 20")
3. **Quizzes with `show_quiz_summary` disabled**: Display generic success message without revealing scores

## Behavior

- **When enabled**: Students see their score, percentage, and total marks after quiz submission
- **When disabled**: Students only see a generic "Your submission has been successfully saved" message
- **Open-ended quizzes**: Continue to show instructor review message regardless of this setting

<img width="1275" height="208" alt="image" src="https://github.com/user-attachments/assets/c5cb2107-09d7-4694-ab3e-ac4f3465a23b" />

<img width="814" height="463" alt="image" src="https://github.com/user-attachments/assets/787cd7e8-8b19-4302-91d3-3458eac8c2bc" />
