### PR TITLE
Fix dashboard charts visibility issue

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -551,7 +551,7 @@ def get_chart_data(
 
 	data = frappe.db.get_all(
 		doctype,
-		fields=[datefield, {"SUM": value_field}, {"COUNT": "*"}],
+		fields=[f"{datefield} as _unit", f"SUM({value_field}) as total", "COUNT(*) as count"],
 		filters=filters,
 		group_by=datefield,
 		order_by=datefield,


### PR DESCRIPTION
This PR improves the clarity and usability of the chart data returned from the get_chart_data function in lms/lms/utils.py.
The update restructures the database query to use explicit aliases, making the returned data cleaner, more readable, and easier to work with in chart visualizations.

**Changes Made**

- Updated the fields parameter in the database query to return meaningful aliases:
datefield → _unit
SUM(value_field) → total
COUNT(*) → count
- Ensures more structured and predictable chart data output
- Improves developer experience and maintainability when consuming chart results

**Impact of the Issue**

 

[When navigating to statistics page , dashboard is not visible #1951](https://github.com/frappe/lms/issues/1951)


**This enhancement makes chart data easier to interpret and appear on the dashboard.**

Before:
![before](https://github.com/user-attachments/assets/197a5a7b-523b-4d17-8ab5-c8d8d442bf07)



After:
![after](https://github.com/user-attachments/assets/e685f6ec-f364-44a8-bde8-e9d209b2d27d)

