### PR TITLE
fix: EmptyState would not translate, returning base non translated doctype name

### DIFF
--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-col items-center justify-center mt-60">
 		<GraduationCap class="size-10 mx-auto stroke-1 text-ink-gray-5" />
 		<div class="text-lg font-semibold text-ink-gray-7 mb-2.5">
-			{{ __('No {0}').format(type?.toLowerCase()) }}
+			{{ __('No {0}').format(translatedType) }}
 		</div>
 		<div
 			class="leading-5 text-base w-full md:w-2/5 text-base text-center text-ink-gray-7"
@@ -10,15 +10,21 @@
 			{{
 				__(
 					'There are no {0} currently. Keep an eye out, fresh learning experiences are on the way!'
-				).format(type?.toLowerCase())
+				).format(translatedType)
 			}}
 		</div>
 	</div>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
 import { BookOpen, GraduationCap } from 'lucide-vue-next'
 
 const props = defineProps({
 	type: String,
+})
+
+const translatedType = computed(() => {
+	if (!props.type) return ''
+	return __(props.type).toLowerCase()
 })
 </script>


### PR DESCRIPTION
## Closes: #1977

### Summary
When a page has no content it creates the message : No {0} (no courses, no batches, . . . )
The script is returning the doctype name without appropriate translation.

### Issue
in the page EmptyState, the props.type isn't being translated, resulting in an inconsistent phrase translation.

### Solution
Adding a translator function in the Vue page that has the job of translating the props.type.

### Before:
<img width="659" height="143" alt="image" src="https://github.com/user-attachments/assets/891308d8-d79b-43b5-acf3-dc7b4d2b87ad" />

### After:
<img width="656" height="118" alt="image" src="https://github.com/user-attachments/assets/1d177a8f-a29c-4a83-87bd-66eb7b38eedc" />