### PR TITLE
fix: Support private Vimeo videos with privacy hash (#1956)

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -165,14 +165,14 @@ export function getEditorTools() {
 						regex: /(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/,
 						embedUrl: '<%= remote_id %>',
 						/* 'https://www.youtube.com/embed/<%= remote_id %>?origin=https://plyr.io&amp;iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1' */
-						html: `<div class="video-player" data-plyr-provider="youtube"></div>`,
+					html: `<div class="video-player" data-plyr-provider="youtube" data-plyr-embed-id="<%= remote_id %>"></div>`,
 						id: ([id]) => id,
 					},
 					vimeo: {
-						regex: /(?:http[s]?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)/,
-						embedUrl: '<%= remote_id %>',
-						html: `<div class="video-player" data-plyr-provider="vimeo"></div>`,
-						id: ([id]) => id,
+						regex: /(?:http[s]?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)(?:\/([a-zA-Z0-9]+))?(?:\?\S*)?/,
+						embedUrl: 'https://player.vimeo.com/video/<%= remote_id %>',
+						html: `<iframe src="https://player.vimeo.com/video/<%= remote_id %>" style="width: 100%; aspect-ratio: 16/9;" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>`,
+						id: ([id, hash]) => hash ? `${id}?h=${hash}` : id,
 					},
 					cloudflareStream: {
 						regex: /https:\/\/customer-[a-z0-9]+\.cloudflarestream\.com\/([a-f0-9]{32})\/watch/,


### PR DESCRIPTION
- Updated Vimeo regex to capture optional privacy hash: /(\d+)(?:\/([a-zA-Z0-9]+))?(?:\?\S*)?/
- Modified id() function to format private videos as 'videoId?h=hash'
- Added data-plyr-embed-id directly in HTML template for both YouTube and Vimeo
- Strips query parameters from source URL to prevent conflicts

This enables proper embedding of private Vimeo videos (format: vimeo.com/ID/HASH) while maintaining backward compatibility with public videos.

Note: Private videos require domain whitelisting in Vimeo privacy settings. Local development domains (localhost, 127.0.0.1) must be added to the video's 'Specific domains' allowlist to avoid 403 Forbidden errors.

Fixes #1956

thanks @hasnainpatil
