### PR TITLE
fix:Rename "Certifications" -> "Members" in sidebar

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -486,7 +486,7 @@ const getSidebarItems = () => {
 					activeFor: ['Batches', 'BatchDetail', 'Batch', 'BatchForm'],
 				},
 				{
-					label: 'Certifications',
+					label: 'Members',
 					icon: 'GraduationCap',
 					to: 'CertifiedParticipants',
 					activeFor: ['CertifiedParticipants'],


### PR DESCRIPTION
fix:
#1974
<img width="187" height="615" alt="Screenshot from 2026-01-21 15-09-43" src="https://github.com/user-attachments/assets/cc1a7297-da2f-4402-840d-d021b9d1c6e7" />
