### PR TITLE
fix: instructor notes block settings menu overlapped by sidebar

### DIFF
--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -665,7 +665,8 @@ iframe {
 	padding: 8px;
 }
 
-.codex-editor--narrow .ce-toolbox .ce-popover {
+.codex-editor--narrow .ce-toolbox .ce-popover,
+.codex-editor--narrow .ce-toolbar__actions .ce-popover {
 	right: unset;
 	left: initial;
 }


### PR DESCRIPTION
PR #1987 fixed the positioning issue for the "+" (Add block) menu in the Instructor Notes editor:
```
.codex-editor--narrow .ce-toolbox .ce-popover {
    right: unset;
    left: initial;
}
```
However, the block settings menu (6-dot "Click to tune" icon) still renders beneath the sidebar because it uses `.ce-toolbar__actions`, not `.ce-toolbox`

This PR adds the missing selector:
```
.codex-editor--narrow .ce-toolbox .ce-popover,
.codex-editor--narrow .ce-toolbar__actions .ce-popover {
    right: unset;
    left: initial;
}
```

Before:
<img width="1600" height="757" alt="image" src="https://github.com/user-attachments/assets/2229f293-53ad-4dc4-90c6-a59d32a9b31a" />

After:
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/eb420155-3348-4e80-b226-9938f6e8759c" />

Related: #1990 