### PR TITLE
fix(quiz): questions list empty on back navigation from test quiz

### DIFF
--- a/frontend/src/pages/QuizForm.vue
+++ b/frontend/src/pages/QuizForm.vue
@@ -226,7 +226,6 @@ import {
 	onMounted,
 	inject,
 	onBeforeUnmount,
-	watch,
 } from 'vue'
 import { sessionStore } from '../stores/session'
 import { ClipboardList, ListChecks, Plus, Trash2 } from 'lucide-vue-next'
@@ -252,7 +251,9 @@ const props = defineProps({
 	},
 })
 
-const questions = ref([])
+const questions = computed(() => {
+	return quizDetails.doc?.questions || []
+})
 
 onMounted(() => {
 	if (!user.data?.is_moderator && !user.data?.is_instructor) {
@@ -273,24 +274,10 @@ onBeforeUnmount(() => {
 	window.removeEventListener('keydown', keyboardShortcut)
 })
 
-watch(
-	() => props.quizID !== 'new',
-	(newVal) => {
-		if (newVal) {
-			quizDetails.reload()
-		}
-	}
-)
-
 const quizDetails = createDocumentResource({
 	doctype: 'LMS Quiz',
 	name: props.quizID,
 	auto: false,
-	onSuccess(doc) {
-		if (doc.questions && doc.questions.length > 0) {
-			questions.value = doc.questions.map((question) => question)
-		}
-	},
 })
 
 const validateTitle = () => {


### PR DESCRIPTION
### Summary:
- **Problem:** When editing a quiz, clicking "Test Quiz" and then navigating back with the browser causes the questions list to appear empty. The questions still exist in the database, but the UI doesn't display them. Users then try to re-add questions and hit a duplicate validation error.
- **Solution:** Replaced questions `ref` with `computed` property which makes sure its always in sync.

### Images:
Before:
![before_quiz_fix](https://github.com/user-attachments/assets/5f617459-6f1c-4cf4-831f-f1b37b222c20)

After:
![after_quiz_fix](https://github.com/user-attachments/assets/b505ade9-e70f-453f-8bcb-a277f5e841da)

### Related Issue:
Fixes #1932 