### PR TITLE
fix(batches): order assessments by their index

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1242,6 +1242,7 @@ def get_assessments(batch):
 		"LMS Assessment",
 		{"parent": batch},
 		["name", "assessment_type", "assessment_name"],
+		order_by="idx",
 	)
 
 	for assessment in assessments:


### PR DESCRIPTION
### Summary: 
- Fix assessment ordering in student portal by sorting by index
- Before:
<img width="1217" height="696" alt="Screenshot 2026-02-02 at 6 20 18 PM" src="https://github.com/user-attachments/assets/2cae6803-f207-410f-8705-10b4e8723ec8" />

- After:
<img width="1217" height="696" alt="Screenshot 2026-02-02 at 6 20 43 PM" src="https://github.com/user-attachments/assets/61c16424-81c5-44c1-8cae-585871476022" />

### Issue:
- Fixes #2034 
