### PR TITLE
fix: add missing type annotation to get_job_details

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -160,7 +160,7 @@ def verify_billing_access(doctype, name, billing_type):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_job_details(job):
+def get_job_details(job: str):
 	return frappe.db.get_value(
 		"Job Opportunity",
 		job,


### PR DESCRIPTION
When `require_type_annotated_api_methods` was enabled in #2063, `get_job_details` — a whitelisted function — was
missed, which causes the Job details page to crash with `FrappeTypeError`.

Added the missing `str` type annotation.

Closes #2071