### PR TITLE
fix: overflow-y-scroll set to auto

### DIFF
--- a/frontend/src/components/Settings/Badges.vue
+++ b/frontend/src/components/Settings/Badges.vue
@@ -21,7 +21,7 @@
 				{{ __('New') }}
 			</Button>
 		</div>
-		<div v-if="badges.data?.length" class="overflow-y-scroll">
+		<div v-if="badges.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="badges.data"

--- a/frontend/src/components/Settings/Categories.vue
+++ b/frontend/src/components/Settings/Categories.vue
@@ -44,7 +44,7 @@
 			</Button>
 		</div>
 
-		<div class="overflow-y-scroll">
+		<div class="overflow-y-auto">
 			<div class="divide-y space-y-2">
 				<div
 					v-for="(cat, index) in categories.data"

--- a/frontend/src/components/Settings/Coupons/CouponList.vue
+++ b/frontend/src/components/Settings/Coupons/CouponList.vue
@@ -17,7 +17,7 @@
 			</Button>
 		</div>
 
-		<div v-if="coupons.data?.length" class="overflow-y-scroll">
+		<div v-if="coupons.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="coupons.data"

--- a/frontend/src/components/Settings/EmailTemplates.vue
+++ b/frontend/src/components/Settings/EmailTemplates.vue
@@ -18,7 +18,7 @@
 				</Button>
 			</div>
 		</div>
-		<div v-if="emailTemplates.data?.length" class="overflow-y-scroll">
+		<div v-if="emailTemplates.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="emailTemplates.data"

--- a/frontend/src/components/Settings/Members.vue
+++ b/frontend/src/components/Settings/Members.vue
@@ -31,7 +31,7 @@
 					<Search class="size-4 stroke-1.5 text-ink-gray-5" />
 				</template>
 			</FormControl>
-			<div class="overflow-y-scroll h-[60vh]">
+			<div class="overflow-y-auto h-[60vh]">
 				<ul class="divide-y">
 					<li
 						v-for="member in memberList"

--- a/frontend/src/components/Settings/PaymentGateways.vue
+++ b/frontend/src/components/Settings/PaymentGateways.vue
@@ -17,7 +17,7 @@
 			</Button>
 		</div>
 
-		<div v-if="paymentGateways.data?.length" class="overflow-y-scroll">
+		<div v-if="paymentGateways.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="paymentGateways.data"

--- a/frontend/src/components/Settings/Transactions/TransactionList.vue
+++ b/frontend/src/components/Settings/Transactions/TransactionList.vue
@@ -39,7 +39,7 @@
 			/>
 		</div>
 
-		<div v-if="transactions.data?.length" class="overflow-y-scroll">
+		<div v-if="transactions.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="transactions.data"

--- a/frontend/src/components/Settings/ZoomSettings.vue
+++ b/frontend/src/components/Settings/ZoomSettings.vue
@@ -18,7 +18,7 @@
 				</Button>
 			</div>
 		</div>
-		<div v-if="zoomAccounts.data?.length" class="overflow-y-scroll">
+		<div v-if="zoomAccounts.data?.length" class="overflow-y-auto">
 			<ListView
 				:columns="columns"
 				:rows="zoomAccounts.data"

--- a/frontend/src/pages/BatchForm.vue
+++ b/frontend/src/pages/BatchForm.vue
@@ -138,7 +138,7 @@
 						@change="(val) => (batch.batch_details = val)"
 						:editable="true"
 						:fixedMenu="true"
-						editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] max-h-[20rem] overflow-y-scroll mb-4"
+						editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] max-h-[20rem] overflow-y-auto mb-4"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
**Description**

This PR sets the overflow-y-scroll property to overflow-y-auto, which enables the vertical scrollbar only when the items exceeds the height. 

Fixes #2079 


**Before**

<img width="1258" height="848" alt="image" src="https://github.com/user-attachments/assets/c8ddd6ef-0136-491c-ac47-188405bdaea2" />


**After**

<img width="1257" height="827" alt="image" src="https://github.com/user-attachments/assets/73d7d0f1-76b4-4368-bd2b-5835f1911d49" />

<img width="1258" height="856" alt="image" src="https://github.com/user-attachments/assets/b79a5161-89ce-46cd-b7a3-cff37c11e46e" />
