### PR TITLE
fix(security): remove ignore_xss_filter to enable HTML sanitization

### DIFF
--- a/lms/lms/doctype/course_lesson/course_lesson.json
+++ b/lms/lms/doctype/course_lesson/course_lesson.json
@@ -160,7 +160,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-10 15:19:22.400932",
+ "modified": "2026-02-20 13:49:25.599827",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Course Lesson",


### PR DESCRIPTION
## Summary
- Removed `ignore_xss_filter: 1` from the `body` field in Course Lesson doctype
- Enables Frappe's built-in `nh3` HTML sanitizer to protect against XSS attacks
- Affects legacy lessons which used `body` field (modern lessons use the `content` instead of `body`)