### PR TITLE
fix: duplicate enrollment validation on update

### DIFF
--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -30,7 +30,7 @@ class LMSEnrollment(Document):
 			},
 		)
 
-		if existing_enrollment:
+		if existing_enrollment and existing_enrollment != self.name:
 			frappe.throw(_("Student is already enrolled in this course."))
 
 	def validate_course_enrollment_eligibility(self):


### PR DESCRIPTION
## Summary
- Fix `validate_duplicate_enrollment` function (did not allow updating existing enrollment)
- Now allows updating existing enrollment by adding an extra check of `existing_enrollment != self.name`