### PR TITLE
fix: disabled save button on no updates

### DIFF
--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -13,7 +13,7 @@
 						<Trash2 class="w-4 h-4 stroke-1.5" />
 					</template>
 				</Button>
-				<Button variant="solid" @click="childRef.submitCourse()">
+				<Button :disabled="!childRef?.isDirty" variant="solid" @click="childRef.submitCourse()">
 					{{ __('Save') }}
 				</Button>
 			</div>

--- a/frontend/src/pages/Courses/CourseForm.vue
+++ b/frontend/src/pages/Courses/CourseForm.vue
@@ -425,7 +425,9 @@ const keyboardShortcut = (e) => {
 		(e.ctrlKey || e.metaKey) &&
 		!e.target.classList.contains('ProseMirror')
 	) {
-		submitCourse()
+		if(isDirty.value) {
+			submitCourse()
+		}
 		e.preventDefault()
 	}
 }


### PR DESCRIPTION
Fixes #2106 

**Before**
The save button always enabled even there is no change in the form. This was leading to unnecessary API calls. 


**After**
The save button only enabled when there are updates in the form. 
https://www.loom.com/share/dd4a15aff3c94813b87904bf96c35920