### PR TITLE
fix: verify quiz answers on server side

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -465,7 +465,7 @@ watch(
 )
 
 const quizSubmission = createResource({
-	url: 'lms.lms.doctype.lms_quiz.lms_quiz.quiz_summary',
+	url: 'lms.lms.doctype.lms_quiz.lms_quiz.submit_quiz',
 	makeParams(values) {
 		return {
 			quiz: quiz.data.name,
@@ -538,7 +538,7 @@ const checkAnswer = () => {
 		url: 'lms.lms.doctype.lms_quiz.lms_quiz.check_answer',
 		params: {
 			question: currentQuestion.value,
-			type: questionDetails.data.type,
+			question_type: questionDetails.data.type,
 			answers: JSON.stringify(answers),
 		},
 		auto: true,
@@ -569,10 +569,7 @@ const addToLocalStorage = () => {
 	let quizData = JSON.parse(localStorage.getItem(quiz.data.title))
 	let questionData = {
 		question_name: currentQuestion.value,
-		answer: getAnswers().join(),
-		is_correct: showAnswers.filter((answer) => {
-			return answer != undefined
-		}),
+		answer: getAnswers(),
 	}
 
 	if (quizData) {

--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -186,6 +186,7 @@ const upcoming_evals = createListResource({
 		'evaluator_name',
 		'course_title',
 		'member',
+		'member_name',
 		'google_meet_link',
 	],
 	orderBy: 'date',


### PR DESCRIPTION
Quiz answers were checked for each question, and the result was then stored in localstorage. When a quiz was submitted, the same data from local storage was passed to the server, and the score was calculated using it. 

There was a chance of users editing this data in the local storage to modify their marks. To prevent this, the server will now verify marks without relying on the client side data