### PR TITLE
fix: add LMS prefix to batch

### DIFF
--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -32,7 +32,7 @@
 								</span>
 							</div>
 						</Tooltip>
-						<Tooltip v-if="event.batch_title" :text="__('Batch')">
+						<Tooltip v-if="event.batch_title" :text="__('LMS Batch')">
 							<div
 								class="flex space-x-2 w-fit cursor-pointer"
 								@click="openLink('batch', event.batch_name)"

--- a/frontend/src/components/Settings/BadgeForm.vue
+++ b/frontend/src/components/Settings/BadgeForm.vue
@@ -192,7 +192,7 @@ const createBadge = (close: () => void) => {
 const referenceDoctypeOptions = computed(() => {
 	return [
 		{ label: __('Course'), value: 'LMS Course' },
-		{ label: __('Batch'), value: 'LMS Batch' },
+		{ label: __('LMS Batch'), value: 'LMS Batch' },
 		{ label: __('User'), value: 'Member' },
 		{ label: __('Quiz Submission'), value: 'LMS Quiz Submission' },
 		{ label: __('Assignment Submission'), value: 'LMS Assignment Submission' },

--- a/frontend/src/components/Settings/Badges.vue
+++ b/frontend/src/components/Settings/Badges.vue
@@ -197,7 +197,7 @@ const deleteBadge = (badgeName: string) => {
 const doctypeLabel = computed(() => {
 	return {
 		'LMS Course': __('Course'),
-		'LMS Batch': __('Batch'),
+		'LMS Batch': __('LMS Batch'),
 		'LMS Enrollment': __('Course Enrollment'),
 		'LMS Batch Enrollment': __('Batch Enrollment'),
 		'LMS Quiz Submission': __('Quiz Submission'),

--- a/frontend/src/components/Settings/Transactions/TransactionDetails.vue
+++ b/frontend/src/components/Settings/Transactions/TransactionDetails.vue
@@ -22,7 +22,7 @@
 					{{
 						transactionData.payment_for_document_type == 'LMS Course'
 							? __('Course')
-							: __('Batch')
+							: __('LMS Batch')
 					}}
 				</Button>
 				<Button variant="solid" @click="saveTransaction()">

--- a/frontend/src/pages/Search/Search.vue
+++ b/frontend/src/pages/Search/Search.vue
@@ -232,7 +232,7 @@ const getDocTypeTitle = (doctype: string) => {
 	if (doctype === 'LMS Course') {
 		return __('Course')
 	} else if (doctype === 'LMS Batch') {
-		return __('Batch')
+		return __('LMS Batch')
 	} else if (doctype === 'Job Opportunity') {
 		return __('Job')
 	} else {


### PR DESCRIPTION
Add LMS prefix to Batch as Batch in ERPNext and LMS have different meaning
If ERPNext and LMS are installed on same instance it becomes impossible to translate as
LMS Batch (Group) overwrites ERPNext translation 

If accepted i can add prefix to rest of translation strings