### PR TITLE
chore: upgrade frappe-ui to v0.1.264

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "dayjs": "1.11.10",
     "dompurify": "3.2.6",
     "feather-icons": "4.28.0",
-    "frappe-ui": "^0.1.261",
+    "frappe-ui": "^0.1.264",
     "highlight.js": "11.11.1",
     "lucide-vue-next": "0.383.0",
     "markdown-it": "14.0.0",


### PR DESCRIPTION
## Summary
- Upgrade frappe-ui from v0.1.261 to [v0.1.264](https://github.com/frappe/frappe-ui/commit/0162ae36f6bb048adae8c7f743c1ef02bee6fecc)
- Includes fix for child tables not being included in mandatory fields in course import. 
    - Issue: frappe/frappe-ui#572
    - Fix: frappe/frappe-ui#573