### PR TITLE
fix(payment gateway): add delete functionality and field details

### DIFF
--- a/frontend/src/components/Settings/PaymentGatewayDetails.vue
+++ b/frontend/src/components/Settings/PaymentGatewayDetails.vue
@@ -131,7 +131,7 @@ watch(newGateway, () => {
 		let fields = gatewayFields.data || []
 		arrangeFields(fields)
 		newGatewayFields.value = makeSections(fields)
-		prepareGatewayData()
+		prepareGatewayData(fields)
 	})
 })
 
@@ -209,13 +209,11 @@ const allGatewayOptions = computed(() => {
 	return options.map((gateway: string) => ({ label: gateway, value: gateway }))
 })
 
-const prepareGatewayData = () => {
+const prepareGatewayData = (fields: any[]) => {
 	newGatewayData.value = {}
-	if (newGatewayFields.value.length) {
-		newGatewayFields.value.forEach((field: any) => {
-			newGatewayData.value[field.fieldname] = field.default || ''
-		})
-	}
+	fields.forEach((field: any) => {
+		newGatewayData.value[field.name] = field.default || ''
+	})
 }
 
 const makeSections = (fields: any[]) => {

--- a/frontend/src/components/Settings/PaymentGateways.vue
+++ b/frontend/src/components/Settings/PaymentGateways.vue
@@ -88,6 +88,7 @@
 import {
 	Badge,
 	Button,
+	call,
 	createListResource,
 	FeatherIcon,
 	ListView,
@@ -97,10 +98,12 @@ import {
 	ListRow,
 	ListRowItem,
 	ListSelectBanner,
+	toast,
 } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { Plus, Trash2 } from 'lucide-vue-next'
 import PaymentGatewayDetails from '@/components/Settings/PaymentGatewayDetails.vue'
+import { cleanError } from '@/utils'
 
 const showForm = ref(false)
 const currentGateway = ref(null)
@@ -126,6 +129,23 @@ const paymentGateways = createListResource({
 const openForm = (gatewayID) => {
 	currentGateway.value = gatewayID
 	showForm.value = true
+}
+
+const removeAccount = (selections, unselectAll) => {
+	call('lms.lms.api.delete_documents', {
+		doctype: 'Payment Gateway',
+		documents: Array.from(selections),
+	})
+		.then(() => {
+			paymentGateways.reload()
+			toast.success(__('Payment gateways deleted successfully'))
+			unselectAll()
+		})
+		.catch((err) => {
+			toast.error(
+				cleanError(err.messages[0]) || __('Error deleting payment gateways')
+			)
+		})
 }
 
 const columns = computed(() => {

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -20,6 +20,7 @@
 							:doctype="field.doctype"
 							:label="__(field.label)"
 							:description="__(field.description)"
+							:required="field.reqd"
 						/>
 
 						<div v-else-if="field.type == 'Code'">
@@ -115,6 +116,7 @@
 							:rows="field.rows"
 							:options="field.options"
 							:description="field.description"
+							:required="field.reqd"
 							placeholder=""
 						/>
 					</div>

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -751,13 +751,25 @@ def get_transformed_fields(meta: list, data: dict = None):
 			else:
 				fieldtype = row.fieldtype
 
-			transformed_fields.append(
-				{
-					"label": row.label,
-					"name": row.fieldname,
-					"type": fieldtype,
-				}
-			)
+			field = {
+				"label": row.label,
+				"name": row.fieldname,
+				"type": fieldtype,
+			}
+
+			if row.reqd:
+				field["reqd"] = 1
+
+			if row.options:
+				field["options"] = row.options
+
+			if row.default:
+				field["default"] = row.default
+
+			if row.description:
+				field["description"] = row.description
+
+			transformed_fields.append(field)
 
 	return transformed_fields
 

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -702,7 +702,13 @@ def save_certificate_details(
 @frappe.whitelist()
 def delete_documents(doctype: str, documents: list):
 	frappe.only_for("Moderator")
+	meta = frappe.get_meta(doctype)
+	non_lms_allowed = ["Payment Gateway", "Email Template"]
+	if meta.module != "LMS" and doctype not in non_lms_allowed:
+		frappe.throw(_("Deletion not allowed for {0}").format(doctype))
 	for doc in documents:
+		if not isinstance(doc, str) or not doc.strip():
+			frappe.throw(_("Invalid document name"))
 		frappe.delete_doc(doctype, doc)
 
 


### PR DESCRIPTION
## Summary:
- Include reqd, options, default, and description in payment gateway fields 
    - Fix default values by iterating fields instead of sections in prepareGatewayData
    - Fix descriptions by passing on descriptions to already existing links
- Add the missing removeAccount function to PaymentGateways
   - Make delete_documents more secure

## Change:
### Field descriptions now visible
#### Examples
- **reqd** — marks the field as mandatory (red asterisk in the form). E.g., in the picture below
- **default** — pre-fills a value. E.g. Mpesa's transaction_limit to 150000
- **description** — helper text below the field. E.g., Paymob's `mention transaction page completion URL`.
#### Before
<img width="1440" height="696" alt="Screenshot 2026-03-02 at 1 22 40 PM" src="https://github.com/user-attachments/assets/82515faa-30f5-4e46-a1d6-1bfa4e3afec2" />
<img width="1440" height="696" alt="Screenshot 2026-03-02 at 1 22 52 PM" src="https://github.com/user-attachments/assets/7114932f-c33c-46fa-9f4f-ac374114e0bd" />

#### After
<img width="1440" height="696" alt="Screenshot 2026-03-02 at 1 07 55 PM" src="https://github.com/user-attachments/assets/f800ca68-334f-4b32-a2c1-4da112c17ae5" />
<img width="1440" height="696" alt="Screenshot 2026-03-02 at 1 17 25 PM" src="https://github.com/user-attachments/assets/5a162000-fb6d-4f16-9cd4-d6531a30d138" />

### Payment Gateway Deletion
### Before
![pg-b](https://github.com/user-attachments/assets/e8e58a34-0abe-4671-893c-a5737bef3796)

### After
![pg-a](https://github.com/user-attachments/assets/957ad5f1-5695-4c2f-8d45-686bde6f1dcc)
