### PR TITLE
style: fix text color for dark mode in Quizzes

### DIFF
--- a/frontend/src/pages/Quizzes.vue
+++ b/frontend/src/pages/Quizzes.vue
@@ -12,7 +12,7 @@
 	</header>
 	<div class="py-5 mx-5">
 		<div class="flex items-center justify-between mb-4">
-			<div class="text-lg font-semibold">
+			<div class="text-lg font-semibold text-ink-gray-9">
 				{{ __('{0} Quizzes').format(quizzes.data.length) }}
 			</div>
 			<FormControl v-model="search" type="text" placeholder="Search">


### PR DESCRIPTION
### Description
Updated the quiz count header in [Quizzes.vue] to use the `text-ink-gray-9` class. 

### Why this change?
Previously, the text color was not explicitly set for the dark theme, making it difficult to read when dark mode was enabled. This change ensures the text remains visible and consistent with the design system.

### Before:

<img width="1919" height="297" alt="Screenshot 2026-03-13 180721" src="https://github.com/user-attachments/assets/f0ce97e5-ccb4-4082-bb6a-f7fa0bbeba54" />


### After:

<img width="1905" height="339" alt="Screenshot 2026-03-13 180801" src="https://github.com/user-attachments/assets/af4349e8-9e10-4995-8af0-f6c5142a0866" />
