### PR TITLE
fix: hide evaluators search when list is empty

### DIFF
--- a/frontend/src/components/Settings/Evaluators.vue
+++ b/frontend/src/components/Settings/Evaluators.vue
@@ -21,7 +21,7 @@
 
 		<div class="mt-8 pb-5">
 			<FormControl
-				v-if="evaluators.data?.length > 0"
+				v-if="evaluators.data?.length > 0 || search"
 				v-model="search"
 				:placeholder="__('Search')"
 				type="text"


### PR DESCRIPTION
### Description
Hides the search bar in the Evaluators settings when the list is empty.

### Related Issues
- Part of #2045 (Fixes: "Evaluator search should not appear when there is no evaluator")

### Changes
- Added a `v-if="evaluators.data?.length > 0"` condition to the search `FormControl` in [Evaluators.vue](cci:7://file://wsl.localhost/Ubuntu-22.04/home/onebook/frappe_pr/apps/lms/frontend/src/components/Settings/Evaluators.vue:0:0-0:0).

### Before

<img width="1905" height="856" alt="Screenshot 2026-03-13 232700" src="https://github.com/user-attachments/assets/ea8bb6c4-f94d-4c01-bc85-94d1b89dd6bd" />

### After

<img width="1901" height="862" alt="Screenshot 2026-03-13 232712" src="https://github.com/user-attachments/assets/cb492027-9f7d-422f-8ef1-53762137efab" />
