### PR TITLE
fix: improve sidebar scrolling with overflow

### DIFF
--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -8,7 +8,7 @@
 			:class="sidebarStore.isSidebarCollapsed ? 'items-center' : ''"
 		>
 			<UserDropdown :isCollapsed="sidebarStore.isSidebarCollapsed" />
-			<div class="flex flex-col" v-if="sidebarSettings.data">
+			<div class="flex flex-col overflow-y-auto" v-if="sidebarSettings.data">
 				<div v-for="link in sidebarLinks" class="mx-2 my-2.5">
 					<div
 						v-if="!link.hideLabel"


### PR DESCRIPTION
### Summary
This PR addresses a UI issue in the main navigation sidebar where links could become inaccessible if the available window height was too small or if there were too many links present. 

By adding the `overflow-y-auto` class to the links container, users can now vertically scroll through the full list of sidebar items.

### Changes
- [AppSidebar.vue](cci:7://file://wsl.localhost/Ubuntu-22.04/home/onebook/frappe_pr/apps/lms/frontend/src/components/Sidebar/AppSidebar.vue:0:0-0:0): Added `overflow-y-auto` to the main sidebar link wrapper div.


### Before


https://github.com/user-attachments/assets/c8502eb9-d3c9-4bbd-b168-94f08b0aa99c

### After

https://github.com/user-attachments/assets/456a0788-b23d-4710-95f3-b6f4554b26d0



