### PR TITLE
fix: include chapter name in lesson and lesson form breadcrumbs

### DIFF
--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -566,6 +566,12 @@ const breadcrumbs = computed(() => {
 		label: lesson?.data?.course_title,
 		route: { name: 'CourseDetail', params: { courseName: props.courseName } },
 	})
+	if (lesson?.data?.chapter_title) {
+		crumbs.push({
+			label: lesson.data.chapter_title,
+			route: { name: 'CourseDetail', params: { courseName: props.courseName } },
+		})
+	}
 	crumbs.push({
 		label: lesson?.data?.title,
 		route: {

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -485,6 +485,17 @@ const breadcrumbs = computed(() => {
 		},
 	]
 
+	// Chapter: use API title when available, else fallback to "Chapter N"
+	const chapterLabel =
+		lessonDetails?.data?.chapter?.title ||
+		( props.chapterNumber ? `${__('Chapter')} ${props.chapterNumber}` : null )
+	if (chapterLabel) {
+		crumbs.push({
+			label: chapterLabel,
+			route: { name: 'CourseDetail', params: { courseName: props.courseName } },
+		})
+	}
+
 	if (lessonDetails?.data?.lesson) {
 		crumbs.push({
 			label: lessonDetails.data.lesson.title,

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1814,9 +1814,14 @@ def calculate_discount_amount(base_amount: float, coupon: dict) -> float:
 @frappe.whitelist()
 def get_lesson_creation_details(course: str, chapter: int, lesson: int) -> dict:
 	frappe.only_for(["Moderator", "Course Creator"])
-	chapter_name = frappe.db.get_value("Chapter Reference", {"parent": course, "idx": chapter}, "chapter")
-	lesson_name = frappe.db.get_value("Lesson Reference", {"parent": chapter_name, "idx": lesson}, "lesson")
+	# Coerce to int (whitelist may pass strings from frontend route params)
+	chapter = cint(chapter)
+	lesson = cint(lesson)
 
+	chapter_name = frappe.db.get_value("Chapter Reference", {"parent": course, "idx": chapter}, "chapter")
+	lesson_name = frappe.db.get_value("Lesson Reference", {"parent": chapter_name, "idx": lesson}, "lesson") if chapter_name else None
+
+	lesson_details = None
 	if lesson_name:
 		lesson_details = frappe.db.get_value(
 			"Course Lesson",
@@ -1835,10 +1840,14 @@ def get_lesson_creation_details(course: str, chapter: int, lesson: int) -> dict:
 			as_dict=1,
 		)
 
+	chapter_info = None
+	if chapter_name:
+		chapter_info = frappe.db.get_value("Course Chapter", chapter_name, ["title", "name"], as_dict=True)
+
 	return {
 		"course_title": frappe.db.get_value("LMS Course", course, "title"),
-		"chapter": frappe.db.get_value("Course Chapter", chapter_name, ["title", "name"], as_dict=True),
-		"lesson": lesson_details if lesson_name else None,
+		"chapter": chapter_info,
+		"lesson": lesson_details,
 	}
 
 


### PR DESCRIPTION
### Changes
- Add chapter crumb between course and lesson in Lesson.vue and LessonForm.vue
- Coerce chapter/lesson params to int in get_lesson_creation_details for reliable lookup
- Fallback to 'Chapter N' in LessonForm when API chapter title is missing

### Issue Screenshot
<img width="1394" height="512" alt="image" src="https://github.com/user-attachments/assets/a6ddc5b9-7af9-4998-8e49-3605a7df835b" />

### Issue Fix Screenshot

<img width="468" height="58" alt="image" src="https://github.com/user-attachments/assets/508abbe4-3f85-459f-a691-e9a0bf7aba55" />

### Related
Fixes #635 
