### PR TITLE
fix(JobDetail): application count and button now load properly on pag…

### DIFF
--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -157,7 +157,7 @@ import {
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
-import { inject, ref, computed } from 'vue'
+import { inject, ref, computed, watch, nextTick } from 'vue'
 import { sessionStore } from '../stores/session'
 import JobApplicationModal from '@/components/Modals/JobApplicationModal.vue'
 import {
@@ -193,17 +193,11 @@ const job = createResource({
 	},
 	cache: ['job', props.job],
 	auto: true,
-	onSuccess: (data) => {
-		if (user.data?.name) {
-			jobApplication.submit()
-			applicationCount.submit()
-		}
-	},
 })
 
 const jobApplication = createResource({
 	url: 'frappe.client.get_list',
-	makeParams(values) {
+	makeParams() {
 		return {
 			doctype: 'LMS Job Application',
 			filters: {
@@ -216,7 +210,7 @@ const jobApplication = createResource({
 
 const applicationCount = createResource({
 	url: 'frappe.client.get_count',
-	makeParams(values) {
+	makeParams() {
 		return {
 			doctype: 'LMS Job Application',
 			filters: {
@@ -225,6 +219,18 @@ const applicationCount = createResource({
 		}
 	},
 })
+
+const stopWatch = watch(
+	() => [job.data?.name, user.data?.name],
+	([jobName, userName]) => {
+		if (jobName && userName) {
+			jobApplication.submit()
+			applicationCount.submit()
+			nextTick(() => stopWatch())
+		}
+	},
+	{ immediate: true }
+)
 
 const openApplicationModal = () => {
 	showApplicationModal.value = true


### PR DESCRIPTION
### Summary
- **Bug:** "View Applications" button and applicant count badge were not visible on
  initial page load, but appeared after a manual page refresh
- **Root cause:** `onSuccess` callback on a cached `createResource` doesn't reliably
  fire on revisits — cached data is returned synchronously, skipping the callback
- **Fix:** Replaced `onSuccess` with a self-stopping `watch` on `[job.data.name, user.data.name]`
  that fires exactly once when both dependencies are ready, works with both cached and
  fresh data

### Changes
- Fixed issue where application count and "View Applications" button were not showing on page load
- Ensured data loads properly every time the page opens
- Kept page loading fast with cached job data

### Before

https://github.com/user-attachments/assets/c525e875-07e3-430b-a317-9708146fcccd

### After

https://github.com/user-attachments/assets/bdb6fdd5-fd0b-4140-b5dc-b475b53fee3b

