### PR TITLE
fix: add overflow-y-auto to settings dialog content panel (#2079)

### DIFF
--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -31,7 +31,7 @@
 				<div
 					v-if="activeTab && data.doc"
 					:key="activeTab.label"
-					class="flex flex-1 flex-col p-8 bg-surface-modal overflow-x-auto"
+					class="flex flex-1 flex-col p-8 bg-surface-modal overflow-x-auto overflow-y-auto"
 				>
 					<component
 						v-if="activeTab.template"


### PR DESCRIPTION
Fixes #2079

The settings dialog content panel was missing `overflow-y-auto`, 
causing lists to overflow without a scrollbar.