### PR TITLE
fix: course progress updated for scorm and video end event

### DIFF
--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -75,6 +75,12 @@
 										/>
 									</Tooltip>
 								</div>
+								<Check
+									v-if="
+										chapter.is_scorm_package && isScormChapterComplete(chapter)
+									"
+									class="h-4 w-4 text-green-700"
+								/>
 							</DisclosureButton>
 							<DisclosurePanel v-if="!chapter.is_scorm_package">
 								<Draggable
@@ -399,6 +405,10 @@ const redirectToChapter = (chapter) => {
 			chapterName: chapter.name,
 		},
 	})
+}
+
+const isScormChapterComplete = (chapter) => {
+	return chapter.lessons?.length && chapter.lessons.every((l) => l.is_complete)
 }
 
 const isActiveLesson = (lessonNumber) => {

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -700,6 +700,31 @@ const updateVideoWatchDuration = () => {
 			}
 		})
 	}
+	attachVideoEndedListeners()
+}
+
+const attachVideoEndedListeners = () => {
+	const onVideoEnded = () => {
+		markProgress()
+		trackVideoWatchDuration()
+	}
+
+	document.querySelectorAll('video').forEach((video) => {
+		if (!video._lmsEndedAttached) {
+			video.addEventListener('ended', onVideoEnded)
+			video._lmsEndedAttached = true
+		}
+	})
+
+	plyrSources.value.forEach((plyrSource) => {
+		if (!plyrSource._lmsEndedAttached) {
+			plyrSource.on('ended', onVideoEnded)
+			plyrSource.on('statechange', (event) => {
+				if (event.detail?.code === 0) onVideoEnded()
+			})
+			plyrSource._lmsEndedAttached = true
+		}
+	})
 }
 
 const updatePlyrVideoTime = (video) => {

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -109,9 +109,10 @@ const getDataFromLMS = (key) => {
 
 let saveTimeout = null
 const debouncedSaveProgress = (scormDetails) => {
+	if (isSuccessfullyCompleted.value) return
 	clearTimeout(saveTimeout)
 	saveTimeout = setTimeout(() => {
-		saveProgress(scormDetails)
+		if (!isSuccessfullyCompleted.value) saveProgress(scormDetails)
 	}, 300)
 }
 
@@ -124,6 +125,7 @@ const saveDataToLMS = (key, value) => {
 		(key === 'cmi.completion_status' && value === 'incomplete')
 
 	if (isLessonStatus || isCompletionStatus) {
+		if (isSuccessfullyCompleted.value) return
 		isSuccessfullyCompleted.value = true
 	}
 

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -78,7 +78,7 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 	if not membership:
 		return 0
 
-	frappe.db.set_value("LMS Enrollment", membership, "current_lesson", lesson)
+	frappe.db.set_value("LMS Enrollment", membership, "current_lesson", lesson, update_modified=False)
 	progress_already_exists = frappe.db.exists(
 		"LMS Course Progress", {"lesson": lesson, "member": frappe.session.user}
 	)
@@ -133,6 +133,7 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 	# Had to get doc, as on_change doesn't trigger when you use set_value. The trigger is necessary for badge to get assigned.
 	enrollment = frappe.get_doc("LMS Enrollment", membership)
 	enrollment.progress = progress
+	enrollment.flags.ignore_version = True
 	enrollment.save()
 	enrollment.run_method("on_change")
 


### PR DESCRIPTION
## Summary
- Fix video lesson progress not updating when the video finishes playing
- Fix SCORM completion race condition causing QueryDeadlockError
- Show completion checkmark on SCORM chapters in course outline

## Changes
1. video lesson progress
![Screen Recording 2026-03-24 at 3 39 57 PM](https://github.com/user-attachments/assets/4fe8bec7-0bf6-4d44-95ea-6944fff2a36b)
2. SCORM completion happens successfully and checkmark appears next to it.
![Screen Recording 2026-03-24 at 3 40 19 PM](https://github.com/user-attachments/assets/40c4bf5a-5f6d-42f6-b942-9de5e4634648)

## Issues
- fixes #2021