### PR TITLE
ux: show chapter title in lesson editor breadcrumb

### DIFF
--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -488,6 +488,17 @@ const breadcrumbs = computed(() => {
 		},
 	]
 
+	if (lessonDetails?.data?.chapter) {
+		crumbs.push({
+			label: lessonDetails.data.chapter.title,
+			route: {
+				name: 'CourseDetail',
+				params: { courseName: props.courseName },
+				hash: '#outline',
+			},
+		})
+	}
+
 	if (lessonDetails?.data?.lesson) {
 		crumbs.push({
 			label: lessonDetails.data.lesson.title,


### PR DESCRIPTION
Adds the chapter title to the breadcrumb in the lesson form so instructors know which chapter's lesson they are editing.

Closes #635