### PR TITLE
fix: show job count on jobs listing for guest users

### DIFF
--- a/frontend/src/pages/Jobs.vue
+++ b/frontend/src/pages/Jobs.vue
@@ -32,7 +32,7 @@
 			>
 				<div class="flex items-center justify-between">
 					<div class="text-lg font-semibold text-ink-gray-9 md:mb-0">
-						{{ __('{0} {1} Jobs').format(jobCount.data, activeTab) }}
+						{{ __('{0} {1} Jobs').format(totalJobs, activeTab) }}
 					</div>
 					<TabButtons
 						v-if="tabs.length > 1"
@@ -123,7 +123,7 @@
 				<div v-if="jobs.hasNextPage" class="h-8 border-s"></div>
 				<div class="text-ink-gray-5">
 					{{ jobs.data?.length }} {{ __('of') }}
-					{{ jobCount.data }}
+					{{ totalJobs }}
 				</div>
 			</div>
 		</div>
@@ -160,6 +160,7 @@ const orFilters = ref({})
 const closedJobs = ref(0)
 const activeTab = ref('Open')
 const readOnlyMode = window.read_only_mode
+const totalJobs = ref(0)
 
 onMounted(() => {
 	getClosedJobCount()
@@ -190,14 +191,6 @@ const getClosedJobCount = () => {
 	})
 }
 
-const jobCount = createResource({
-	url: 'frappe.client.get_count',
-	params: {
-		doctype: 'Job Opportunity',
-		filters: filters.value,
-	},
-})
-
 const setFiltersFromURL = () => {
 	let queries = new URLSearchParams(location.search)
 	if (queries.has('type')) {
@@ -214,6 +207,10 @@ const jobs = createListResource({
 	start: 0,
 	cache: ['jobs'],
 	pageLength: 40,
+	transform(data) {
+		totalJobs.value = data.total
+		return data.jobs
+	},
 })
 
 const updateJobs = () => {
@@ -223,11 +220,6 @@ const updateJobs = () => {
 		orFilters: orFilters.value,
 	})
 	jobs.reload()
-	jobCount.update({
-		filters: filters.value,
-		orFilters: orFilters.value,
-	})
-	jobCount.reload()
 }
 
 const updateFilters = () => {

--- a/frontend/src/pages/Jobs.vue
+++ b/frontend/src/pages/Jobs.vue
@@ -230,7 +230,7 @@ const updateJobs = () => {
 }
 
 const updateFilters = () => {
-	filters.value.status = 'Open'
+	filters.value.status = activeTab.value === 'Open' ? 'Open' : 'Closed'
 	updateJobTypeFilter()
 	updateWorkModeFilter()
 	updateSearchQueryFilter()

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -238,6 +238,8 @@ def get_job_opportunities(
 	if not filters:
 		filters = {}
 
+	total_jobs = frappe.db.count("Job Opportunity", filters, or_filters)
+
 	jobs = frappe.get_all(
 		"Job Opportunity",
 		filters=filters,
@@ -262,7 +264,10 @@ def get_job_opportunities(
 	for job in jobs:
 		job.description = frappe.utils.strip_html_tags(job.description)
 		job.applicants = frappe.db.count("LMS Job Application", {"job": job.name})
-	return jobs
+	return {
+		"jobs": jobs,
+		"total": total_jobs,
+	}
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
## Summary
- Job opportunity function now returns jobs and total number of jobs
- Removed redundant `jobCount` which used frappe.db.count causing permission issue for guest roles

## Change
- Now even without role, job opportunity numbers are visible
<img width="3199" height="1714" alt="image" src="https://github.com/user-attachments/assets/73541433-2153-48a7-9f82-6ed08899bd3c" />

## Issues
- Closes #2323