### PR TITLE
fix: update notification count on sidebar after they are read

### DIFF
--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -673,6 +673,7 @@ watch(settingsStore.settings, () => {
 const updateSidebarLinks = () => {
 	sidebarLinks.value = getSidebarLinks()
 	updateSidebarLinksVisibility()
+	updateUnreadCount()
 }
 
 const redirectToWebsite = () => {

--- a/frontend/src/pages/Notifications.vue
+++ b/frontend/src/pages/Notifications.vue
@@ -169,6 +169,7 @@ import {
 	Button,
 	createListResource,
 	createResource,
+	getCachedResource,
 	TabButtons,
 	usePageMeta,
 } from 'frappe-ui'
@@ -219,6 +220,10 @@ const readNotifications = createListResource({
 	cache: 'Read Notifications',
 })
 
+const refreshSidebarCount = () => {
+	getCachedResource('Unread Notifications Count')?.reload()
+}
+
 const markAsRead = createResource({
 	url: 'frappe.desk.doctype.notification_log.notification_log.mark_as_read',
 	makeParams(values) {
@@ -229,6 +234,7 @@ const markAsRead = createResource({
 	onSuccess(data) {
 		unReadNotifications.reload()
 		readNotifications.reload()
+		refreshSidebarCount()
 	},
 })
 
@@ -237,6 +243,7 @@ const markAllAsRead = createResource({
 	onSuccess(data) {
 		unReadNotifications.reload()
 		readNotifications.reload()
+		refreshSidebarCount()
 	},
 })
 


### PR DESCRIPTION
## Summary
- Notification count in sidebar didnt update when notifications were marked as read, required a hard refresh
<img width="3196" height="1662" alt="out" src="https://github.com/user-attachments/assets/50851f80-b44f-4a11-a6b0-ba18ca8e2d34" />

## Changes
- CreateResource cache only refreshed on its reload, added a refreshSidebarCount function which calls getCachedResource that updates it from frontend
- Added a function to update count in sidebar for the count to persist after sidebar rebuilds

## Issue
- Closes #1431