### PR TITLE
fix: sidebar_for_certified_members patch

### DIFF
--- a/lms/patches/v2_0/sidebar_for_certified_members.py
+++ b/lms/patches/v2_0/sidebar_for_certified_members.py
@@ -1,8 +1,12 @@
 import frappe
+from frappe.utils import cint
 
 
 def execute():
-	show_certified_members = frappe.db.get_single_value("LMS Settings", "certified_participants")
+	lms_settings = frappe.db.get_singles_dict("LMS Settings")
+	certified_participant_field_exists = "certified_participants" in lms_settings
+	if certified_participant_field_exists:
+		show_certified_members = lms_settings.get("certified_participants")
 
-	if show_certified_members:
+	if certified_participant_field_exists and cint(show_certified_members):
 		frappe.db.set_single_value("LMS Settings", "certified_members", 1)


### PR DESCRIPTION
## Summary
- Avoid meta lookup which causes the patch to fail on sites without the legacy field `certified_participants` on `LMS Settings` doctype.