### PR TITLE
docs: updated readme to include instructions for payments app

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,19 @@ You need Docker, docker-compose and git setup on your machine. Refer [Docker doc
 To setup the repository locally follow the steps mentioned below:
 
 1. Install bench and setup a `frappe-bench` directory by following the [Installation Steps](https://frappeframework.com/docs/user/en/installation)
-1. Start the server by running `bench start`
-1. In a separate terminal window, create a new site by running `bench new-site learning.test`
-1. Map your site to localhost with the command `bench --site learning.test add-to-hosts`
-1. Get the Learning app. Run `bench get-app https://github.com/frappe/lms`
-1. Run `bench --site learning.test install-app lms`.
+1. Start the server by running
+	```sh
+	$ bench start
+	```
+1. In a separate terminal window, run the following commands.
+	```sh
+	$ bench new-site learning.test
+ 	$ bench --site learning.test add-to-hosts
+ 	$ bench get-app https://github.com/frappe/payments
+ 	$ bench get-app https://github.com/frappe/lms
+ 	$ bench --site learning.test install-app lms
+ 	
+	```
 1. Now open the URL `http://learning.test:8000/lms` in your browser, you should see the app running
 
 ## Learn and connect


### PR DESCRIPTION
## Before

Instruction for the payments app was missing

<img width="905" height="309" alt="Screenshot 2026-05-01 at 6 18 39 PM" src="https://github.com/user-attachments/assets/937bab5f-c15e-400a-ac89-16217fafbf93" />

## After

<img width="897" height="423" alt="Screenshot 2026-05-01 at 6 25 37 PM" src="https://github.com/user-attachments/assets/ba313dfe-f0c4-4087-ae42-c25e8b7f1b8e" />

