### PR TITLE
chore: add payments in pyproject for auto install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
 frappe = ">=14.0.0,<=17.0.0-dev"
+payments = ">=14.0.0,<=17.0.0-dev"
 
 [tool.bench.assets]
 build_dir = "./frontend"


### PR DESCRIPTION
## Summary
- Add payments app as a frappe dependency for lms so that the build pipeline auto adds it for all new benches when deploying lms

## Reference
- https://github.com/frappe/press/pull/6097
