### PR TITLE
Fix alignment issues in persona page (tab & desktop)

### DIFF
--- a/frontend/src/pages/PersonaForm.vue
+++ b/frontend/src/pages/PersonaForm.vue
@@ -24,6 +24,7 @@
 						v-model="persona.useCase"
 						type="select"
 						:options="useCaseOptions"
+						class="w-full min-w-0 [&_[data-slot=trigger]]:w-full"
 					/>
 				</div>
 


### PR DESCRIPTION
## Before

The persona form was not aligned properly across desktop and tablets:

Screenshots:

<img width="801" height="972" alt="before tab persona alignment issue" src="https://github.com/user-attachments/assets/5ff70cb9-bec8-4533-be9d-065e94c044ef" /> 
<br><br>
<img width="1920" height="1080" alt="persona page alignment issue" src="https://github.com/user-attachments/assets/07a3e662-ae87-4204-bddf-528b077a642c" />

## Fix
- Added `w-full min-w-0 [&_[data-slot=trigger]]:w-full` to   
  FormControl elements so the trigger fills the card width
  
## After

Screenshots:

<img width="1920" height="1080" alt="after alignment issue fix" src="https://github.com/user-attachments/assets/d3769647-31b3-4686-ac8f-7f8b3ebbed1c" /> 
<br><br>
<img width="1920" height="1080" alt="after allignment issue fix desktop" src="https://github.com/user-attachments/assets/6dff93d8-757a-4b4b-a873-6f48b36f69df" />

## Summary

This fixes alignment and responsiveness issues in the persona form to ensure a consistent layout across different screen sizes.