### PR TITLE
fix: use before_insert to assign student role to preserve password

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -125,7 +125,7 @@ doc_events = {
 	"Notification Log": {"on_change": "lms.lms.utils.publish_notifications"},
 	"User": {
 		"validate": "lms.lms.user.validate_username_duplicates",
-		"after_insert": "lms.lms.user.after_insert",
+		"before_insert": "lms.lms.user.add_lms_student_role",
 	},
 }
 

--- a/lms/lms/user.py
+++ b/lms/lms/user.py
@@ -19,8 +19,8 @@ def validate_username_duplicates(doc, method):
 		doc.username = doc.email.replace("@", "").replace(".", "")
 
 
-def after_insert(doc, method):
-	doc.add_roles("LMS Student")
+def add_lms_student_role(doc, method):
+	doc.append_roles("LMS Student")
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method


### PR DESCRIPTION
## Summary
-  Move LMS Student role assignment from after_insert to before_insert to prevent password loss caused by the nested save() in add_roles() during user creation.