### PR TITLE
docs: explain Docker demo data setup

### DIFF
--- a/docker-installation.md
+++ b/docker-installation.md
@@ -16,14 +16,24 @@ $ docker-compose up
 
 **Step 3:** Visit the website at http://localhost:8000/
 
-You'll have to go through the setup wizard to setup the website for the first time you access it. Login using the following credentiasl to complete the setup wizard.
+You'll have to go through the setup wizard to setup the website for the first time you access it. Login using the following credentials to complete the setup wizard.
 
 ```
 Username: Administrator
 password: admin
 ```
 
-TODO: Explain how to load sample data
+These credentials are intended for local development only. Change the administrator password before using the site outside a local test environment.
+
+## Loading demo data
+
+The LMS app creates demo data when the setup wizard completes. If you need to recreate the demo course after clearing it, run the following command from another terminal while the Docker services are running:
+
+```
+$ docker-compose exec frappe bash -lc "cd frappe-bench && bench --site lms.localhost execute lms.demo.demo_data.create_demo_data"
+```
+
+This creates the sample course, instructor, learners, lessons, quizzes, and progress records used for local evaluation. To remove the demo course later, open the user menu in the LMS interface and choose **Clear Demo Data**.
 
 ## Stopping the server
 


### PR DESCRIPTION
## Summary
- fix a typo in the Docker setup credentials paragraph
- replace the sample-data TODO with a concrete demo-data command for the Docker environment
- clarify that the default administrator password is only for local development

## Validation
- Verified the `frappe` service exists in `docker/docker-compose.yml`
- Verified `lms.demo.demo_data.create_demo_data` exists
- Verified the UI includes a `Clear Demo Data` action
- Ran `git diff --check`