### PR TITLE
fix: keep only active course chapter expanded

### DIFF
--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -327,7 +327,8 @@ const trashLesson = (lessonName, chapterName) => {
 }
 
 const openChapterDetail = (index) => {
-	return index == route.params.chapterNumber || index == 1
+	const activeChapter = route.params.chapterNumber
+	return activeChapter ? index == activeChapter : index == 1
 }
 
 const openChapterModal = (chapter = null) => {


### PR DESCRIPTION
## Summary
- keep Chapter 1 expanded by default only when there is no active chapter in the route
- avoid forcing Chapter 1 open while learners are viewing later chapters
- keep the current chapter expanded based on the lesson route

Fixes #2348.

## Validation
- `git diff --check`

Frontend tests were not run locally because only `node` is available in this environment; `npm` and `yarn` are not installed.