### PR TITLE
fix: persist SCORM session time

### DIFF
--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -53,6 +53,10 @@ const sidebarStore = useSidebar()
 const user = inject('$user')
 const readyToRender = ref(false)
 const isSuccessfullyCompleted = ref(false)
+const scormSessionTime = ref(0)
+const scormTotalTime = ref(null)
+const scormContent = ref('')
+const scormSessionEnded = ref(false)
 
 // If courseRestartOnFailure is true, student has to restart the whole course if failed.
 // Otherwise, student could retake the final quiz portion.
@@ -103,17 +107,87 @@ const getDataFromLMS = (key) => {
 		return progress.data?.scorm_content || ''
 	} else if (key === 'cmi.suspend_data') {
 		return progress.data?.scorm_content || ''
+	} else if (key === 'cmi.session_time' || key === 'cmi.core.session_time') {
+		return formatSCORMDuration(progress.data?.session_time, key)
+	} else if (key === 'cmi.total_time' || key === 'cmi.core.total_time') {
+		return formatSCORMDuration(progress.data?.total_time, key)
 	}
 	return ''
 }
 
 let saveTimeout = null
 const debouncedSaveProgress = (scormDetails) => {
-	if (isSuccessfullyCompleted.value) return
+	if (isSuccessfullyCompleted.value && !hasSCORMTime(scormDetails)) return
 	clearTimeout(saveTimeout)
 	saveTimeout = setTimeout(() => {
-		if (!isSuccessfullyCompleted.value) saveProgress(scormDetails)
+		if (!isSuccessfullyCompleted.value || hasSCORMTime(scormDetails))
+			saveProgress(scormDetails)
 	}, 300)
+}
+
+const parseSCORMDuration = (value) => {
+	if (!value) return null
+	const timeSpan = /^(\d+):([0-5]\d):([0-5]\d(?:\.\d+)?)$/.exec(value)
+	if (timeSpan) {
+		return Math.round(
+			Number(timeSpan[1]) * 3600 +
+				Number(timeSpan[2]) * 60 +
+				Number(timeSpan[3])
+		)
+	}
+
+	const isoDuration =
+		/^P(?:(\d+(?:\.\d+)?)Y)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/.exec(
+			value
+		)
+	if (!isoDuration) return null
+
+	const [, years, months, days, hours, minutes, seconds] = isoDuration
+	return Math.round(
+		Number(years || 0) * 31536000 +
+			Number(months || 0) * 2592000 +
+			Number(days || 0) * 86400 +
+			Number(hours || 0) * 3600 +
+			Number(minutes || 0) * 60 +
+			Number(seconds || 0)
+	)
+}
+
+const formatSCORMDuration = (seconds, key) => {
+	const totalSeconds = Math.max(0, Math.round(Number(seconds || 0)))
+	if (key.startsWith('cmi.core')) {
+		const hours = String(Math.floor(totalSeconds / 3600)).padStart(4, '0')
+		const minutes = String(Math.floor((totalSeconds % 3600) / 60)).padStart(
+			2,
+			'0'
+		)
+		const remainingSeconds = String(totalSeconds % 60).padStart(2, '0')
+		return `${hours}:${minutes}:${remainingSeconds}`
+	}
+
+	const hours = Math.floor(totalSeconds / 3600)
+	const minutes = Math.floor((totalSeconds % 3600) / 60)
+	const remainingSeconds = totalSeconds % 60
+	return `PT${hours}H${minutes}M${remainingSeconds}S`
+}
+
+const hasSCORMTime = (scormDetails) => {
+	return (
+		scormDetails &&
+		('session_time' in scormDetails || 'total_time' in scormDetails)
+	)
+}
+
+const getSCORMTimeDetails = (extraDetails = {}) => {
+	return {
+		is_complete: isSuccessfullyCompleted.value,
+		scorm_content: scormContent.value || progress.data?.scorm_content || '',
+		session_time: scormSessionTime.value,
+		...(scormTotalTime.value !== null
+			? { total_time: scormTotalTime.value }
+			: {}),
+		...extraDetails,
+	}
 }
 
 const saveDataToLMS = (key, value) => {
@@ -135,18 +209,46 @@ const saveDataToLMS = (key, value) => {
 		(shouldRestart && courseRestartOnFailure)
 	) {
 		saveProgress({
+			...getSCORMTimeDetails(),
 			is_complete: isSuccessfullyCompleted.value,
 			scorm_content: '',
 		})
 		return
 	}
 
+	if (key === 'cmi.session_time' || key === 'cmi.core.session_time') {
+		const duration = parseSCORMDuration(value)
+		if (duration === null) return
+		scormSessionTime.value = duration
+		scormSessionEnded.value = false
+		debouncedSaveProgress(getSCORMTimeDetails({ session_time: duration }))
+		return
+	}
+
+	if (key === 'cmi.total_time' || key === 'cmi.core.total_time') {
+		const duration = parseSCORMDuration(value)
+		if (duration === null) return
+		scormTotalTime.value = duration
+		debouncedSaveProgress(getSCORMTimeDetails({ total_time: duration }))
+		return
+	}
+
 	if (key === 'cmi.suspend_data' && !isSuccessfullyCompleted.value) {
+		scormContent.value = value
 		debouncedSaveProgress({
 			is_complete: false,
 			scorm_content: value,
 		})
 	}
+}
+
+const endSCORMSession = () => {
+	if (scormSessionEnded.value) return 'true'
+	if (scormSessionTime.value || scormTotalTime.value !== null) {
+		scormSessionEnded.value = true
+		saveProgress(getSCORMTimeDetails({ is_session_end: true }))
+	}
+	return 'true'
 }
 
 const saveProgress = (scormDetails = null) => {
@@ -162,7 +264,7 @@ const progress = createResource({
 	makeParams(values) {
 		return {
 			doctype: 'LMS Course Progress',
-			fieldname: ['status', 'scorm_content'],
+			fieldname: ['status', 'scorm_content', 'session_time', 'total_time'],
 			filters: {
 				member: user.data?.name,
 				lesson: chapter.doc.lessons[0].lesson,
@@ -193,7 +295,7 @@ const enrollStudent = () => {
 const setupSCORMAPI = () => {
 	window.API_1484_11 = {
 		Initialize: () => 'true',
-		Terminate: () => 'true',
+		Terminate: endSCORMSession,
 		GetValue: (key) => {
 			console.log(`GET: ${key}`)
 			return getDataFromLMS(key)
@@ -211,7 +313,7 @@ const setupSCORMAPI = () => {
 	}
 	window.API = {
 		LMSInitialize: () => 'true',
-		LMSFinish: () => 'true',
+		LMSFinish: endSCORMSession,
 		LMSGetValue: (key) => {
 			console.log(`GET: ${key}`)
 			return getDataFromLMS(key)

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.realtime import get_website_room
+from frappe.utils import cint
 from frappe.utils.telemetry import capture
 
 from lms.lms.utils import get_course_progress, is_demo_course, recalculate_course_progress, sanitize_editorjs
@@ -96,6 +97,9 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 
 	if scorm_details:
 		scorm_details = frappe._dict(**scorm_details)
+		scorm_progress = get_scorm_progress_values(scorm_details, progress_already_exists)
+	else:
+		scorm_progress = {}
 
 	if not progress_already_exists and quiz_completed and assignment_completed and not scorm_details:
 		frappe.get_doc(
@@ -115,20 +119,27 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 				"status": "Complete" if scorm_details.is_complete else "Partially Complete",
 				"member": frappe.session.user,
 				"scorm_content": "" if scorm_details.is_complete else scorm_details.scorm_content,
+				**scorm_progress,
 			}
 		).save(ignore_permissions=True)
-	elif scorm_details and not lesson_already_completed and progress_already_exists:
+	elif scorm_details and progress_already_exists:
 		# Update Existing SCORM Progress
-		frappe.db.set_value(
-			"LMS Course Progress",
-			progress_already_exists,
-			{
-				"lesson": lesson,
-				"status": "Complete" if scorm_details.is_complete else "Partially Complete",
-				"member": frappe.session.user,
-				"scorm_content": "" if scorm_details.is_complete else scorm_details.scorm_content,
-			},
-		)
+		progress_values = scorm_progress
+		if not lesson_already_completed:
+			progress_values.update(
+				{
+					"lesson": lesson,
+					"status": "Complete" if scorm_details.is_complete else "Partially Complete",
+					"member": frappe.session.user,
+					"scorm_content": "" if scorm_details.is_complete else scorm_details.scorm_content,
+				}
+			)
+		if progress_values:
+			frappe.db.set_value(
+				"LMS Course Progress",
+				progress_already_exists,
+				progress_values,
+			)
 	if (not progress_already_exists and quiz_completed and assignment_completed and not scorm_details) or (
 		scorm_details and scorm_details.is_complete and not lesson_already_completed
 	):
@@ -160,6 +171,27 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 	)
 
 	return progress
+
+
+def get_scorm_progress_values(scorm_details, progress_name=None):
+	progress_values = {}
+
+	if "session_time" in scorm_details:
+		progress_values["session_time"] = max(cint(scorm_details.session_time), 0)
+
+	if "total_time" in scorm_details:
+		progress_values["total_time"] = max(cint(scorm_details.total_time), 0)
+	elif scorm_details.get("is_session_end") and progress_values.get("session_time"):
+		current_total = (
+			frappe.db.get_value("LMS Course Progress", progress_name, "total_time")
+			if progress_name
+			else 0
+		)
+		progress_values["total_time"] = (
+			max(cint(current_total), 0) + progress_values["session_time"]
+		)
+
+	return progress_values
 
 
 def get_next_lesson(course: str, lesson: str):

--- a/lms/lms/doctype/lms_course_progress/lms_course_progress.json
+++ b/lms/lms/doctype/lms_course_progress/lms_course_progress.json
@@ -15,7 +15,9 @@
   "section_break_uoob",
   "is_scorm_chapter",
   "column_break_wskp",
-  "scorm_content"
+  "scorm_content",
+  "session_time",
+  "total_time"
  ],
  "fields": [
   {
@@ -96,6 +98,22 @@
    "fieldname": "scorm_content",
    "fieldtype": "Long Text",
    "label": "SCORM Content",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.is_scorm_chapter == 1",
+   "description": "Duration in seconds for the current SCORM session.",
+   "fieldname": "session_time",
+   "fieldtype": "Int",
+   "label": "Session Time",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.is_scorm_chapter == 1",
+   "description": "Total SCORM duration in seconds across learner sessions.",
+   "fieldname": "total_time",
+   "fieldtype": "Int",
+   "label": "Total Time",
    "read_only": 1
   }
  ],


### PR DESCRIPTION
## Summary
- add `session_time` and `total_time` fields to `LMS Course Progress` for SCORM chapters
- parse SCORM 2004 ISO durations and SCORM 1.2 timespans from runtime `SetValue` calls
- persist session time during the session and accumulate total time on `Terminate` / `Finish`
- keep time updates available even after the lesson is already complete

Fixes #2329.

## Validation
- `git diff --check`
- `python -m py_compile lms/lms/doctype/course_lesson/course_lesson.py`
- parsed `lms_course_progress.json` with Python `json.load`

Frontend tests were not run locally because only `node` is available in this environment; `npm` and `yarn` are not installed.