### PR TITLE
chore: add rtl semgrep to identify tailwindcss physical classes

### DIFF
--- a/.github/semgrep/tailwind-rtl.yml
+++ b/.github/semgrep/tailwind-rtl.yml
@@ -1,0 +1,22 @@
+# Local run: semgrep scan --config .github/semgrep/tailwind-rtl.yml --metrics off .
+rules:
+    - id: tailwind-physical-class
+      message: |
+          RTL: replace physical Tailwind class with logical equivalent.
+      languages: [generic]
+      severity: WARNING
+      paths: { include: ["*.vue"] }
+      pattern-regex: |
+          (?x)
+          (?:^|[\s'"`{(\[,]) !?(?:[a-z][a-z0-9-]*:)*-?
+          (?:
+              (?:scroll-)?[mp][lr]-(?:auto|px|full|\d+(?:[./]\d+)?|\[[^\]]+\])
+            | (?:left|right)-(?:auto|px|full|\d+(?:[./]\d+)?|\[[^\]]+\])
+            | text-(?:left|right)
+            | float-(?:left|right)
+            | clear-(?:left|right)
+            | (?:border|rounded)-[lr](?:-[A-Za-z0-9\[\]./#%_-]+)?
+            | rounded-(?:tl|tr|bl|br)(?:-[A-Za-z0-9\[\]./#%_-]+)?
+            | space-x-(?:auto|px|reverse|\d+(?:[./]\d+)?|\[[^\]]+\])
+          )
+          !? (?=$|[\s'"`})\],>;])

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Run Semgrep rules
         run: semgrep ci --config ./frappe-semgrep-rules/rules
+
+      - name: Run RTL Semgrep rules
+        run: semgrep scan --config ./.github/semgrep/tailwind-rtl.yml


### PR DESCRIPTION
## Summary
- Added semgrep to catch physical tailwindcss* classes to ensure rtl friendly development  (warning not blocking)
- Catches the following physical classes and expects the logical equivalent

| Physical class | Logical equivalent |
|---|---|
| `ml-*` | `ms-*` |
| `mr-*` | `me-*` |
| `pl-*` | `ps-*` |
| `pr-*` | `pe-*` |
| `scroll-ml-*` | `scroll-ms-*` |
| `scroll-mr-*` | `scroll-me-*` |
| `scroll-pl-*` | `scroll-ps-*` |
| `scroll-pr-*` | `scroll-pe-*` |
| `left-*` | `start-*` |
| `right-*` | `end-*` |
| `text-left` | `text-start` |
| `text-right` | `text-end` |
| `float-left` | `float-start` |
| `float-right` | `float-end` |
| `clear-left` | `clear-start` |
| `clear-right` | `clear-end` |
| `border-l*` | `border-s*` |
| `border-r*` | `border-e*` |
| `rounded-l*` | `rounded-s*` |
| `rounded-r*` | `rounded-e*` |
| `rounded-tl*` | `rounded-ss*` |
| `rounded-tr*` | `rounded-se*` |
| `rounded-bl*` | `rounded-es*` |
| `rounded-br*` | `rounded-ee*` |
| `space-x-*` | `gap-x-*` (on flex/grid) |

_* only works for version 3.3 and above_