### PR TITLE
fix: timezone now renders for courses and batches

### DIFF
--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -131,7 +131,7 @@ class LMSCertificateRequest(Document):
 
 			args = {
 				"course": self.course_title,
-				"timezone": self.timezone if self.batch_name else "",
+				"timezone": self.timezone,
 				"date": format_date(self.date, "medium"),
 				"member_name": self.member_name,
 				"start_time": format_time(self.start_time, "short"),


### PR DESCRIPTION
## Summary
- Render timezone in certificate request emails for course-only evaluations as well. 
- Remove `if self.batch_name` in `send_notification()` (`validate_timezone()` ensures `self.timezone` is set)