### PR TITLE
fix: recalculate enrollment on course progress save from desk

### DIFF
--- a/lms/lms/doctype/lms_course_progress/lms_course_progress.py
+++ b/lms/lms/doctype/lms_course_progress/lms_course_progress.py
@@ -8,5 +8,8 @@ from lms.lms.utils import recalculate_course_progress
 
 
 class LMSCourseProgress(Document):
+	def on_update(self):
+		recalculate_course_progress(self.course, self.member)
+
 	def after_delete(self):
 		recalculate_course_progress(self.course, self.member)

--- a/lms/lms/doctype/lms_course_progress/test_lms_course_progress.py
+++ b/lms/lms/doctype/lms_course_progress/test_lms_course_progress.py
@@ -1,9 +1,39 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
-# import frappe
-import unittest
+from lms.lms.test_helpers import BaseTestUtils
 
 
-class TestLMSCourseProgress(unittest.TestCase):
-	pass
+class TestLMSCourseProgress(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		self.admin = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"]
+		)
+		self.student = self._create_user("student@example.com", "Test", "Student", ["LMS Student"])
+		self.course = self._create_course()
+
+		self.lessons = []
+		for i in range(1, 3):
+			chapter = self._create_chapter(f"Chapter {i}", self.course.name)
+			self._create_chapter_reference(self.course.name, chapter.name, idx=i)
+			for j in range(1, 3):
+				lesson = self._create_lesson(f"Lesson {i}.{j}", chapter.name, self.course.name)
+				self._create_lesson_reference(chapter.name, lesson.name)
+				self.lessons.append(lesson)
+
+		self.enrollment = self._create_enrollment(self.student.email, self.course.name)
+
+	def test_manual_progress_recalculates_enrollment(self):
+		"""Creating a course progress (desk) must update the enrollment progress"""
+		self._create_lesson_progress(self.student.email, self.course.name, self.lessons[0].name)
+		self._create_lesson_progress(self.student.email, self.course.name, self.lessons[1].name)
+
+		self.enrollment.reload()
+		self.assertEqual(self.enrollment.progress, 50)
+
+		self._create_lesson_progress(self.student.email, self.course.name, self.lessons[2].name)
+		self._create_lesson_progress(self.student.email, self.course.name, self.lessons[3].name)
+
+		self.enrollment.reload()
+		self.assertEqual(self.enrollment.progress, 100)

--- a/lms/lms/test_helpers.py
+++ b/lms/lms/test_helpers.py
@@ -50,6 +50,12 @@ class BaseTestUtils(UnitTestCase):
 		if existing:
 			return frappe.get_doc("LMS Course", existing)
 
+		if not frappe.db.exists("LMS Category", "Business"):
+			frappe.get_doc({"doctype": "LMS Category", "category": "Business"}).insert(
+				ignore_permissions=True
+			)
+			self.cleanup_items.append(("LMS Category", "Business"))
+
 		course = frappe.new_doc("LMS Course")
 		course.update(
 			{


### PR DESCRIPTION
## Summary

- `lms course progress` only had an `after_delete` hook, so saves from anywhere other than the portal flow left `lms_enrollment.progress` stale
- Added an `on_update` hook so every save updates enrollment percent

## Changes
- Added `on_update` hook for updating course progress
- Added test to confirm the fix
- Updated `_create_course` helper for scenario where `lms category` doesnt exist

## Issues
- https://support.frappe.io/helpdesk/tickets/67035