### PR TITLE
fix(quiz): exam submissions and scope check_answer

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -512,7 +512,7 @@ const handlePageHide = () => {
 	if (activeQuestion.value > 0 && !quizSubmission.data) {
 		const params = new URLSearchParams({
 			quiz: quiz.data.name,
-			results: localStorage.getItem(quiz.data.title),
+			results: localStorage.getItem(quiz.data.title) || '[]',
 		})
 
 		navigator.sendBeacon(
@@ -648,7 +648,7 @@ const quizSubmission = createResource({
 	makeParams(values) {
 		return {
 			quiz: quiz.data.name,
-			results: localStorage.getItem(quiz.data.title),
+			results: localStorage.getItem(quiz.data.title) || '[]',
 		}
 	},
 })
@@ -833,7 +833,9 @@ const resetQuestion = () => {
 
 const submitQuiz = () => {
 	if (!quiz.data.show_answers) {
-		if (questionDetails.data.type == 'Open Ended') addToLocalStorage()
+		if (questionDetails.data.type == 'Open Ended' || getAnswers().length) {
+			addToLocalStorage()
+		}
 		setTimeout(() => {
 			createSubmission()
 		}, 500)

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -767,6 +767,7 @@ const checkAnswer = () => {
 	createResource({
 		url: 'lms.lms.doctype.lms_quiz.lms_quiz.check_answer',
 		params: {
+			quiz: quiz.data.name,
 			question: currentQuestion.value,
 			question_type: questionDetails.data.type,
 			answers: JSON.stringify(answers),

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -275,7 +275,19 @@ def save_progress_after_quiz(quiz_details: dict, percentage: float):
 
 
 @frappe.whitelist()
-def check_answer(question: str, question_type: str, answers: str):
+def check_answer(quiz: str, question: str, question_type: str, answers: str):
+	ADMIN_ROLES = ("System Manager", "Moderator", "Course Creator", "Batch Evaluator")
+	is_admin = any(role in ADMIN_ROLES for role in frappe.get_roles())
+
+	if not frappe.db.exists("LMS Quiz Question", {"parent": quiz, "question": question}):
+		frappe.throw(_("Question not found in this quiz."), frappe.PermissionError)
+
+	if not is_admin and not frappe.db.get_value("LMS Quiz", quiz, "show_answers"):
+		frappe.throw(
+			_("Live answer checking is not enabled for this quiz."),
+			frappe.PermissionError,
+		)
+
 	answers = answers and json.loads(answers)
 	if question_type == "Choices":
 		return check_choice_answers(question, answers)

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -101,8 +101,8 @@ def set_total_marks(questions: list) -> int:
 
 
 @frappe.whitelist()
-def submit_quiz(quiz: str, results: str):
-	results = results and json.loads(results)
+def submit_quiz(quiz: str, results: str | None = None):
+	results = json.loads(results) if results else []
 	percentage = 0
 
 	quiz_details = frappe.db.get_value(


### PR DESCRIPTION
## Summary
- `check_answer` previously was open for anyone to call. Now only works when quiz has `show_answers` enabled.
- `submitQuiz` in exam mode silently dropped submissions for user input and choices before. Server ran on empty results and scored it as 0 before even if user had selected correct option.