### PR TITLE
fix(persona) :Adjust persona form container width to fit content

### DIFF
--- a/frontend/src/pages/PersonaForm.vue
+++ b/frontend/src/pages/PersonaForm.vue
@@ -10,7 +10,7 @@
 				</span>
 			</div>
 			<div
-				class="mx-auto w-full h-fit bg-white py-8 sm:mt-6 sm:w-96 sm:rounded-lg sm:px-8 sm:shadow-xl"
+				class="mx-auto w-full h-fit bg-white py-8 sm:mt-6 sm:w-fit sm:rounded-lg sm:px-8 sm:shadow-xl"
 			>
 				<div class="font-medium text-center mb-8">
 					{{ __('Help us understand your needs') }}


### PR DESCRIPTION
## Summary

The card was fixed at sm:w-96 (384px) but the FormControl select
trigger sizes itself to the longest option text via an internal
sizer span. This caused the trigger to overflow the card boundary.

Changed sm:w-96 to sm:w-fit so the card grows to accommodate the
trigger width naturally on desktop, while w-full (already present)
handles mobile viewports below the sm: breakpoint

## Changes.

### Before

<img width="1920" height="1080" alt="Screenshot from 2026-05-13 15-07-46" src="https://github.com/user-attachments/assets/f513504a-22e0-469e-aad5-5dc272f96050" />

---

### After
<img width="1920" height="1080" alt="Screenshot from 2026-05-13 15-17-15" src="https://github.com/user-attachments/assets/1669ab3b-b0e7-4dc3-b16a-b5680ab31b6b" />
