### PR TITLE
fix: system manager permissions are set properly on install

### DIFF
--- a/lms/install.py
+++ b/lms/install.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.permissions import add_permission, update_permission_property
 
 from lms.lms.api import give_discussions_permission
 
@@ -200,26 +201,16 @@ def give_event_permission():
 
 
 def create_role(doctype, role, permlevel, write=0, create=0):
-	if not frappe.db.exists("Custom DocPerm", {"parent": doctype, "role": role, "permlevel": permlevel}):
-		if not write and not create:
-			if role in ["Moderator", "System Manager"]:
-				write = 1
-			if role == "Moderator":
-				create = 1
-		doc = frappe.new_doc("Custom DocPerm")
-		doc.update(
-			{
-				"doctype": "Custom DocPerm",
-				"parent": doctype,
-				"role": role,
-				"read": 1,
-				"select": 1,
-				"write": write,
-				"create": create,
-				"permlevel": permlevel,
-			}
-		)
-		doc.save()
+	if frappe.db.exists("Custom DocPerm", {"parent": doctype, "role": role, "permlevel": permlevel}):
+		return
+
+	add_permission(doctype, role, permlevel)
+	update_permission_property(doctype, role, permlevel, "select", 1)
+
+	if role in ["Moderator", "System Manager"] or write == 1:
+		update_permission_property(doctype, role, permlevel, "write", 1)
+	if role == "Moderator" or create == 1:
+		update_permission_property(doctype, role, permlevel, "create", 1)
 
 
 def delete_lms_roles():

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -124,3 +124,4 @@ lms.patches.v2_0.set_conferencing_provider_for_zoom
 lms.patches.v2_0.sync_evaluator_roles
 lms.patches.v2_0.fix_livecode_url_default
 lms.patches.v2_0.give_event_permission #10-03-2026
+lms.patches.v2_0.restore_system_manager_perms #13-05-2026

--- a/lms/patches/v2_0/restore_system_manager_perms.py
+++ b/lms/patches/v2_0/restore_system_manager_perms.py
@@ -1,0 +1,77 @@
+import frappe
+
+
+def execute():
+	"""
+	Restore system manager perms on doctypes
+	"""
+	doctypes = ["User", "Event", "Discussion Topic", "Discussion Reply"]
+
+	perm_fields = (
+		"read",
+		"write",
+		"create",
+		"delete",
+		"submit",
+		"cancel",
+		"amend",
+		"report",
+		"export",
+		"import",
+		"print",
+		"email",
+		"share",
+		"select",
+	)
+
+	for doctype in doctypes:
+		if not frappe.db.exists("Custom DocPerm", {"parent": doctype}):
+			continue
+
+		standard_perms = frappe.get_all(
+			"DocPerm",
+			fields=["permlevel", "if_owner", *perm_fields],
+			filters={"parent": doctype, "role": "System Manager"},
+		)
+
+		for standard_perm in standard_perms:
+			permlevel = standard_perm.permlevel or 0
+			if_owner = standard_perm.if_owner or 0
+
+			custom_perm_name = frappe.db.exists(
+				"Custom DocPerm",
+				{
+					"parent": doctype,
+					"role": "System Manager",
+					"permlevel": permlevel,
+					"if_owner": if_owner,
+				},
+			)
+
+			if custom_perm_name:
+				custom_perm = frappe.get_doc("Custom DocPerm", custom_perm_name)
+			else:
+				custom_perm = frappe.new_doc("Custom DocPerm")
+				custom_perm.update(
+					{
+						"parent": doctype,
+						"parenttype": "DocType",
+						"parentfield": "permissions",
+						"role": "System Manager",
+						"permlevel": permlevel,
+						"if_owner": if_owner,
+					}
+				)
+
+			is_dirty = False
+			for field in perm_fields:
+				if standard_perm.get(field) and not custom_perm.get(field):
+					custom_perm.set(field, 1)
+					is_dirty = True
+
+			if not custom_perm_name:
+				custom_perm.insert(ignore_permissions=True)
+			elif is_dirty:
+				custom_perm.save(ignore_permissions=True)
+
+	frappe.clear_cache()


### PR DESCRIPTION
## Summary
- Before level 0 system manager permissions were overridden on install making it unable for for them to do actions such as import Users. This has been fixed.
- Added a patch which grants this back to system manager roles.