### PR TITLE
fix(certificate): permission and progress check 

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -230,7 +230,7 @@ const is_instructor = () => {
 const canGetCertificate = computed(() => {
 	if (
 		props.course.data?.enable_certification &&
-		props.course.data?.membership?.progress == 100
+		props.course.data?.membership?.progress >= 100
 	) {
 		return true
 	}

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -148,7 +148,7 @@ class LMSCertificate(Document):
 
 
 def has_website_permission(doc, ptype, user, verbose=False):
-	if ptype in ["read", "print"]:
+	if ptype in ["read", "print"] and doc.published:
 		return True
 	if doc.member == user and ptype == "create":
 		return True


### PR DESCRIPTION
## Summary
  - Tightened website permissions on LMS Certificate so unpublished certificates aren't readable by end users.
  - Fixed `canGetCertificate` so learners whose progress ticks above 100 (rounding/recalc edge cases) can still claim their certificate, before,  it required `progress == 100` exactly.