### PR TITLE
fix: batch errors are now rendered

### DIFF
--- a/frontend/src/pages/Batches/components/NewBatchModal.vue
+++ b/frontend/src/pages/Batches/components/NewBatchModal.vue
@@ -120,7 +120,7 @@ import { Button, Dialog, FormControl, TextEditor, toast } from 'frappe-ui'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { computed, inject, onMounted, onBeforeUnmount, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { sanitizeHTML, createLMSCategory } from '@/utils'
+import { sanitizeHTML, createLMSCategory, cleanError } from '@/utils'
 import MultiSelect from '@/components/Controls/MultiSelect.vue'
 import Link from '@/components/Controls/Link.vue'
 import NewMemberModal from '@/components/Modals/NewMemberModal.vue'
@@ -214,7 +214,8 @@ const saveBatch = (close: () => void = () => {}) => {
 				}
 			},
 			onError(err: any) {
-				toast.error(cleanError(err.messages?.[0]))
+				const message = err?.messages?.[0]
+				toast.error(message ? cleanError(message) : __('Error creating batch'))
 				console.error(err)
 			},
 		}

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -27,6 +27,7 @@ from lms.lms.utils import (
 
 class LMSBatch(Document):
 	def validate(self):
+		self._validate_mandatory()
 		self.validate_seats_left()
 		self.validate_batch_end_date()
 		self.validate_batch_time()
@@ -43,7 +44,7 @@ class LMSBatch(Document):
 			frappe.enqueue(send_notification_for_published_batch, batch=self)
 
 	def autoname(self):
-		if not self.name:
+		if not self.name and self.title:
 			self.name = generate_slug(self.title, "LMS Batch")
 
 	def validate_batch_end_date(self):


### PR DESCRIPTION
## Summary
- Creating a batch with missing required fields failed silently: frontend toast was blank, backend crashed before the mandatory check ran.

## Changes
- `lms_batch.py`: run `_validate_mandatory()` first
- `NewBatchModal.vue`: fall back to a generic toast when `err.messages` is empty