### PR TITLE
fix: resolved race condition for get certificate button

### DIFF
--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -77,18 +77,20 @@
 						{{ __('Start Learning') }}
 					</span>
 				</Button>
-				<Button
-					v-if="canGetCertificate"
-					@click="fetchCertificate()"
-					variant="subtle"
-					class="w-full mt-2"
-					size="md"
-				>
-					<template #prefix>
-						<GraduationCap class="size-4 stroke-1.5" />
-					</template>
-					{{ __('Get Certificate') }}
-				</Button>
+			<Button
+				v-if="canGetCertificate"
+				@click="fetchCertificate()"
+				:disabled="certificate.loading"
+				:loading="certificate.loading"
+				variant="subtle"
+				class="w-full mt-2"
+				size="md"
+			>
+				<template #prefix>
+					<GraduationCap class="size-4 stroke-1.5" />
+				</template>
+				{{ __('Get Certificate') }}
+			</Button>
 			</div>
 			<div class="space-y-3">
 				<div class="font-medium text-ink-gray-9">
@@ -255,6 +257,7 @@ const certificate = createResource({
 })
 
 const fetchCertificate = () => {
+	if (certificate.loading) return
 	certificate.submit({
 		course: props.course.data?.name,
 		member: user.data?.name,

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -11,6 +11,13 @@ from frappe.utils.telemetry import capture
 
 
 class LMSCertificate(Document):
+	@staticmethod
+	def on_doctype_update():
+		frappe.db.sql_ddl(
+			"""CREATE UNIQUE INDEX IF NOT EXISTS unique_member_course
+			ON `tabLMS Certificate` (member, course)"""
+		)
+
 	def validate(self):
 		self.validate_criteria()
 		self.validate_duplicate_certificate()
@@ -164,15 +171,23 @@ def is_certified(course):
 
 @frappe.whitelist()
 def create_certificate(course: str):
+	# Acquire row-level lock to serialize concurrent requests for the same user+course.
+	# If a row exists, FOR UPDATE blocks other transactions until this one completes.
+	frappe.db.sql(
+		"SELECT name FROM `tabLMS Certificate` WHERE member=%s AND course=%s FOR UPDATE",
+		(frappe.session.user, course),
+	)
+
 	certificate = is_certified(course)
 	if certificate:
 		return frappe.db.get_value(
 			"LMS Certificate", certificate, ["name", "course", "template"], as_dict=True
 		)
 
-	else:
-		validate_certification_eligibility(course)
-		default_certificate_template = get_default_certificate_template()
+	validate_certification_eligibility(course)
+	default_certificate_template = get_default_certificate_template()
+
+	try:
 		certificate = frappe.get_doc(
 			{
 				"doctype": "LMS Certificate",
@@ -184,6 +199,13 @@ def create_certificate(course: str):
 		)
 		certificate.save(ignore_permissions=True)
 		return certificate
+	except frappe.DuplicateEntryError:
+		frappe.clear_last_message()
+		certificate_name = is_certified(course)
+		if certificate_name:
+			return frappe.db.get_value(
+				"LMS Certificate", certificate_name, ["name", "course", "template"], as_dict=True
+			)
 
 
 def get_default_certificate_template():


### PR DESCRIPTION
1. Add server-side locking (SELECT ... FOR UPDATE) in create_certificate to serialize concurrent requests for the same user+course, preventing duplicate certificates from being created when the "Get Certificate" button is clicked rapidly

2. Add a composite unique index on (member, course) via on_doctype_update as a database-level safety net, with a DuplicateEntryError handler that gracefully returns the existing certificate.

3. Add a frontend loading guard and disable the "Get Certificate" button while a request is in flight to prevent unnecessary duplicate submissions.

FIXES #2408 