### PR TITLE
fix: race condition caused duplicate course progress

### DIFF
--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -98,25 +98,32 @@ def save_progress(lesson: str, course: str, scorm_details: dict = None):
 		scorm_details = frappe._dict(**scorm_details)
 
 	if not progress_already_exists and quiz_completed and assignment_completed and not scorm_details:
-		frappe.get_doc(
-			{
-				"doctype": "LMS Course Progress",
-				"lesson": lesson,
-				"status": "Complete",
-				"member": frappe.session.user,
-			}
-		).save(ignore_permissions=True)
+		try:
+			frappe.get_doc(
+				{
+					"doctype": "LMS Course Progress",
+					"lesson": lesson,
+					"status": "Complete",
+					"member": frappe.session.user,
+				}
+			).save(ignore_permissions=True)
+		except frappe.UniqueValidationError:
+			# concurrent request created the progress doc
+			pass
 	elif scorm_details and not lesson_already_completed and not progress_already_exists:
 		# Create new SCORM progress
-		frappe.get_doc(
-			{
-				"doctype": "LMS Course Progress",
-				"lesson": lesson,
-				"status": "Complete" if scorm_details.is_complete else "Partially Complete",
-				"member": frappe.session.user,
-				"scorm_content": "" if scorm_details.is_complete else scorm_details.scorm_content,
-			}
-		).save(ignore_permissions=True)
+		try:
+			frappe.get_doc(
+				{
+					"doctype": "LMS Course Progress",
+					"lesson": lesson,
+					"status": "Complete" if scorm_details.is_complete else "Partially Complete",
+					"member": frappe.session.user,
+					"scorm_content": "" if scorm_details.is_complete else scorm_details.scorm_content,
+				}
+			).save(ignore_permissions=True)
+		except frappe.UniqueValidationError:
+			pass
 	elif scorm_details and not lesson_already_completed and progress_already_exists:
 		# Update Existing SCORM Progress
 		frappe.db.set_value(

--- a/lms/lms/doctype/lms_course_progress/lms_course_progress.py
+++ b/lms/lms/doctype/lms_course_progress/lms_course_progress.py
@@ -2,12 +2,24 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from lms.lms.utils import recalculate_course_progress
 
 
 class LMSCourseProgress(Document):
+	def before_insert(self):
+		if (
+			self.member
+			and self.lesson
+			and frappe.db.exists("LMS Course Progress", {"member": self.member, "lesson": self.lesson})
+		):
+			frappe.throw(
+				_("Progress is already recorded for this lesson."),
+				frappe.UniqueValidationError,
+			)
+
 	def on_update(self):
 		recalculate_course_progress(self.course, self.member)
 

--- a/lms/lms/doctype/lms_course_progress/test_lms_course_progress.py
+++ b/lms/lms/doctype/lms_course_progress/test_lms_course_progress.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
+import frappe
+
 from lms.lms.test_helpers import BaseTestUtils
 
 
@@ -37,3 +39,28 @@ class TestLMSCourseProgress(BaseTestUtils):
 
 		self.enrollment.reload()
 		self.assertEqual(self.enrollment.progress, 100)
+
+	def test_duplicate_progress_is_rejected(self):
+		"""Duplicate progress row for the same (member, lesson) not allowed"""
+		self._create_lesson_progress(self.student.email, self.course.name, self.lessons[0].name)
+
+		lms_course_progress = frappe.new_doc("LMS Course Progress")
+		lms_course_progress.update(
+			{
+				"member": self.student.email,
+				"course": self.course.name,
+				"lesson": self.lessons[0].name,
+				"status": "Complete",
+			}
+		)
+		with self.assertRaises(frappe.UniqueValidationError):
+			lms_course_progress.insert(ignore_permissions=True)
+
+		count = frappe.db.count(
+			"LMS Course Progress",
+			{"member": self.student.email, "lesson": self.lessons[0].name},
+		)
+		self.assertEqual(count, 1)
+
+		self.enrollment.reload()
+		self.assertEqual(self.enrollment.progress, 25)

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -124,4 +124,5 @@ lms.patches.v2_0.set_conferencing_provider_for_zoom
 lms.patches.v2_0.sync_evaluator_roles
 lms.patches.v2_0.fix_livecode_url_default
 lms.patches.v2_0.give_event_permission #10-03-2026
+lms.patches.v2_0.delete_duplicate_course_progress #13-05-2026
 lms.patches.v2_0.restore_system_manager_perms #13-05-2026

--- a/lms/patches/v2_0/delete_duplicate_course_progress.py
+++ b/lms/patches/v2_0/delete_duplicate_course_progress.py
@@ -1,0 +1,45 @@
+import frappe
+from frappe.query_builder.functions import Count
+
+from lms.lms.utils import recalculate_course_progress
+
+
+def execute():
+	"""
+	Remove duplicates from course progress caused by race condition
+	"""
+	CourseProgress = frappe.qb.DocType("LMS Course Progress")
+	duplicate_groups = (
+		frappe.qb.from_(CourseProgress)
+		.select(CourseProgress.member, CourseProgress.lesson)
+		.where(CourseProgress.member.isnotnull() & CourseProgress.lesson.isnotnull())
+		.groupby(CourseProgress.member, CourseProgress.lesson)
+		.having(Count(CourseProgress.name) > 1)
+	).run(as_dict=True)
+
+	affected = set()
+	for group in duplicate_groups:
+		rows = frappe.get_all(
+			"LMS Course Progress",
+			filters={"member": group.member, "lesson": group.lesson},
+			fields=["name", "course", "status", "creation"],
+		)
+		# keep row with the most completion and earlier creation
+		status_rank = {"Complete": 2, "Partially Complete": 1, "Incomplete": 0}
+		rows.sort(key=lambda row: row.creation)
+		rows.sort(key=lambda row: status_rank.get(row.status, -1), reverse=True)
+		for row in rows[1:]:
+			frappe.db.delete("LMS Course Progress", {"name": row.name})
+			if row.course:
+				affected.add((row.course, group.member))
+
+	for course, member in affected:
+		try:
+			recalculate_course_progress(course, member)
+		except Exception:
+			frappe.log_error(
+				title="dedupe_course_progress: recalculate failed",
+				message=f"course={course} member={member}",
+			)
+
+	frappe.db.add_unique("LMS Course Progress", ["member", "lesson"])


### PR DESCRIPTION
## Summary
- Concurrent `save_progress` functions calls create duplicate `LMS Course Progress` rows for the same (member, lesson) before, now:
    - Added a `before_insert` that raises `UniqueValidationError` if row already exists 
    - Wrapped the .save() calls in `save_progress` with try/except so duplicate inserts are silently ignored.
    - Added patch for cleaning up existing duplicates
    - Added a test for making sure duplicates are no longer created

## Issues
- Fixes #2423 