### PR TITLE
fix(scorm): upload package zip as private file

### DIFF
--- a/frontend/src/components/Controls/Uploader.vue
+++ b/frontend/src/components/Controls/Uploader.vue
@@ -8,6 +8,7 @@
 			v-if="!modelValue"
 			:fileTypes="[fileType]"
 			:validateFile="(file: File) => validateFile(file, true, type)"
+			:uploadArgs="{ private: false }"
 			@success="(file: File) => saveFile(file)"
 			@failure="onUploadFailure"
 		>

--- a/frontend/src/components/Modals/ChapterModal.vue
+++ b/frontend/src/components/Modals/ChapterModal.vue
@@ -37,6 +37,7 @@
 						v-if="!chapter.scorm_package"
 						:fileTypes="['.zip']"
 						:validateFile="validateFile"
+						:uploadArgs="{ private: true }"
 						@success="(file) => (chapter.scorm_package = file)"
 					>
 						<template v-slot="{ file, progress, uploading, openFileSelector }">

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -21,6 +21,7 @@
 						<FileUploader
 							:fileTypes="['image/*']"
 							:validateFile="validateFile"
+							:uploadArgs="{ private: false }"
 							@success="(file) => saveImage(file)"
 						>
 							<template

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -49,6 +49,7 @@
 								v-if="!data[field.name]"
 								:fileTypes="['image/*']"
 								:validateFile="validateFile"
+								:uploadArgs="{ private: false }"
 								@success="(file) => (data[field.name] = file.file_url)"
 							>
 								<template

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -19,7 +19,10 @@
 								:debounce="300"
 							/>
 						</div>
-						<FileUploader @success="(file) => $emit('select', file.file_url)">
+						<FileUploader
+							:uploadArgs="{ private: false }"
+							@success="(file) => $emit('select', file.file_url)"
+						>
 							<template
 								v-slot="{ file, progress, uploading, openFileSelector }"
 							>

--- a/frontend/src/components/UploadPlugin.vue
+++ b/frontend/src/components/UploadPlugin.vue
@@ -2,6 +2,7 @@
 	<FileUploader
 		:fileTypes="['image/*', 'video/*', 'audio/*', '.pdf']"
 		:validateFile="validateFile"
+		:uploadArgs="uploadArgs"
 		@success="(data) => addFile(data)"
 		ref="fileUploader"
 		class="hide"
@@ -18,6 +19,10 @@ const props = defineProps({
 	onFileUploaded: {
 		type: Function,
 		required: true,
+	},
+	uploadArgs: {
+		type: Object,
+		default: () => ({ private: false }),
 	},
 })
 

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -146,7 +146,11 @@ onMounted(() => {
 const renderEditor = (holder) => {
 	return new EditorJS({
 		holder: holder,
-		tools: getEditorTools(true),
+		tools: getEditorTools({
+			private: false,
+			doctype: 'LMS Course',
+			docname: props.courseName,
+		}),
 		defaultBlock: 'markdown',
 		i18n: {
 			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -111,7 +111,7 @@ export function htmlToText(html) {
 	return div.textContent || div.innerText || ''
 }
 
-export function getEditorTools() {
+export function getEditorTools(uploadArgs = { private: false }) {
 	return {
 		header: {
 			class: Header,
@@ -126,7 +126,10 @@ export function getEditorTools() {
 				defaultStyle: 'ordered',
 			},
 		},
-		upload: Upload,
+		upload: {
+			class: Upload,
+			config: { uploadArgs },
+		},
 		table: {
 			class: Table,
 			inlineToolbar: true,

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -7,9 +7,10 @@ import { createDialog } from '@/utils/dialogs'
 import translationPlugin from '../translation'
 
 export class Upload {
-	constructor({ data, api, readOnly }) {
+	constructor({ data, api, readOnly, config }) {
 		this.data = data
 		this.readOnly = readOnly
+		this.uploadArgs = config?.uploadArgs || { private: false }
 	}
 
 	static get toolbox() {
@@ -81,6 +82,7 @@ export class Upload {
 
 	renderFileUploader() {
 		const app = createApp(UploadPlugin, {
+			uploadArgs: this.uploadArgs,
 			onFileUploaded: (file) => {
 				this.data.file_url = file.file_url
 				this.data.file_type = file.file_type


### PR DESCRIPTION
## Summary
  - SCORM package zips were uploaded as public files, so the raw archive URL was accessible to anyone with the link
  - Now SCORM zips upload with `private: true`. Other uploads (cover images, settings images, etc) explicitly stay public