### PR TITLE
fix: job application page is now visible

### DIFF
--- a/frontend/src/pages/JobApplications.vue
+++ b/frontend/src/pages/JobApplications.vue
@@ -209,20 +209,26 @@ const props = defineProps({
 
 const applications = createListResource({
 	doctype: 'LMS Job Application',
-	fields: [
-		'name',
-		'user.user_image as user_image',
-		'user.full_name as full_name',
-		'user.email as email',
-		'creation',
-		'resume',
-		'job.job_title as job_title',
-	],
+	fields: ['name', 'user', 'creation', 'resume', 'job_title'],
 	filters: {
 		job: props.job,
 	},
 	auto: true,
 })
+
+const users = createResource({
+	url: 'lms.lms.api.get_application_users',
+	makeParams: () => ({
+		user_names: (applications.data || []).map((a) => a.user),
+	}),
+})
+
+watch(
+	() => applications.data,
+	(rows) => {
+		if (rows?.length) users.submit()
+	}
+)
 
 const totalApplications = createResource({
 	url: 'frappe.client.get_count',
@@ -354,11 +360,17 @@ const applicationColumns = computed(() => {
 
 const applicantRows = computed(() => {
 	if (!applications.data) return []
-	return applications.data.map((application) => ({
-		...application,
-		full_name: application.full_name,
-		applied_on: dayjs(application.creation).format('DD MMM YYYY'),
-	}))
+	const userMap = Object.fromEntries((users.data || []).map((u) => [u.name, u]))
+	return applications.data.map((application) => {
+		const user = userMap[application.user] || {}
+		return {
+			...application,
+			user_image: user.user_image,
+			full_name: user.full_name,
+			email: user.email,
+			applied_on: dayjs(application.creation).format('DD MMM YYYY'),
+		}
+	})
 })
 
 usePageMeta(() => {

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -231,6 +231,31 @@ def get_job_details(job: str):
 	)
 
 
+@frappe.whitelist()
+def get_application_users(user_names: list | str):
+	# temp function workaround:reverting once upstream restores dotted-field JOINs in `frappe.client.get_list`
+	if isinstance(user_names, str):
+		user_names = json.loads(user_names)
+	if not user_names:
+		return []
+
+	visible = frappe.get_list(
+		"LMS Job Application",
+		filters={"user": ["in", user_names]},
+		fields=["user"],
+		pluck="user",
+	)
+	visible_user_names = list(set(visible))
+	if not visible_user_names:
+		return []
+
+	return frappe.get_all(
+		"User",
+		filters={"name": ["in", visible_user_names]},
+		fields=["name", "user_image", "full_name", "email"],
+	)
+
+
 def sanitize_job_filters(filters, or_filters):
 	ALLOWED_FILTERS = ("status", "type", "work_mode", "country")
 	ALLOWED_OR_FILTERS = ("job_title", "company_name", "location")


### PR DESCRIPTION
## Summary
- The Job Applications page was not rendering due to `createListResource` asking for dotted-field joins (`user.full_name as full_name`, etc.) on `LMS Job Application`, which upstream `frappe.client.get_list` no longer supports.
- Turned it to 2 queries: 
    1. fetch applications first 
    2. fetch the matching users via a whitelisted helper. 

> Note: Temp workaround until framework restores dotted joins (going to be reverted)