### PR TITLE
fix: drop member email from certified participants response

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -417,6 +417,7 @@ def get_certified_participants(
 	for participant in participants:
 		details = get_certified_participant_details(participant.member)
 		participant.update(details)
+		participant.pop("member", None)
 
 	return participants
 

--- a/lms/lms/test_api.py
+++ b/lms/lms/test_api.py
@@ -24,7 +24,8 @@ class TestLMSAPI(BaseTestUtils):
 		filters = {"category": "Utility Course"}
 		certified_participants = get_certified_participants(filters=filters)
 		self.assertEqual(len(certified_participants), 1)
-		self.assertEqual(certified_participants[0].member, self.student1.email)
+		self.assertEqual(certified_participants[0].full_name, self.student1.full_name)
+		self.assertNotIn("member", certified_participants[0])
 
 		filters = {"category": "Nonexistent Category"}
 		certified_participants_no_match = get_certified_participants(filters=filters)


### PR DESCRIPTION
- Drop member email from certified participants response for privacy