### PR TITLE
fix(router): install shared router for standalone AssessmentPlugin mounts

### DIFF
--- a/frontend/src/utils/assignment.js
+++ b/frontend/src/utils/assignment.js
@@ -4,10 +4,9 @@ import AssessmentPlugin from '@/components/AssessmentPlugin.vue'
 import translationPlugin from '../translation'
 import { usersStore } from '@/stores/user'
 import { call } from 'frappe-ui'
-import { useRouter } from 'vue-router'
+import router from '@/router'
 import { getLmsRoute } from '@/utils/basePath'
 
-const router = useRouter()
 export class Assignment {
 	constructor({ data, api, readOnly }) {
 		this.data = data

--- a/frontend/src/utils/quiz.js
+++ b/frontend/src/utils/quiz.js
@@ -4,6 +4,7 @@ import { createApp, h } from 'vue'
 import { usersStore } from '../stores/user'
 import translationPlugin from '../translation'
 import { CircleHelp } from 'lucide-vue-next'
+import router from '@/router'
 
 export class Quiz {
 	constructor({ data, api, readOnly }) {
@@ -85,6 +86,7 @@ export class Quiz {
 			},
 		})
 		app.use(translationPlugin)
+		app.use(router)
 		app.mount(this.wrapper)
 	}
 


### PR DESCRIPTION
Install the shared `router` in apps created by `assignment.js` and `quiz.js`.
Remove invalid top-level `useRouter()` usage in `assignment.js`.
Ensures `useRoute()` inside `AssessmentPlugin.vue` receives a valid router context and fixes undefined route params.