### PR TITLE
fix: mobile layout scroll

### DIFF
--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="relative flex h-screen flex-col">
 		<div
-			class="flex flex-1 flex-col overflow-hidden pb-10"
+			class="flex flex-1 flex-col overflow-y-auto pb-10"
 			id="scrollContainer"
 		>
 			<slot />


### PR DESCRIPTION
## Summary
- Overflow-hidden prevented users from scrolling on mobile

## Issues
- Fixes #2410