### PR TITLE
fix(quiz): attempted quiz count during submission

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -523,9 +523,7 @@ const handlePageHide = () => {
 
 const handleBeforeUnload = (event) => {
 	if (activeQuestion.value > 0 && !quizSubmission.data) {
-		if (attemptedQuestions.value.length) {
-			switchQuestion(activeQuestion.value)
-		}
+		recordCurrentAttempt()
 		event.preventDefault()
 		event.returnValue = ''
 	}
@@ -910,13 +908,19 @@ const markLessonProgress = () => {
 
 const handleSubmitClick = () => {
 	if (!quiz.data.show_answers) {
-		if (attemptedQuestions.value.length) {
-			switchQuestion(activeQuestion.value)
-		}
+		recordCurrentAttempt()
 		showSubmissionConfirmation.value = true
 	} else {
 		submitQuiz()
 	}
+}
+
+const recordCurrentAttempt = () => {
+	if (!getAnswers().length) return
+	if (!attemptedQuestions.value.includes(activeQuestion.value)) {
+		attemptedQuestions.value.push(activeQuestion.value)
+	}
+	addToLocalStorage()
 }
 
 const paginationWindow = computed(() => {


### PR DESCRIPTION
## Summary
When a learner submitted a quiz (or tried to leave the page), the answer on the currently open question wasn't always counted. The old code only re-recorded an answer if there were already other attempted questions, so an answer on the active question could be missed in the attempted count. Now it is fixed.

## Changes
Added a small helper recordCurrentAttempt() that:
- skips if the current question has no answer,
- adds the current question to attemptedQuestions if it isn't there yet,
- saves progress to local storage.
It now runs in both handleSubmitClick and handleBeforeUnload, replacing the old if (attemptedQuestions.length) switchQuestion(...) logic.

<img width="2879" height="1603" alt="image" src="https://github.com/user-attachments/assets/bf303a18-0372-444c-9737-9992f55c11d7" />
