### PR TITLE
fix: zoom live class not auto-recording

### DIFF
--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -250,9 +250,11 @@ def create_live_class(
 		"start_time": format_datetime(f"{date} {time}", "yyyy-MM-ddTHH:mm:ssZ"),
 		"duration": duration,
 		"agenda": description,
-		"private_meeting": True,
-		"auto_recording": "none" if auto_recording == "No Recording" else auto_recording.lower(),
 		"timezone": timezone,
+		"settings": {
+			"private_meeting": True,
+			"auto_recording": "none" if auto_recording == "No Recording" else auto_recording.lower(),
+		},
 	}
 	headers = {
 		"Authorization": "Bearer " + authenticate(zoom_account),


### PR DESCRIPTION
## Problem

Live classes were not auto-recording even when auto recording was set to "Cloud". The Zoom Create Meeting API expects `auto_recording` (and `private_meeting`) nested inside the `settings` object, but we sent them as top-level fields — Zoom silently ignores unknown top-level fields, so the setting never took effect and meetings fell back to the host's account-level recording defaults.

## How this PR solves it

Moves `auto_recording` and `private_meeting` into the `settings` object of the meeting creation payload, as required by the Zoom API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)