### PR TITLE
fix: scope evaluator writes to the assigned

### DIFF
--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -253,7 +253,6 @@ const evaluationResource = createResource({
 			status: evaluation.status,
 			rating: evaluation.rating,
 			summary: evaluation.summary,
-			evaluator: props.event.evaluator,
 		}
 	},
 	auto: false,
@@ -313,7 +312,6 @@ const certificateResource = createResource({
 			issue_date: certificate.issue_date,
 			expiry_date: certificate.expiry_date,
 			template: certificate.template,
-			evaluator: props.event.evaluator,
 		}
 	},
 	auto: false,

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -37,6 +37,7 @@ from lms.lms.utils import (
 	can_modify_course,
 	get_batch_details,
 	get_course_details,
+	get_evaluator,
 	get_field_meta,
 	get_instructors,
 	get_lms_route,
@@ -734,7 +735,6 @@ def save_evaluation_details(
 	end_time: str,
 	status: str,
 	batch_name: str = None,
-	evaluator: str = None,
 	rating: float = 0,
 	summary: str = None,
 ):
@@ -742,6 +742,14 @@ def save_evaluation_details(
 	Save evaluation details for a member against a course.
 	"""
 	frappe.only_for(["Batch Evaluator", "Moderator"])
+	assigned_evaluator = get_evaluator(course, batch_name)
+	if not has_moderator_role() and frappe.session.user != assigned_evaluator:
+		frappe.throw(
+			_("You are not the assigned evaluator for this course and batch."),
+			frappe.PermissionError,
+		)
+	evaluator = assigned_evaluator or frappe.session.user
+
 	evaluation = frappe.db.exists("LMS Certificate Evaluation", {"member": member, "course": course})
 
 	details = {
@@ -778,7 +786,6 @@ def save_certificate_details(
 	template: str,
 	course: str = None,
 	batch_name: str = None,
-	evaluator: str = None,
 	expiry_date: str = None,
 	published: bool = True,
 ):
@@ -786,6 +793,14 @@ def save_certificate_details(
 	Save certificate details for a member against a course.
 	"""
 	frappe.only_for(["Batch Evaluator", "Moderator"])
+	assigned_evaluator = get_evaluator(course, batch_name)
+	if not has_moderator_role() and frappe.session.user != assigned_evaluator:
+		frappe.throw(
+			_("You are not the assigned evaluator for this course and batch."),
+			frappe.PermissionError,
+		)
+	evaluator = assigned_evaluator or frappe.session.user
+
 	certificate = frappe.db.exists("LMS Certificate", {"member": member, "course": course})
 
 	details = {


### PR DESCRIPTION
## Summary
- Verify the caller is the assigned evaluator for (course, batch_name) via get_evaluator() before allowing the write;
- Drop the evaluator parameter from both whitelisted methods and derive it server-side as assigned_evaluator or frappe.session.user, eliminating the forgery surface entirely.
- Stop sending evaluator from the single frontend caller (Modals/Event.vue).