### PR TITLE
fix(ui): batch form layout polish and rich-text instructor bios

### DIFF
--- a/cypress/e2e/batch_creation.cy.js
+++ b/cypress/e2e/batch_creation.cy.js
@@ -96,23 +96,22 @@ describe("Batch Creation", () => {
 			.type(
 				"Test Batch Description. I need a very big description to test the UI. This is a very big description. It contains more than once sentence. Its meant to be this long as this is a UI test. Its unbearably long and I'm not sure why I'm typing this much. I'm just going to keep typing until I feel like its long enough. I think its long enough now. I'm going to stop typing now."
 			);
-		/* Instructor */
+		/* Instructor — MultiLink renders a button trigger; its search input
+		   and options live in a popover teleported to <body>. */
 		cy.get("label")
 			.contains("Instructors")
 			.parent()
-			.within(() => {
-				cy.get("input").click().clear().type(randomEvaluator);
-				cy.get("input")
-					.invoke("attr", "aria-controls")
-					.as("instructor_list_id");
-			});
-		cy.get("@instructor_list_id").then((instructor_list_id) => {
-			cy.get(`[id^=${instructor_list_id}`)
-				.should("be.visible")
-				.within(() => {
-					cy.get("[id^=headlessui-combobox-option-").first().click();
-				});
-		});
+			.find("button[data-slot=trigger]")
+			.click();
+		cy.get("[data-slot=content] [data-slot=input]")
+			.should("be.visible")
+			.type(randomEvaluator);
+		cy.get("[data-slot=content] [data-slot=item]")
+			.first()
+			.should("be.visible")
+			.click();
+		// Close the popover so it doesn't overlay the Save button.
+		cy.get("body").type("{esc}");
 		cy.button("Save").click();
 		cy.wait(1000);
 

--- a/cypress/e2e/batch_creation.cy.js
+++ b/cypress/e2e/batch_creation.cy.js
@@ -96,20 +96,20 @@ describe("Batch Creation", () => {
 			.type(
 				"Test Batch Description. I need a very big description to test the UI. This is a very big description. It contains more than once sentence. Its meant to be this long as this is a UI test. Its unbearably long and I'm not sure why I'm typing this much. I'm just going to keep typing until I feel like its long enough. I think its long enough now. I'm going to stop typing now."
 			);
-		/* Instructor — MultiLink renders a button trigger; its search input
-		   and options live in a popover teleported to <body>. */
+		// Instructors — frappe-ui MultiSelect. Click the trigger button;
+		// the search input lives in a popover portalled to body, so we
+		// type it outside the field wrapper.
 		cy.get("label")
 			.contains("Instructors")
 			.parent()
-			.find("button[data-slot=trigger]")
+			.find("button")
+			.first()
 			.click();
-		cy.get("[data-slot=content] [data-slot=input]")
+		cy.get('[data-slot="content-body"] [data-slot="input"]')
 			.should("be.visible")
 			.type(randomEvaluator);
-		cy.get("[data-slot=content] [data-slot=item]")
-			.first()
-			.should("be.visible")
-			.click();
+		cy.wait(500);
+		cy.get('[data-slot="content-body"] [role="option"]').first().click();
 		// Close the popover so it doesn't overlay the Save button.
 		cy.get("body").type("{esc}");
 		cy.button("Save").click();

--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -20,7 +20,7 @@
 			<template #footer>
 				<div
 					data-popover-footer-sticky
-					class="-m-1 border-t border-outline-gray-2 bg-surface-modal p-2"
+					class="-m-1 border-t border-outline-gray-2 bg-surface-modal p-2 mt-1"
 				>
 					<div v-if="creating" class="flex items-center gap-1">
 						<button

--- a/frontend/src/components/Controls/MultiLink.vue
+++ b/frontend/src/components/Controls/MultiLink.vue
@@ -55,7 +55,7 @@
 			<template #footer="{ clearAll }">
 				<slot name="footer" :close="closePopover">
 					<div
-						class="flex items-center justify-between gap-2 border-t border-outline-gray-1 px-2 py-1.5"
+						class="flex items-center justify-between gap-2 border-t border-outline-gray-1 px-2 py-1.5 mt-1"
 					>
 						<Button
 							variant="ghost"

--- a/frontend/src/components/CourseCreatorCard.vue
+++ b/frontend/src/components/CourseCreatorCard.vue
@@ -18,12 +18,11 @@
 					</div>
 				</div>
 			</router-link>
-			<p
-				v-if="instructors[0].bio"
-				class="text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
-			>
-				{{ instructors[0].bio }}
-			</p>
+			<div
+				v-if="hasBio(instructors[0].bio)"
+				v-html="renderBio(instructors[0].bio)"
+				class="ProseMirror prose prose-sm max-w-none text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
+			></div>
 		</template>
 
 		<template v-else>
@@ -39,12 +38,11 @@
 					</div>
 				</div>
 			</router-link>
-			<p
-				v-if="focused?.bio"
-				class="text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
-			>
-				{{ focused.bio }}
-			</p>
+			<div
+				v-if="hasBio(focused?.bio)"
+				v-html="renderBio(focused?.bio)"
+				class="ProseMirror prose prose-sm max-w-none text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
+			></div>
 
 			<div class="mt-4 pt-4 border-t border-outline-gray-2">
 				<div
@@ -83,7 +81,9 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import DOMPurify from 'dompurify'
 import UserAvatar from '@/components/UserAvatar.vue'
+import { decodeEntities, htmlToText } from '@/utils'
 import type { CourseInstructorInfo } from '@/types/api'
 
 const props = defineProps<{
@@ -141,6 +141,30 @@ const headerLabel = computed<string>(() => {
 	if (n <= 4) return __('Taught by')
 	return __('Taught by a team of {0}').format(String(n))
 })
+
+function hasBio(bio?: string | null): boolean {
+	if (!bio) return false
+	return htmlToText(bio).trim().length > 0 || /<img\b/i.test(bio)
+}
+
+function renderBio(bio?: string | null): string {
+	return DOMPurify.sanitize(decodeEntities(bio || ''), {
+		ALLOWED_TAGS: [
+			'b',
+			'i',
+			'em',
+			'strong',
+			'a',
+			'p',
+			'br',
+			'ul',
+			'ol',
+			'li',
+			'img',
+		],
+		ALLOWED_ATTR: ['href', 'target', 'rel', 'src'],
+	})
+}
 
 function profileLink(instructor: CourseInstructorInfo) {
 	return { name: 'Profile', params: { username: instructor.username } }

--- a/frontend/src/components/Modals/BatchCourseModal.vue
+++ b/frontend/src/components/Modals/BatchCourseModal.vue
@@ -20,6 +20,7 @@
 				:label="__('Course')"
 				:required="true"
 				:filters="{ published: 1 }"
+				variant="outline"
 				:onCreate="
 					(value, close) => {
 						close()
@@ -34,6 +35,7 @@
 				doctype="Course Evaluator"
 				v-model="evaluator"
 				:label="__('Evaluator')"
+				variant="outline"
 				:onCreate="(value, close) => openSettings('Evaluators', close)"
 				class="mt-4"
 			/>

--- a/frontend/src/pages/Batches/BatchForm.vue
+++ b/frontend/src/pages/Batches/BatchForm.vue
@@ -137,7 +137,10 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="grid grid-cols-2 gap-5">
+					<div class="text-base font-semibold text-ink-gray-9">
+						{{ __('Batch overview') }}
+					</div>
+					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<MultiLink
 							v-model="instructors"
 							doctype="User"
@@ -149,6 +152,26 @@
 							variant="outline"
 							:onCreate="() => (showMemberModal = true)"
 						/>
+						<Select
+							v-model="batchDetail.doc.medium"
+							:label="__('Medium')"
+							:options="mediumOptions"
+							variant="outline"
+							class="w-full"
+						/>
+						<Link
+							ref="emailTemplateLinkRef"
+							doctype="Email Template"
+							:label="__('Enrollment Confirmation Email Template')"
+							v-model="batchDetail.doc.confirmation_email_template"
+							variant="outline"
+							:onCreate="
+								(value, close) => {
+									if (close) close()
+									showEmailTemplateModal = true
+								}
+							"
+						/>
 						<FormControl
 							v-model="batchDetail.doc.description"
 							:label="__('Short Description')"
@@ -157,8 +180,15 @@
 							:placeholder="__('Short description of the batch')"
 							:required="true"
 							variant="outline"
+							class="md:col-span-2"
 						/>
 					</div>
+					<Uploader
+						v-model="batchDetail.doc.video_link"
+						:label="__('Preview Video')"
+						type="video"
+						:required="false"
+					/>
 					<div class="space-y-1.5">
 						<FormLabel
 							:label="__('Batch Details')"
@@ -177,39 +207,6 @@
 								editorClass="prose-sm max-w-none border-b border-x border-outline-gray-2 hover:border-outline-gray-3 hover:shadow-sm focus-within:border-outline-gray-4 focus-within:shadow-sm rounded-b-md py-1 px-2 min-h-[7rem] max-h-[16rem] overflow-y-scroll transition-colors"
 							/>
 						</div>
-					</div>
-				</div>
-
-				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
-						<div class="space-y-5">
-							<Select
-								v-model="batchDetail.doc.medium"
-								:label="__('Medium')"
-								:options="mediumOptions"
-								variant="outline"
-								class="w-full"
-							/>
-							<Link
-								ref="emailTemplateLinkRef"
-								doctype="Email Template"
-								:label="__('Enrollment Confirmation Email Template')"
-								v-model="batchDetail.doc.confirmation_email_template"
-								variant="outline"
-								:onCreate="
-									(value, close) => {
-										if (close) close()
-										showEmailTemplateModal = true
-									}
-								"
-							/>
-						</div>
-						<Uploader
-							v-model="batchDetail.doc.video_link"
-							:label="__('Preview Video')"
-							type="video"
-							:required="false"
-						/>
 					</div>
 				</div>
 

--- a/frontend/src/pages/Batches/BatchForm.vue
+++ b/frontend/src/pages/Batches/BatchForm.vue
@@ -3,7 +3,7 @@
 		<div class="grid grid-cols-1 lg:grid-cols-[3fr,2fr]">
 			<div v-if="batchDetail.doc" class="py-5 lg:h-[88vh] lg:overflow-y-auto">
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-lg text-ink-gray-9 font-semibold mb-4">
+					<div class="text-base font-semibold text-ink-gray-9">
 						{{ __('Details') }}
 					</div>
 
@@ -12,6 +12,7 @@
 							v-model="batchDetail.doc.title"
 							:label="__('Title')"
 							:required="true"
+							variant="outline"
 							class="w-full"
 						/>
 						<Link
@@ -19,6 +20,7 @@
 							doctype="LMS Category"
 							:label="__('Category')"
 							:inlineCreate="true"
+							variant="outline"
 							:onCreate="createCategory"
 						/>
 						<FormControl
@@ -26,12 +28,14 @@
 							:label="__('Batch Start Date')"
 							type="date"
 							:required="true"
+							variant="outline"
 						/>
 						<FormControl
 							v-model="batchDetail.doc.end_date"
 							:label="__('Batch End Date')"
 							type="date"
 							:required="true"
+							variant="outline"
 						/>
 
 						<FormControl
@@ -39,22 +43,22 @@
 							:label="__('Session Start Time')"
 							type="time"
 							:required="true"
+							variant="outline"
 						/>
 						<FormControl
 							v-model="batchDetail.doc.end_time"
 							:label="__('Session End Time')"
 							type="time"
 							:required="true"
+							variant="outline"
 						/>
-						<div>
-							<label class="block text-sm text-ink-gray-5 mb-1.5">
-								{{ __('Timezone') }}
-								<span class="text-ink-red-3">*</span>
-							</label>
+						<div class="space-y-1.5">
+							<FormLabel :label="__('Timezone')" :required="true" />
 							<Combobox
 								v-model="batchDetail.doc.timezone"
 								:options="timezoneOptions"
 								:placeholder="__('Select timezone')"
+								variant="outline"
 								class="w-full"
 							/>
 						</div>
@@ -63,13 +67,14 @@
 							v-model="batchDetail.doc.seat_count"
 							:label="__('Seat Count')"
 							type="number"
+							variant="outline"
 							:placeholder="__('Number of seats available')"
 						/>
 					</div>
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-lg text-ink-gray-9 font-semibold mb-4">
+					<div class="text-base font-semibold text-ink-gray-9">
 						{{ __('Enrollment & Certification') }}
 					</div>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5 items-start">
@@ -102,12 +107,14 @@
 									v-model="batchDetail.doc.amount"
 									:label="__('Amount')"
 									type="number"
+									variant="outline"
 								/>
 								<Link
 									doctype="Currency"
 									v-model="batchDetail.doc.currency"
 									:filters="{ enabled: 1 }"
 									:label="__('Currency')"
+									variant="outline"
 								/>
 							</div>
 						</div>
@@ -123,6 +130,7 @@
 								v-model="batchDetail.doc.evaluation_end_date"
 								:label="__('Evaluation End Date')"
 								type="date"
+								variant="outline"
 							/>
 						</div>
 					</div>
@@ -130,14 +138,16 @@
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
 					<div class="grid grid-cols-2 gap-5">
-						<MultiSelect
+						<MultiLink
 							v-model="instructors"
 							doctype="User"
-							:label="__('Instructors')"
-							:required="true"
-							:onCreate="() => (showMemberModal = true)"
 							url="lms.lms.api.search_users_by_role"
 							:searchParams="{ roles: JSON.stringify(['Batch Evaluator']) }"
+							:label="__('Instructors')"
+							:placeholder="__('Select instructors')"
+							:required="true"
+							variant="outline"
+							:onCreate="() => (showMemberModal = true)"
 						/>
 						<FormControl
 							v-model="batchDetail.doc.description"
@@ -146,41 +156,46 @@
 							:rows="4"
 							:placeholder="__('Short description of the batch')"
 							:required="true"
+							variant="outline"
 						/>
 					</div>
-					<div>
-						<label class="block text-sm text-ink-gray-5 mb-2">
-							{{ __('Batch Details') }}
-							<span class="text-ink-red-3">*</span>
-						</label>
-						<TextEditor
-							:content="batchDetail.doc.batch_details"
-							@change="(val) => (batchDetail.doc.batch_details = val)"
-							:editable="true"
-							:fixedMenu="true"
-							editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[7rem] max-h-[16rem] overflow-y-scroll mb-4"
+					<div class="space-y-1.5">
+						<FormLabel
+							:label="__('Batch Details')"
+							:id="batchDetailsId"
+							:required="true"
 						/>
+						<div
+							class="rounded-t-lg rounded-b-md outline-none transition-[box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:ring-2 ring-outline-gray-3"
+						>
+							<TextEditor
+								:id="batchDetailsId"
+								:content="batchDetail.doc.batch_details"
+								@change="(val) => (batchDetail.doc.batch_details = val)"
+								:editable="true"
+								:fixedMenu="true"
+								editorClass="prose-sm max-w-none border-b border-x border-outline-gray-2 hover:border-outline-gray-3 hover:shadow-sm focus-within:border-outline-gray-4 focus-within:shadow-sm rounded-b-md py-1 px-2 min-h-[7rem] max-h-[16rem] overflow-y-scroll transition-colors"
+							/>
+						</div>
 					</div>
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<div class="space-y-5">
-							<div>
-								<label class="block text-sm text-ink-gray-5 mb-2">
-									{{ __('Medium') }}
-								</label>
-								<Select
-									v-model="batchDetail.doc.medium"
-									:options="mediumOptions"
-									class="w-full"
-								/>
-							</div>
+							<Select
+								v-model="batchDetail.doc.medium"
+								:label="__('Medium')"
+								:options="mediumOptions"
+								variant="outline"
+								class="w-full"
+							/>
 							<Link
 								ref="emailTemplateLinkRef"
 								doctype="Email Template"
 								:label="__('Enrollment Confirmation Email Template')"
 								v-model="batchDetail.doc.confirmation_email_template"
+								variant="outline"
 								:onCreate="
 									(value, close) => {
 										if (close) close()
@@ -199,7 +214,7 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-lg text-ink-gray-9 font-semibold mb-4">
+					<div class="text-base font-semibold text-ink-gray-9">
 						{{ __('Conferencing') }}
 					</div>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
@@ -207,6 +222,7 @@
 							v-model="batchDetail.doc.conferencing_provider"
 							:options="conferencingOptions"
 							:label="__('Conferencing Provider')"
+							variant="outline"
 							class="w-full"
 						/>
 						<Link
@@ -214,6 +230,7 @@
 							doctype="LMS Zoom Settings"
 							:label="__('Zoom Account')"
 							v-model="batchDetail.doc.zoom_account"
+							variant="outline"
 							:onCreate="
 								(value, close) => {
 									openSettings('Zoom Accounts', close)
@@ -225,6 +242,7 @@
 							doctype="LMS Google Meet Settings"
 							:label="__('Google Meet Account')"
 							v-model="batchDetail.doc.google_meet_account"
+							variant="outline"
 							:onCreate="
 								(value, close) => {
 									openSettings('Google Meet Accounts', close)
@@ -235,7 +253,7 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5">
-					<div class="text-lg text-ink-gray-9 font-semibold">
+					<div class="text-base font-semibold text-ink-gray-9">
 						{{ __('Meta Tags') }}
 					</div>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
@@ -244,6 +262,7 @@
 							:label="__('Meta Description')"
 							type="textarea"
 							:rows="4"
+							variant="outline"
 						/>
 						<FormControl
 							v-model="meta.keywords"
@@ -251,6 +270,7 @@
 							type="textarea"
 							:rows="4"
 							:placeholder="__('Comma separated keywords')"
+							variant="outline"
 						/>
 						<Uploader
 							v-model="batchDetail.doc.meta_image"
@@ -295,10 +315,12 @@ import {
 	toRaw,
 	watch,
 	nextTick,
+	useId,
 } from 'vue'
 import {
 	Combobox,
 	FormControl,
+	FormLabel,
 	TextEditor,
 	createDocumentResource,
 	createResource,
@@ -316,7 +338,7 @@ import {
 import { useRouter } from 'vue-router'
 import { useTelemetry } from 'frappe-ui/frappe'
 import Uploader from '@/components/Controls/Uploader.vue'
-import MultiSelect from '@/components/Controls/MultiSelect.vue'
+import MultiLink from '@/components/Controls/MultiLink.vue'
 import Link from '@/components/Controls/Link.vue'
 import Select from '@/components/Controls/Select.vue'
 import BatchCourses from '@/pages/Batches/components/BatchCourses.vue'
@@ -332,6 +354,7 @@ const { capture } = useTelemetry()
 const { $dialog } = app.appContext.config.globalProperties
 const isDirty = ref(false)
 const originalDoc = ref(null)
+const batchDetailsId = useId()
 const showMemberModal = ref(false)
 const showEmailTemplateModal = ref(false)
 const emailTemplateLinkRef = ref(null)

--- a/frontend/src/pages/Batches/components/NewBatchModal.vue
+++ b/frontend/src/pages/Batches/components/NewBatchModal.vue
@@ -13,6 +13,7 @@
 						v-model="batch.title"
 						:label="__('Title')"
 						:required="true"
+						variant="outline"
 						autocomplete="off"
 					/>
 					<FormControl
@@ -20,34 +21,36 @@
 						:label="__('Start Date')"
 						type="date"
 						:required="true"
+						variant="outline"
 					/>
 					<FormControl
 						v-model="batch.end_date"
 						:label="__('End Date')"
 						type="date"
 						:required="true"
+						variant="outline"
 					/>
 					<FormControl
 						v-model="batch.start_time"
 						:label="__('Start Time')"
 						type="time"
 						:required="true"
+						variant="outline"
 					/>
 					<FormControl
 						v-model="batch.end_time"
 						:label="__('End Time')"
 						type="time"
 						:required="true"
+						variant="outline"
 					/>
-					<div>
-						<label class="block text-sm text-ink-gray-5 mb-1.5">
-							{{ __('Timezone') }}
-							<span class="text-ink-red-3">*</span>
-						</label>
+					<div class="space-y-1.5">
+						<FormLabel :label="__('Timezone')" :required="true" />
 						<Combobox
 							v-model="batch.timezone"
 							:options="timezoneOptions"
 							:placeholder="__('Select timezone')"
+							variant="outline"
 							class="w-full"
 						/>
 					</div>
@@ -55,6 +58,7 @@
 						v-model="batch.category"
 						doctype="LMS Category"
 						:label="__('Category')"
+						variant="outline"
 						:onCreate="createCategory"
 					/>
 					<FormControl
@@ -62,17 +66,15 @@
 						:label="__('Seat Count')"
 						type="number"
 						:required="false"
+						variant="outline"
 					/>
-					<div>
-						<label class="block text-sm text-ink-gray-5 mb-2">
-							{{ __('Medium') }}
-						</label>
-						<Select
-							v-model="batch.medium"
-							:options="mediumOptions"
-							class="w-full"
-						/>
-					</div>
+					<Select
+						v-model="batch.medium"
+						:label="__('Medium')"
+						:options="mediumOptions"
+						variant="outline"
+						class="w-full"
+					/>
 				</div>
 
 				<div class="space-y-5 border-t mt-5 pt-5">
@@ -83,29 +85,38 @@
 							type="textarea"
 							:required="true"
 							:rows="4"
+							variant="outline"
 						/>
-						<MultiSelect
+						<MultiLink
 							v-model="batch.instructors"
 							doctype="User"
-							:label="__('Instructors')"
-							:required="true"
-							:onCreate="() => (showMemberModal = true)"
 							url="lms.lms.api.search_users_by_role"
 							:searchParams="{ roles: JSON.stringify(['Batch Evaluator']) }"
+							:label="__('Instructors')"
+							:placeholder="__('Select instructors')"
+							:required="true"
+							variant="outline"
+							:onCreate="() => (showMemberModal = true)"
 						/>
 					</div>
-					<div class="">
-						<div class="mb-1.5 text-sm text-ink-gray-5">
-							{{ __('Batch Details') }}
-							<span class="text-ink-red-3">*</span>
-						</div>
-						<TextEditor
-							:content="batch.batch_details"
-							@change="(val: string) => (batch.batch_details = val)"
-							:editable="true"
-							:fixedMenu="true"
-							editorClass="prose-sm max-w-none border-b border-x bg-surface-gray-2 rounded-b-md py-1 px-2 min-h-[10rem] max-h-[14rem] overflow-auto"
+					<div class="space-y-1.5">
+						<FormLabel
+							:label="__('Batch Details')"
+							:id="batchDetailsId"
+							:required="true"
 						/>
+						<div
+							class="rounded-t-lg rounded-b-md outline-none transition-[box-shadow] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] focus-within:ring-2 ring-outline-gray-3"
+						>
+							<TextEditor
+								:id="batchDetailsId"
+								:content="batch.batch_details"
+								@change="(val: string) => (batch.batch_details = val)"
+								:editable="true"
+								:fixedMenu="true"
+								editorClass="prose-sm max-w-none border-b border-x border-outline-gray-2 hover:border-outline-gray-3 hover:shadow-sm focus-within:border-outline-gray-4 focus-within:shadow-sm rounded-b-md py-1 px-2 min-h-[10rem] max-h-[14rem] overflow-auto transition-colors"
+							/>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -130,15 +141,16 @@ import {
 	Combobox,
 	Dialog,
 	FormControl,
+	FormLabel,
 	TextEditor,
 	createResource,
 	toast,
 } from 'frappe-ui'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import { computed, inject, onMounted, onBeforeUnmount, ref } from 'vue'
+import { computed, inject, onMounted, onBeforeUnmount, ref, useId } from 'vue'
 import { useRouter } from 'vue-router'
 import { sanitizeHTML, createLMSCategory, cleanError } from '@/utils'
-import MultiSelect from '@/components/Controls/MultiSelect.vue'
+import MultiLink from '@/components/Controls/MultiLink.vue'
 import Link from '@/components/Controls/Link.vue'
 import Select from '@/components/Controls/Select.vue'
 import NewMemberModal from '@/components/Modals/NewMemberModal.vue'
@@ -149,6 +161,7 @@ const { capture } = useTelemetry()
 const { updateOnboardingStep } = useOnboarding('learning')
 const user = inject<any>('$user')
 const showMemberModal = ref(false)
+const batchDetailsId = useId()
 
 const props = defineProps<{
 	batches: any

--- a/frontend/src/pages/Courses/CourseOverview.vue
+++ b/frontend/src/pages/Courses/CourseOverview.vue
@@ -89,6 +89,14 @@
 							variant="list"
 							:count="6"
 						/>
+						<div
+							v-else-if="!hasCourseContent"
+							class="flex items-center justify-center px-4 py-10 text-center"
+						>
+							<span class="text-sm text-ink-gray-5">
+								{{ __('Course Content coming soon!') }}
+							</span>
+						</div>
 						<CourseOutline
 							v-else
 							:courseName="course.data.name"
@@ -188,5 +196,14 @@ const outlineStats = computed(() => {
 		)
 	}
 	return parts.join(' · ')
+})
+
+const hasCourseContent = computed(() => {
+	const chapters = outline.data || []
+	const lessonCount = chapters.reduce(
+		(acc, c) => acc + (c.lessons?.length || 0),
+		0
+	)
+	return chapters.length > 0 && lessonCount > 0
 })
 </script>

--- a/frontend/src/pages/Courses/CourseThumbnailField.vue
+++ b/frontend/src/pages/Courses/CourseThumbnailField.vue
@@ -109,9 +109,9 @@
 								</Button>
 							</template>
 						</FileUploader>
-						<span class="text-p-xs text-ink-gray-5">
-							{{ __('An image will replace the color.') }}
-						</span>
+						<p class="text-p-xs text-ink-gray-5">
+							{{ __('Upload an image to replace the color.') }}
+						</p>
 					</div>
 				</template>
 			</div>

--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -9,7 +9,6 @@ from frappe.utils import validate_url
 
 from lms.lms.utils import get_lms_route
 
-
 PRIVILEGED_ROLES = {"Moderator", "Course Creator", "Batch Evaluator", "System Manager"}
 
 

--- a/lms/lms/doctype/lms_assignment_submission/test_lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/test_lms_assignment_submission.py
@@ -9,15 +9,9 @@ from lms.lms.test_helpers import BaseTestUtils
 class TestLMSAssignmentSubmission(BaseTestUtils):
 	def setUp(self):
 		super().setUp()
-		self.student_a = self._create_user(
-			"rtv.student.a@example.com", "Student", "Alpha", ["LMS Student"]
-		)
-		self.student_b = self._create_user(
-			"rtv.student.b@example.com", "Student", "Bravo", ["LMS Student"]
-		)
-		self.moderator = self._create_user(
-			"rtv.moderator@example.com", "Mod", "Erator", ["Moderator"]
-		)
+		self.student_a = self._create_user("rtv.student.a@example.com", "Student", "Alpha", ["LMS Student"])
+		self.student_b = self._create_user("rtv.student.b@example.com", "Student", "Bravo", ["LMS Student"])
+		self.moderator = self._create_user("rtv.moderator@example.com", "Mod", "Erator", ["Moderator"])
 		self.assignment = self._create_assignment()
 
 	def tearDown(self):


### PR DESCRIPTION
## Summary
- Batch forms: consistent variant="outline" inputs, FormLabel instead of raw labels, MultiSelect→MultiLink for Instructors, restructured layout, focus-ring on TextEditor.
- Instructor bios: render sanitized rich HTML (DOMPurify) instead of plain text.
- Misc: popover footer spacing, "Course Content coming soon!" empty state, reworded thumbnail helper text.