### PR TITLE
feat(lesson): gate private lesson media, SCORM

### DIFF
--- a/frontend/src/components/UploadPlugin.vue
+++ b/frontend/src/components/UploadPlugin.vue
@@ -1,6 +1,7 @@
 <template>
 	<FileUploader
 		:fileTypes="['image/*', 'video/*', 'audio/*', '.pdf']"
+		:uploadArgs="uploadArgs"
 		:validateFile="validateFile"
 		@success="(data) => addFile(data)"
 		ref="fileUploader"
@@ -9,7 +10,7 @@
 </template>
 <script setup>
 import { FileUploader } from 'frappe-ui'
-import { onMounted, ref, nextTick } from 'vue'
+import { onMounted, ref, nextTick, computed } from 'vue'
 
 const fileUploader = ref(null)
 const emit = defineEmits(['fileUploaded'])
@@ -19,7 +20,22 @@ const props = defineProps({
 		type: Function,
 		required: true,
 	},
+	docname: {
+		type: String,
+		default: null,
+	},
+	fieldname: {
+		type: String,
+		default: 'content',
+	},
 })
+
+const uploadArgs = computed(() => ({
+	private: true,
+	doctype: 'Course Lesson',
+	docname: props.docname,
+	fieldname: props.fieldname,
+}))
 
 onMounted(async () => {
 	await nextTick()

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -53,6 +53,11 @@ const editor = ref(null)
 const instructorEditor = ref(null)
 const user = inject('$user')
 const openInstructorEditor = ref(false)
+const contentUploadContext = { docname: null, fieldname: 'content' }
+const instructorUploadContext = {
+	docname: null,
+	fieldname: 'instructor_content',
+}
 const { capture } = useTelemetry()
 const { updateOnboardingStep } = useOnboarding('learning')
 let autoSaveInterval
@@ -88,21 +93,24 @@ onMounted(() => {
 		window.location.href = '/login'
 	}
 	capture('lesson_form_opened')
-	editor.value = renderEditor('content')
-	instructorEditor.value = renderEditor('instructor-notes')
+	editor.value = renderEditor('content', contentUploadContext)
+	instructorEditor.value = renderEditor(
+		'instructor-notes',
+		instructorUploadContext
+	)
 	window.addEventListener('keydown', keyboardShortcut)
 	enablePlyr()
 })
 
-const renderEditor = (holder) => {
+const renderEditor = (holder, uploadContext = {}) => {
 	return new EditorJS({
 		holder: holder,
-		tools: getEditorTools(true),
+		tools: getEditorTools(false, uploadContext),
 		defaultBlock: 'markdown',
 		i18n: {
 			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',
 		},
-		onChange: async (api, event) => {
+		onChange: async () => {
 			enablePlyr()
 			markDirty()
 		},
@@ -133,6 +141,8 @@ const lessonDetails = createResource({
 			lesson.include_in_preview = data?.lesson?.include_in_preview
 				? true
 				: false
+			contentUploadContext.docname = data.lesson.name
+			instructorUploadContext.docname = data.lesson.name
 			addLessonContent(data)
 			addInstructorNotes(data)
 			enableAutoSave()

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -117,7 +117,7 @@ export function htmlToText(html) {
 	return div.textContent || div.innerText || ''
 }
 
-export function getEditorTools() {
+export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 	return {
 		header: {
 			class: Header,
@@ -132,7 +132,10 @@ export function getEditorTools() {
 				defaultStyle: 'ordered',
 			},
 		},
-		upload: Upload,
+		upload: {
+			class: Upload,
+			config: uploadContext,
+		},
 		table: {
 			class: Table,
 			inlineToolbar: true,

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -7,9 +7,10 @@ import { createDialog } from '@/utils/dialogs'
 import translationPlugin from '../translation'
 
 export class Upload {
-	constructor({ data, api, readOnly }) {
+	constructor({ data, api, config, readOnly }) {
 		this.data = data
 		this.readOnly = readOnly
+		this.config = config || {}
 	}
 
 	static get toolbox() {
@@ -81,6 +82,8 @@ export class Upload {
 
 	renderFileUploader() {
 		const app = createApp(UploadPlugin, {
+			docname: this.config.docname || null,
+			fieldname: this.config.fieldname || 'content',
 			onFileUploaded: (file) => {
 				this.data.file_url = file.file_url
 				this.data.file_type = file.file_type

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -48,6 +48,19 @@ export default defineConfig(async ({ mode }) => {
 		server: {
 			host: '0.0.0.0', // Accept connections from any network interface
 			allowedHosts: true,
+			// SCORM packages are served by Frappe's SCORMRenderer at /scorm/... .
+			// frappeProxy only forwards ^/(desk|app|login|api|assets|files|private),
+			// so without this the iframe's /scorm URL hits the SPA fallback and renders
+			// blank. The `router` mirrors frappeProxy: Frappe resolves the site from the
+			// Host header, so we must forward to http://<site>:8000 — a bare 127.0.0.1
+			// target makes Frappe 404 with "127.0.0.1 does not exist". (Backend :8000.)
+			proxy: {
+				'/scorm': {
+					target: 'http://127.0.0.1:8000',
+					router: (req) =>
+						`http://${req.headers.host.split(':')[0]}:8000`,
+				},
+			},
 		},
 		resolve: {
 			alias: {

--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -98,6 +98,8 @@ has_permission = {
 	"LMS Batch": "lms.lms.doctype.lms_batch.lms_batch.has_permission",
 	"LMS Program": "lms.lms.doctype.lms_program.lms_program.has_permission",
 	"LMS Certificate": "lms.lms.doctype.lms_certificate.lms_certificate.has_permission",
+	"Course Lesson": "lms.lms.doctype.course_lesson.course_lesson.has_permission",
+	"File": "lms.lms.permissions.file_has_permission",
 }
 
 # DocType Class

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -1062,9 +1062,9 @@ def upsert_chapter(
 		values.update(
 			{
 				"scorm_package": scorm_package.name,
-				"scorm_package_path": extract_path.split("public")[1],
-				"manifest_file": get_manifest_file(extract_path).split("public")[1],
-				"launch_file": get_launch_file(extract_path).split("public")[1],
+				"scorm_package_path": _scorm_url(extract_path),
+				"manifest_file": _scorm_url(get_manifest_file(extract_path)),
+				"launch_file": _scorm_url(get_launch_file(extract_path)),
 			}
 		)
 
@@ -1092,11 +1092,19 @@ def upsert_chapter(
 	return chapter
 
 
+def _scorm_url(abs_path: str) -> str:
+	"""Map an extracted SCORM disk path under <site>/private/scorm/... to the
+	location-independent "/scorm/<course>/<title>/..." URL stored on Course Chapter.
+	Keeps the same URL shape legacy (public) chapters already have, so no DB change."""
+	rel = os.path.relpath(abs_path, frappe.get_site_path("private"))
+	return "/" + rel.replace(os.sep, "/")
+
+
 def extract_package(course: str, title: str, scorm_package: dict):
 	package = frappe.get_doc("File", scorm_package.name)
 	zip_path = package.get_full_path()
-	scorm_root = os.path.realpath(frappe.get_site_path("public", "scorm"))
-	extract_path = frappe.get_site_path("public", "scorm", course, title)
+	scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
+	extract_path = frappe.get_site_path("private", "scorm", course, title)
 
 	if not os.path.realpath(extract_path).startswith(scorm_root + os.sep):
 		frappe.throw(_("Invalid course or chapter name"))

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -2,14 +2,22 @@
 # For license information, please see license.txt
 
 import json
+from urllib.parse import unquote
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.realtime import get_website_room
+from frappe.utils.response import send_private_file
 from frappe.utils.telemetry import capture
 
-from lms.lms.utils import get_course_progress, is_demo_course, recalculate_course_progress, sanitize_editorjs
+from lms.lms.permissions import INSTRUCTOR_FIELDS, can_access_lesson
+from lms.lms.utils import (
+	get_course_progress,
+	is_demo_course,
+	recalculate_course_progress,
+	sanitize_editorjs,
+)
 
 from ...md import find_macros
 
@@ -71,6 +79,113 @@ class CourseLesson(Document):
 						"lesson": self.name,
 					},
 				)
+
+
+def has_permission(doc, ptype="read", user=None):
+	user = user or frappe.session.user
+	if ptype not in ("read", "select", "print"):
+		# Authoring (create/write/delete): mirror sibling LMS hooks — Moderators
+		# and Course Creators manage lessons; otherwise fall back to per-course
+		# instructor/moderator via the rule.
+		roles = frappe.get_roles(user)
+		if "Moderator" in roles or "Course Creator" in roles:
+			return True
+		return can_access_lesson(doc.name, instructor_only=True, user=user)
+	# Read/select/print: the security gate — enrollment / preview / instructor only.
+	# Deliberately NOT widened to all Course Creators, to preserve the media-access
+	# boundary (matches the original get_lesson gate).
+	return can_access_lesson(doc.name, user=user)
+
+
+# Lesson content fields a student may reach vs. instructor-only fields (gated harder).
+STUDENT_CONTENT_FIELDS = ("content", "body")
+
+
+def _like_escape(value: str) -> str:
+	"""Escape LIKE wildcards so a file_url containing % or _ matches literally."""
+	return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _resolve_lesson_references(file_url: str) -> list[tuple[str, bool]]:
+	"""Every (lesson, instructor_only) pair that references file_url.
+
+	Two sources, unioned:
+	- File attachments (fast path) — gives the exact attached_to_field.
+	- A search of the lesson content fields (the source of truth: uploaded files
+	  are frequently private-but-unattached, and pre-existing/seeded files always are).
+	An empty/unknown attachment field is treated as instructor-only (fail-closed).
+	"""
+	refs: list[tuple[str, bool]] = []
+
+	for r in frappe.db.get_all(
+		"File",
+		filters={"file_url": file_url, "is_private": 1, "attached_to_doctype": "Course Lesson"},
+		fields=["attached_to_name", "attached_to_field"],
+	):
+		if r.attached_to_name:
+			refs.append(
+				(r.attached_to_name, r.attached_to_field in INSTRUCTOR_FIELDS or not r.attached_to_field)
+			)
+
+	pattern = f"%{_like_escape(file_url)}%"
+	fields = [(f, False) for f in STUDENT_CONTENT_FIELDS] + [(f, True) for f in INSTRUCTOR_FIELDS]
+	for field, instructor_only in fields:
+		for row in frappe.db.get_all("Course Lesson", filters={field: ["like", pattern]}, fields=["name"]):
+			refs.append((row.name, instructor_only))
+
+	return refs
+
+
+@frappe.whitelist(allow_guest=True)
+def serve_resource(file_url: str):
+	"""Access-gated streaming of private lesson media for all users.
+
+	Native /private/files/ needs a Course Lesson read role-perm that LMS students and
+	guests don't hold, and it hard-refuses Guest — so ALL private lesson media is served
+	here instead (get_lesson rewrites embedded URLs to this endpoint for every user).
+	The owning lesson is resolved from the lesson content (source of truth) and from any
+	File attachment, then gated by the same can_access_lesson rule.
+	"""
+	if not isinstance(file_url, str):
+		frappe.throw(_("file_url must be a string"))
+
+	# URLs are percent-encoded in transit; decode before matching the File row / lesson
+	# content (which store the decoded path) and before the traversal check, so encoded
+	# spaces (%20) resolve and encoded traversal (%2e%2e) is still caught.
+	file_url = unquote(file_url)
+
+	if ".." in file_url:
+		frappe.throw(_("Invalid file path"))
+
+	file_row = frappe.db.get_value("File", {"file_url": file_url, "is_private": 1}, "file_name", as_dict=True)
+	if not file_row:
+		_deny(file_url, "no matching private file")
+		raise frappe.PermissionError
+
+	references = _resolve_lesson_references(file_url)
+	if not references:
+		_deny(file_url, "file not referenced by any lesson")
+		raise frappe.PermissionError
+
+	# Serve if the caller may reach the bytes through ANY referencing lesson.
+	if not any(
+		can_access_lesson(lesson, instructor_only=instructor_only) for lesson, instructor_only in references
+	):
+		_deny(file_url, "can_access_lesson denied for all references")
+		raise frappe.PermissionError
+
+	# send_private_file expects a path relative to the site's private/ dir.
+	relative_path = file_url.split("/private", 1)[1] if "/private" in file_url else file_url
+	return send_private_file(relative_path, filename=file_row.file_name)
+
+
+def _deny(file_url, reason):
+	frappe.logger("lms.security").warning(
+		"Lesson resource access denied: user=%s file_url=%s reason=%s",
+		frappe.session.user,
+		file_url,
+		reason,
+	)
 
 
 def apply_enforcement_flags(quiz_done: bool, assignment_done: bool, settings: dict) -> tuple[bool, bool]:

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, Frappe and Contributors
+# For license information, please see license.txt
+
+"""Shared access-control helpers for LMS lesson media.
+
+Centralizes the cross-doctype permission logic that the Course Lesson controller,
+the serve_resource endpoint, the SCORM renderer, and the File has_permission hook
+all rely on — mirroring the dedicated permissions module pattern used by frappe
+core (frappe/permissions.py), CRM (crm.permissions.*), and Raven (raven.permissions).
+"""
+
+import frappe
+
+from lms.lms.utils import can_modify_course, get_membership, guest_access_allowed
+
+# File fields that hold instructor-only lesson media (never served to students).
+INSTRUCTOR_FIELDS = {"instructor_content", "instructor_notes"}
+
+
+def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str | None = None) -> bool:
+	"""Single source of truth for who may read a lesson's resources.
+
+	- instructors / moderators (can_modify_course) → all media (incl. instructor files)
+	- instructor_only=True → only the above; enrolled students denied
+	- else (student media): enrolled member OR (published course AND include_in_preview
+	  AND guest access allowed)
+	"""
+	if not isinstance(lesson, str) or not lesson:
+		return False
+
+	lesson_row = frappe.db.get_value("Course Lesson", lesson, ["course", "include_in_preview"], as_dict=True)
+	if not lesson_row:
+		return False
+
+	original_user = frappe.session.user
+	user = user or original_user
+	try:
+		# can_modify_course / get_membership / guest_access_allowed read session.user.
+		frappe.session.user = user
+		if can_modify_course(lesson_row.course):
+			return True
+		if instructor_only:
+			return False
+		if get_membership(lesson_row.course, user):
+			return True
+		# Preview is for prospective students of a LIVE course. Require the course to be
+		# published so draft lessons don't leak via this gate (matches get_course_details,
+		# which already hides unpublished courses from non-authors). Instructors/members
+		# are handled above, so unpublishing never locks them out.
+		if (
+			lesson_row.include_in_preview
+			and frappe.db.get_value("LMS Course", lesson_row.course, "published")
+			and guest_access_allowed()
+		):
+			return True
+		return False
+	finally:
+		frappe.session.user = original_user
+
+
+def file_has_permission(doc, ptype="read", user=None):
+	"""File has_permission hook: deny-only tightening for instructor-only lesson files.
+
+	For private Files attached to a Course Lesson via instructor_content /
+	instructor_notes, deny ALL access (read and authoring) to anyone who cannot
+	author the course. For every other File, return True (no opinion) so the
+	student/native serving path is unaffected.
+
+	Instructor-only access == can author the course == can_access_lesson with
+	instructor_only=True, so delegate to it (the single source of truth) rather
+	than re-implementing the course lookup / session swap. This is fail-closed: a
+	missing/deleted owning lesson makes can_access_lesson return False, denying the
+	orphaned instructor file.
+	"""
+	user = user or frappe.session.user
+
+	if doc.attached_to_doctype != "Course Lesson":
+		return True
+	if doc.attached_to_field not in INSTRUCTOR_FIELDS:
+		return True
+
+	if can_access_lesson(doc.attached_to_name, instructor_only=True, user=user):
+		return True
+
+	frappe.logger("lms.security").warning(
+		"Lesson resource access denied: user=%s file=%s field=%s lesson=%s",
+		user,
+		doc.name,
+		doc.attached_to_field,
+		doc.attached_to_name,
+	)
+	return False

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import re
+from urllib.parse import quote
 
 import frappe
 import requests
@@ -258,6 +259,17 @@ def get_lesson_icon(body: str, content: str):
 			return "icon-quiz"
 
 	return "icon-list"
+
+
+def rewrite_private_media(content: str) -> str:
+	if not content:
+		return content
+	endpoint = "/api/method/lms.lms.doctype.course_lesson.course_lesson.serve_resource?file_url="
+	return re.sub(
+		r"/private/files/([^\"'\\]+)",
+		lambda m: endpoint + quote(m.group(0)),
+		content,
+	)
 
 
 def get_instructors(doctype: str, docname: str):
@@ -1201,7 +1213,11 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 		as_dict=1,
 	)
 
-	if not lesson_details.include_in_preview and not membership and not can_modify_course(course):
+	# Local import: permissions imports from utils at module load, so importing it
+	# at the top of utils would create a cycle.
+	from lms.lms.permissions import can_access_lesson
+
+	if not can_access_lesson(lesson_name):
 		return {
 			"no_preview": 1,
 			"title": lesson_details.title,
@@ -1227,6 +1243,13 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 	lesson_details.paid_certificate = course_info.paid_certificate
 	lesson_details.disable_self_learning = course_info.disable_self_learning
 	lesson_details.videos = get_video_details(lesson_name)
+
+	# Rewrite for EVERYONE, not just guests: native /private/files/ needs a Course
+	# Lesson read role-perm that students/guests lack, so all private media is routed
+	# through the access-gated serve_resource endpoint.
+	lesson_details.content = rewrite_private_media(lesson_details.content)
+	lesson_details.instructor_content = rewrite_private_media(lesson_details.instructor_content)
+
 	return lesson_details
 
 

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -5,6 +5,7 @@ Handles rendering of profile pages.
 
 import mimetypes
 import os
+from urllib.parse import unquote
 
 import frappe
 from frappe.website.page_renderers.base_renderer import BaseRenderer
@@ -16,10 +17,51 @@ class SCORMRenderer(BaseRenderer):
 	def can_render(self):
 		return "scorm/" in self.path
 
+	# Disk roots tried, in order, to resolve SCORM bytes. New packages are extracted
+	# under private/scorm (gated: /private is always routed through Frappe, so this
+	# permission gate runs in production too). Legacy packages already extracted under
+	# public/scorm are still served as a fallback — but the standard bench nginx config
+	# serves public/ directly (try_files .../public/$uri @webserver), so for those legacy
+	# files this Python gate is BYPASSED in production, exactly as before. Such packages
+	# stay ungated in prod until re-uploaded (re-extraction lands them in private). New
+	# uploads are gated in dev and prod alike.
+	_DISK_ROOTS = ("private", "public")
+
+	def _check_permission(self):
+		from lms.lms.permissions import can_access_lesson
+
+		parts = self.path.strip("/").split("/")
+		# scorm/<course>/<title>/...
+		if len(parts) < 3 or parts[0] != "scorm":
+			raise frappe.PermissionError
+		course, title = unquote(parts[1]), unquote(parts[2])
+
+		chapter = frappe.db.get_value(
+			"Course Chapter",
+			{"course": course, "title": title, "is_scorm_package": 1},
+			"name",
+		)
+		if not chapter:
+			raise frappe.PermissionError
+
+		# SCORM chapters are created with exactly one lesson (upsert_chapter invariant
+		# in api.py). order_by keeps the access check deterministic if that ever changes.
+		lesson = frappe.db.get_value("Lesson Reference", {"parent": chapter}, "lesson", order_by="idx asc")
+		if not lesson or not can_access_lesson(lesson):
+			frappe.logger("lms.security").warning(
+				"SCORM resource access denied: user=%s path=%s",
+				frappe.session.user,
+				self.path,
+			)
+			raise frappe.PermissionError
+
 	def _is_safe_path(self, path):
-		scorm_root = os.path.realpath(os.path.join(frappe.local.site_path, "public", "scorm"))
 		resolved = os.path.realpath(path)
-		return resolved.startswith(scorm_root + os.sep) or resolved == scorm_root
+		for base in self._DISK_ROOTS:
+			scorm_root = os.path.realpath(os.path.join(frappe.local.site_path, base, "scorm"))
+			if resolved == scorm_root or resolved.startswith(scorm_root + os.sep):
+				return True
+		return False
 
 	def _serve_file(self, path):
 		f = open(path, "rb")
@@ -28,7 +70,15 @@ class SCORMRenderer(BaseRenderer):
 		return response
 
 	def render(self):
-		path = os.path.join(frappe.local.site_path, "public", self.path.lstrip("/"))
+		self._check_permission()
+		# Try private/scorm first (new, gated), then public/scorm (legacy).
+		for base in self._DISK_ROOTS:
+			response = self._render_from_root(base)
+			if response is not None:
+				return response
+
+	def _render_from_root(self, base):
+		path = os.path.join(frappe.local.site_path, base, self.path.lstrip("/"))
 
 		if not self._is_safe_path(path):
 			raise frappe.PermissionError
@@ -48,7 +98,7 @@ class SCORMRenderer(BaseRenderer):
 					return self._serve_file(index_path)
 			elif not os.path.exists(path):
 				chapter_folder = "/".join(self.path.split("/")[:3])
-				chapter_folder_path = os.path.realpath(frappe.get_site_path("public", chapter_folder))
+				chapter_folder_path = os.path.realpath(frappe.get_site_path(base, chapter_folder))
 				file = path.split("/")[-1]
 				correct_file_path = None
 
@@ -62,3 +112,4 @@ class SCORMRenderer(BaseRenderer):
 
 				if correct_file_path and self._is_safe_path(correct_file_path):
 					return self._serve_file(correct_file_path)
+		return None


### PR DESCRIPTION
## Summary
- gate private lesson media, SCORM; previously this was public.

## Changes
- permissions.py: Adds can_access_lesson as the single source of truth for lesson access: instructors/moderators, enrolled members, or guests viewing a preview lesson of a published course. Adds file_has_permission, a deny-only File hook for instructor-only attachments that delegates to the same rule and fails closed.
- Uploads are private
- serve_resource — Streams private media to any request that passes the access gate. get_lesson rewrites embedded /private/files/... URLs to this endpoint at read time, so nothing stored changes and the editor path is untouched.
- SCORM: New packages extract to private/scorm and serve through SCORMRenderer's gate.
- vite: Adds a /scorm dev proxy to fix the blank iframe on :8080 (dev-only).