### PR TITLE
fix: apply role filter to Members Load More

### DIFF
--- a/frontend/src/components/Settings/Members.vue
+++ b/frontend/src/components/Settings/Members.vue
@@ -176,12 +176,7 @@ const roleOptions = [
 	{ label: __('Evaluator'), value: 'Batch Evaluator' },
 ]
 
-const displayedMembers = computed(() =>
-	memberList.value.filter(
-		(member) =>
-			currentRole.value === 'All' || member.roles?.includes(currentRole.value)
-	)
-)
+const displayedMembers = computed(() => memberList.value)
 const memberList = ref<Member[]>([])
 const hasNextPage = ref(false)
 const showNewMember = ref(false)
@@ -210,6 +205,7 @@ const members = createResource({
 		return {
 			search: search.value,
 			start: start.value,
+			role: currentRole.value,
 		}
 	},
 	onSuccess(data: Member[]) {
@@ -242,7 +238,7 @@ const onMemberCreated = (data: any) => {
 	refreshMembers()
 }
 
-watch(search, () => {
+watch([search, currentRole], () => {
 	refreshMembers()
 })
 

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -679,10 +679,26 @@ def update_chapter_index(chapter: str, course: str, idx: int):
 
 
 @frappe.whitelist()
-def get_members(start: int = 0, search: str = None):
+def get_members(start: int = 0, search: str = None, role: str = "All"):
 	frappe.only_for(["Moderator"])
-	filters = {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]}
+
+	lms_roles = ["Moderator", "Course Creator", "Batch Evaluator", "LMS Student"]
+	if not isinstance(role, str) or role not in (["All"] + lms_roles):
+		frappe.throw(_("Invalid role filter."), frappe.ValidationError)
+	if search is not None and not isinstance(search, str):
+		frappe.throw(_("Invalid search query."), frappe.ValidationError)
+
+	filters = [
+		["enabled", "=", 1],
+		["name", "not in", ["Administrator", "Guest"]],
+	]
 	or_filters = {}
+
+	if role != "All":
+		role_users = frappe.get_all("Has Role", {"role": role, "parenttype": "User"}, pluck="parent")
+		if not role_users:
+			return []
+		filters.append(["name", "in", role_users])
 
 	if search:
 		or_filters["full_name"] = ["like", f"%{search}%"]
@@ -697,7 +713,6 @@ def get_members(start: int = 0, search: str = None):
 		start=start,
 	)
 
-	lms_roles = ["Moderator", "Course Creator", "Batch Evaluator", "LMS Student"]
 	for member in members:
 		roles = frappe.get_all(
 			"Has Role",


### PR DESCRIPTION
The role dropdown in Settings > Members was a client-side filter over already-fetched pages, while get_members only received search + start. Load More then pulled the next unfiltered page from the server, which the role filter mostly hid — leaving an empty list with Load More still shown.

Filter by role server-side: get_members takes a validated role param and filters Users via Has Role. The frontend passes currentRole in makeParams, reloads on role change, and drops the redundant client-side filter.