### PR TITLE
fix: stop settings form focus rings from clipping at scroll edge

### DIFF
--- a/frontend/src/components/Layouts/SettingsLayout.vue
+++ b/frontend/src/components/Layouts/SettingsLayout.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-col h-full min-h-0 text-base">
-		<header class="flex items-start justify-between mb-5">
+		<header class="flex items-start justify-between p-8">
 			<div class="flex flex-col gap-1 max-w-3xl">
 				<!-- Back button sits in the left gutter, vertically centered on the
 				     title line (Helpdesk pattern) so it reads as part of the heading
@@ -31,9 +31,15 @@
 			</div>
 		</header>
 
-		<slot name="header-bottom" />
+		<div v-if="$slots['header-bottom']" class="px-8">
+			<slot name="header-bottom" />
+		</div>
 
-		<div class="flex-1 min-h-0 overflow-y-auto">
+		<!-- Scroll container owns the horizontal padding so focus rings on
+		     controls aren't clipped at the scroll edge (CRM SettingsLayoutBase
+		     pattern). overflow-y:auto forces overflow-x to clip, so flush
+		     controls need this breathing room. -->
+		<div class="flex-1 min-h-0 overflow-y-auto px-8 pb-8">
 			<slot />
 		</div>
 	</div>

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="overflow-y-auto">
+	<div>
 		<template v-for="(section, index) in sections" :key="index">
 			<!-- Divider only between topics (sections), never between fields -->
 			<div v-if="index > 0" class="h-px border-t border-outline-gray-modals" />

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -31,7 +31,7 @@
 				<div
 					v-if="activeTab && data.doc"
 					:key="activeTab.label"
-					class="flex flex-1 flex-col p-8 bg-surface-modal overflow-x-auto overflow-y-auto"
+					class="flex flex-1 flex-col bg-surface-modal overflow-hidden"
 				>
 					<component
 						v-if="activeTab.template"


### PR DESCRIPTION
Settings controls (frappe-ui Select uses focus-visible:ring-2, a 2px ring outside the box) had their focus ring clipped because the settings panel nested three scroll containers and the two inner ones had no padding. overflow-y:auto forces overflow-x to clip, so a control flush to the scroll edge loses its ring.

| Before | After |
| ---- | ---- |
| <img width="1796" height="1571" alt="image" src="https://github.com/user-attachments/assets/700ed125-898c-45f1-9eaa-cea8b82f59c5" /> | <img width="1796" height="1571" alt="image" src="https://github.com/user-attachments/assets/9916199a-d073-4d65-a036-3e3b53460d68" /> |

