### PR TITLE
Fix lms billing razorpay hardcoded

### DIFF
--- a/frontend/src/pages/Billing.vue
+++ b/frontend/src/pages/Billing.vue
@@ -246,6 +246,7 @@ import {
 } from 'frappe-ui'
 import { reactive, inject, onMounted, computed, ref, watch } from 'vue'
 import { sessionStore } from '../stores/session'
+import { useSettings } from '@/stores/settings'
 import Link from '@/components/Controls/Link.vue'
 import NotPermitted from '@/components/NotPermitted.vue'
 import { X } from 'lucide-vue-next'
@@ -256,11 +257,14 @@ const user = inject('$user')
 const { brand } = sessionStore()
 const showConsentWarning = ref(false)
 const { capture } = useTelemetry()
+const settings = useSettings()
 
 onMounted(() => {
-	const script = document.createElement('script')
-	script.src = `https://checkout.razorpay.com/v1/checkout.js`
-	document.body.appendChild(script)
+	if (settings.data?.payment_gateway === 'Razorpay') {
+		const script = document.createElement('script')
+		script.src = `https://checkout.razorpay.com/v1/checkout.js`
+		document.body.appendChild(script)
+	}
 	if (user.data?.name) {
 		access.submit()
 	}

--- a/lms/lms/payments.py
+++ b/lms/lms/payments.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 from lms.lms.utils import (
 	complete_enrollment,
@@ -33,6 +34,11 @@ def get_payment_link(
 	country: str | None = None,
 ):
 	payment_gateway = get_payment_gateway()
+	if not payment_gateway:
+		frappe.throw(
+			_("No payment gateway is configured. Please contact the administrator."),
+			frappe.ValidationError,
+		)
 	address = frappe._dict(address)
 	redirect_to = get_redirect_url(doctype, docname, payment_for_certificate)
 
@@ -66,7 +72,15 @@ def get_payment_link(
 		complete_enrollment(payment.name, doctype, docname)
 		return redirect_to
 
-	controller = get_controller(payment_gateway)
+	try:
+		controller = get_controller(payment_gateway)
+	except frappe.DoesNotExistError:
+		frappe.throw(
+			_("Payment gateway '{0}' is not properly configured. Please contact the administrator.").format(
+				payment_gateway
+			),
+			frappe.ValidationError,
+		)
 
 	payment_details = {
 		"amount": total_amount,


### PR DESCRIPTION
Fixes frappe/lms#2458

## What

Billing.vue's onMounted hook unconditionally injects the Razorpay
checkout script on every page load, regardless of which payment
gateway the operator has configured in LMS Settings. When the operator
uses Stripe (or any non-Razorpay gateway from the `payments` app),
this leads to:

1. A red 404 in the Network tab on
   `checkout-static-next.razorpay.com/build/undefined` (the Razorpay
   script's auto-loader fetches a path-derived bundle that becomes
   'undefined' when no API key is set).
2. The Razorpay script may interfere with the student checkout flow
   (overlapping toast/dialog), masking the actual error from the
   configured gateway.

## Why

For non-Razorpay operators (Stripe, Paymob, Braintree, etc.), every
billing page load produces a visible error in DevTools, and the
checkout UX is degraded by a third-party script that should not be
loaded.

## How

Only inject the Razorpay checkout script when
`LMS Settings.payment_gateway === 'Razorpay'`. The `useSettings`
Pinia store already loads LMS Settings on app boot, so we just read
`settings.data?.payment_gateway` in onMounted.