### PR TITLE
feat(lms): redesign the lesson editor — inline title, instructor notes, shared BlockEditor

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -24,6 +24,7 @@ declare module 'vue' {
     BadgeForm: typeof import('./src/components/Settings/BadgeForm.vue')['default']
     Badges: typeof import('./src/components/Settings/Badges.vue')['default']
     BatchCourseModal: typeof import('./src/components/Modals/BatchCourseModal.vue')['default']
+    BlockEditor: typeof import('./src/components/BlockEditor.vue')['default']
     BrandSettings: typeof import('./src/components/Settings/BrandSettings.vue')['default']
     Categories: typeof import('./src/components/Settings/Categories.vue')['default']
     CertificationLinks: typeof import('./src/components/CertificationLinks.vue')['default']

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "codemirror": "6.0.1",
     "dayjs": "1.11.10",
     "dompurify": "3.2.6",
+    "editorjs-drag-drop": "1.1.16",
     "feather-icons": "4.28.0",
     "frappe-ui": "^1.0.0-beta.7",
     "highlight.js": "11.11.1",

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -1,0 +1,72 @@
+<template>
+	<div
+		ref="holderRef"
+		class="bn-editor ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal mx-2"
+	></div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import EditorJS from '@editorjs/editorjs'
+import DragDrop from 'editorjs-drag-drop'
+import { enablePlyr, getEditorTools } from '@/utils'
+
+const props = defineProps({
+	uploadContext: {
+		type: Object,
+		default: () => ({}),
+	},
+})
+
+const emit = defineEmits(['change'])
+
+const holderRef = ref(null)
+let editor = null
+
+onMounted(() => {
+	editor = new EditorJS({
+		holder: holderRef.value,
+		tools: getEditorTools(false, props.uploadContext),
+		defaultBlock: 'markdown',
+		i18n: {
+			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',
+		},
+		onReady: () => {
+			// Native EditorJS block menu (the ⋮⋮ settings button → Convert to
+			// H1/H2/…, Move up/down, Delete) plus editorjs-drag-drop, which makes
+			// that settings button a drag handle so blocks reorder by dragging.
+			new DragDrop(editor)
+		},
+		onChange: async () => {
+			enablePlyr()
+			emit('change')
+		},
+	})
+})
+
+onBeforeUnmount(() => {
+	const instance = editor
+	editor = null
+	instance?.isReady.then(() => instance.destroy()).catch(() => {})
+})
+
+defineExpose({
+	isReady: () => editor.isReady,
+	render: (data) => editor.render(data),
+	save: () => editor.save(),
+	// Put a blinking caret in the editor, ready to type. Prefers EditorJS's own
+	// placement, but falls back to the first editable element when the boundary
+	// block isn't focusable (e.g. a lesson that opens on a video embed).
+	focus: (atEnd = false) => {
+		if (!editor) return
+		editor.caret?.focus(atEnd)
+		if (holderRef.value?.contains(document.activeElement)) return
+		holderRef.value
+			?.querySelector('.codex-editor__redactor [contenteditable="true"]')
+			?.focus()
+	},
+})
+</script>
+
+<!-- Editor chrome styles live in src/styles/blockEditor.css (global on
+     purpose: EditorJS renders outside Vue's scope-attribute reach). -->

--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -95,12 +95,6 @@
 								/>
 								{{ lesson.title }}
 								<div v-if="allowEdit" class="ms-auto flex items-center gap-2">
-									<Tooltip :text="__('Edit lesson')" placement="bottom">
-										<span
-											@click.prevent="emit('edit-lesson', { chapter, lesson })"
-											class="lucide-file-pen-line h-4 w-4 text-ink-gray-9 invisible group-hover:visible"
-										/>
-									</Tooltip>
 									<span
 										@click.prevent="
 											emit('delete-lesson', {
@@ -170,7 +164,6 @@ const emit = defineEmits<{
 	'delete-lesson': [{ lesson: string; chapter: string }]
 	'move-lesson': [DraggableEvent]
 	'add-lesson': [{ chapter: OutlineChapter; lessonIdx: number }]
-	'edit-lesson': [{ chapter: OutlineChapter; lesson: OutlineLesson }]
 }>()
 
 const route = useRoute()

--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -7,6 +7,7 @@
 					'rtl:rotate-180': !open,
 					hidden: chapter.is_scorm_package,
 					open: index == 1,
+					'self-start mt-0.5': inlineSelect,
 				}"
 				class="lucide-chevron-right size-4 text-ink-gray-9 stroke-1 transform duration-200"
 			/>

--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -66,7 +66,6 @@
 							"
 							@move-lesson="updateOutline"
 							@add-lesson="openLessonModalForAdd"
-							@edit-lesson="openLessonModalForEdit"
 						/>
 					</div>
 				</template>
@@ -89,7 +88,6 @@
 		:lessonIdx="lessonContext.lessonIdx"
 		:lessonDetail="lessonContext.lessonDetail"
 		@created="onLessonCreated"
-		@updated="onLessonUpdated"
 	/>
 </template>
 
@@ -169,23 +167,6 @@ function openLessonModalForAdd(payload: {
 	showLessonModal.value = true
 }
 
-function openLessonModalForEdit(payload: {
-	chapter: OutlineChapter
-	lesson: OutlineLesson
-}) {
-	lessonContext.value = {
-		chapterName: payload.chapter.name,
-		chapterIdx: payload.chapter.idx,
-		lessonIdx: Number(payload.lesson.number.split('-')[1]) || 1,
-		lessonDetail: {
-			name: payload.lesson.name,
-			title: payload.lesson.title,
-			include_in_preview: payload.lesson.include_in_preview,
-		},
-	}
-	showLessonModal.value = true
-}
-
 function onLessonCreated(created: { name: string; number: string }) {
 	outline.reload()
 	const ctx = lessonContext.value
@@ -207,10 +188,6 @@ function onLessonCreated(created: { name: string; number: string }) {
 			},
 		})
 	}
-}
-
-function onLessonUpdated(_payload: { name: string }) {
-	outline.reload()
 }
 
 const props = withDefaults(

--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -76,9 +76,10 @@
 	<ChapterModal
 		v-if="user.data"
 		v-model="showChapterModal"
-		v-model:outline="outline"
 		:course="courseName"
 		:chapterDetail="currentChapter"
+		@created="outline.reload()"
+		@updated="outline.reload()"
 	/>
 	<LessonModal
 		v-if="user.data && lessonContext"
@@ -290,6 +291,7 @@ const updateLessonIndex = createResource({
 		return values
 	},
 	onSuccess() {
+		outline.reload()
 		toast.success(__('Lesson moved successfully'))
 	},
 })
@@ -300,6 +302,7 @@ const updateChapterIndex = createResource({
 		return values
 	},
 	onSuccess() {
+		outline.reload()
 		toast.success(__('Chapter moved successfully'))
 	},
 })

--- a/frontend/src/components/Modals/ChapterModal.vue
+++ b/frontend/src/components/Modals/ChapterModal.vue
@@ -84,7 +84,7 @@ import Switch from '@/components/Controls/Switch.vue'
 import { reactive, watch, inject } from 'vue'
 import { getFileSize } from '@/utils/'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
-import type { ChapterDetailInput, Resource, SessionUser } from '@/types/api'
+import type { ChapterDetailInput, SessionUser } from '@/types/api'
 
 type ScormPackage = { file_name: string; file_size: number } | null
 
@@ -95,7 +95,7 @@ interface ChapterForm {
 }
 
 const show = defineModel<boolean>()
-const outline = defineModel<Resource<unknown> | undefined>('outline')
+const emit = defineEmits<{ created: []; updated: [] }>()
 const user = inject<SessionUser>('$user')!
 const { capture } = useTelemetry()
 const { updateOnboardingStep } = useOnboarding('learning')
@@ -140,7 +140,7 @@ const addChapter = async (close: () => void) => {
 
 				capture('chapter_created')
 				cleanChapter()
-				outline.value?.reload()
+				emit('created')
 				toast.success(__('Chapter added successfully'))
 				close()
 			},
@@ -177,7 +177,7 @@ const editChapter = (close: () => void) => {
 				}
 			},
 			onSuccess() {
-				outline.value?.reload()
+				emit('updated')
 				toast.success(__('Chapter updated successfully'))
 				close()
 			},

--- a/frontend/src/components/Modals/LessonModal.vue
+++ b/frontend/src/components/Modals/LessonModal.vue
@@ -9,15 +9,6 @@
 					autocomplete="off"
 					@keyup.enter="submit"
 				/>
-				<Switch
-					v-model="lesson.include_in_preview"
-					:label="__('Include in Preview')"
-					:description="
-						__(
-							'If enabled, the lesson will also be accessible to users who are not enrolled in the course.'
-						)
-					"
-				/>
 			</div>
 		</template>
 		<template #actions>
@@ -30,7 +21,6 @@
 
 <script setup lang="ts">
 import { Dialog, FormControl, Button, createResource, toast } from 'frappe-ui'
-import Switch from '@/components/Controls/Switch.vue'
 import { computed, reactive, ref, watch } from 'vue'
 import { useTelemetry } from 'frappe-ui/frappe'
 
@@ -77,12 +67,11 @@ const fetchLesson = createResource({
 	makeParams: () => ({
 		doctype: 'Course Lesson',
 		filters: { name: props.lessonDetail?.name },
-		fieldname: ['title', 'include_in_preview'],
+		fieldname: ['title'],
 	}),
-	onSuccess(data: { title?: string; include_in_preview?: 0 | 1 } | undefined) {
+	onSuccess(data: { title?: string } | undefined) {
 		if (!data) return
 		if (data.title != null) lesson.title = data.title
-		lesson.include_in_preview = data.include_in_preview ? 1 : 0
 	},
 })
 
@@ -91,9 +80,7 @@ watch(
 	([open, detail]) => {
 		if (!open) return
 		lesson.title = detail?.title ?? ''
-		lesson.include_in_preview = detail?.include_in_preview ? 1 : 0
-		// Outline rows don't carry include_in_preview — hydrate from the doc
-		// so the toggle reflects current state instead of always off.
+		// Refresh the title from the doc in case the outline row is stale.
 		if (detail?.name) fetchLesson.reload()
 	},
 	{ immediate: true }
@@ -136,7 +123,6 @@ const updateLesson = createResource({
 		name: props.lessonDetail?.name,
 		fieldname: {
 			title: lesson.title,
-			include_in_preview: lesson.include_in_preview,
 		},
 	}),
 })

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,5 +1,10 @@
 export {}
 
+declare module '*.svg?raw' {
+  const content: string
+  export default content
+}
+
 declare global {
   function __(text: string): string
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 @import 'frappe-ui/style.css';
 @import './styles/codemirror.css';
+@import './styles/blockEditor.css';
 
 /*
  * Pin a Combobox/MultiSelect footer to the bottom of its dropdown so footer

--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -32,24 +32,9 @@
 					</Tooltip>
 				</template>
 				<template v-if="tabIndex === 2 && editorSelected">
-					<template v-if="editorMode === 'edit'">
-						<Badge v-if="courseEditorRef?.isDirty" theme="orange">
-							{{ __('Not Saved') }}
-						</Badge>
-						<Tooltip
-							:text="courseEditorRef?.isDirty ? '' : __('No changes to save')"
-							:hoverDelay="0.1"
-						>
-							<Button
-								variant="solid"
-								:disabled="!courseEditorRef?.isDirty"
-								@click="courseEditorRef?.saveSelectedLesson()"
-							>
-								{{ __('Save') }}
-							</Button>
-						</Tooltip>
-					</template>
-					<template v-else-if="editorMode === 'preview'">
+					<!-- Edit mode autosaves continuously, so there is no Save
+					     button or dirty badge here. -->
+					<template v-if="editorMode === 'preview'">
 						<Tooltip v-if="courseEditorRef?.canGoZen" :text="__('Zen Mode')">
 							<Button @click="courseEditorRef?.previewZen()">
 								<template #icon>

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -22,6 +22,7 @@
 					:courseName="props.course.data.name"
 					:chapterNumber="selected.chapterNumber"
 					:lessonNumber="selected.lessonNumber"
+					@saved="onLessonSaved"
 				/>
 				<Lesson
 					v-else
@@ -69,9 +70,10 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createResource } from 'frappe-ui'
+import { useSidebar } from '@/stores/sidebar'
 import CourseOutline from '@/components/CourseOutline.vue'
 import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -86,6 +88,17 @@ const selected = defineModel('selected', { default: null })
 const mode = defineModel('mode', { default: 'edit' })
 const route = useRoute()
 const router = useRouter()
+
+// Collapse the app sidebar while the lesson editor is open to give the
+// editing surface room, then restore it on leaving the tab. Mirrors the
+// student-facing Lesson.vue pattern.
+const sidebarStore = useSidebar()
+onMounted(() => {
+	sidebarStore.isSidebarCollapsed = true
+})
+onBeforeUnmount(() => {
+	sidebarStore.isSidebarCollapsed = false
+})
 
 // Keep ?editLesson + ?lessonMode in sync with what's selected so a refresh,
 // tab-switch round-trip, or shared URL lands on the same lesson in the same
@@ -156,6 +169,25 @@ function setSelectedFromNumber(number) {
 	syncSelectedToUrl(number)
 }
 
+// Reflect an autosaved lesson title/preview-flag in the shared outline
+// resource. `outline` here is the same cached instance CourseOutline renders,
+// so mutating it in place updates the sidebar with no extra request. A brand
+// new lesson needs a reload to pull in its outline row.
+function onLessonSaved({ name, title, include_in_preview, isNew }) {
+	if (isNew) {
+		outline.reload()
+		return
+	}
+	for (const chapter of outline.data ?? []) {
+		const lesson = chapter.lessons?.find((l) => l.name === name)
+		if (lesson) {
+			lesson.title = title
+			lesson.include_in_preview = include_in_preview ? 1 : 0
+			break
+		}
+	}
+}
+
 function onSelectLesson({ chapterNumber, lessonNumber }) {
 	const number = `${chapterNumber}-${lessonNumber}`
 	selected.value = { chapterNumber, lessonNumber, number, title: '' }
@@ -209,6 +241,29 @@ function pickInitialLesson() {
 }
 
 watch(() => outline.data, pickInitialLesson, { immediate: true })
+
+// When the selected lesson disappears from the outline (e.g. it was just
+// deleted), drop back to the empty "choose a lesson" state instead of
+// editing a lesson that no longer exists.
+watch(
+	() => outline.data,
+	(chapters) => {
+		if (
+			selected.value?.number &&
+			chapters &&
+			!lessonExists(chapters, selected.value.number)
+		) {
+			selected.value = null
+			if (route.query.editLesson) {
+				const { editLesson, ...rest } = route.query
+				router.replace({
+					query: rest,
+					hash: route.hash || '#course editor',
+				})
+			}
+		}
+	}
+)
 
 watch(
 	() => props.course?.data?.name,

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -1,64 +1,113 @@
 <template>
-	<div class="py-5">
-		<div class="mt-0">
-			<div class="w-5/6 mx-auto pt-4">
-				<div
-					class="flex items-center gap-1 w-fit cursor-pointer mb-1"
-					@click="
-						() => {
-							openInstructorEditor = !openInstructorEditor
-						}
-					"
-				>
-					<label class="block font-medium text-ink-gray-5 cursor-pointer">
-						{{ __('Instructor Notes') }}
-					</label>
-					<span
-						class="lucide-chevron-right size-5 text-ink-gray-5 transform duration-200"
-						:class="{
-							'rotate-90': openInstructorEditor,
-							'rtl:rotate-180': !openInstructorEditor,
-						}"
-					/>
+	<div class="py-10">
+		<div class="mx-10 space-y-6 px-20">
+			<!-- Include-in-preview control row -->
+			<div class="flex items-center gap-3">
+				<Switch v-model="lesson.include_in_preview" @change="markDirty" />
+				<div class="flex items-baseline gap-1.5">
+					<span class="text-p-base font-medium text-ink-gray-8">
+						{{ __('Include in preview') }}
+					</span>
+					<span class="text-p-sm text-ink-gray-5">
+						{{
+							lesson.include_in_preview
+								? __('Anyone can preview')
+								: __('Enrolled students only')
+						}}
+					</span>
 				</div>
-				<div
-					v-show="openInstructorEditor"
-					id="instructor-notes"
-					class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal py-3"
-				></div>
 			</div>
-		</div>
-		<div class="border-t mt-4">
-			<div class="w-5/6 mx-auto pt-4">
-				<label class="block font-medium text-ink-gray-5 mb-1">
-					{{ __('Content') }}
-				</label>
-				<div
-					id="content"
-					class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal py-3"
-				></div>
-			</div>
+
+			<!-- Inline-editable lesson title -->
+			<textarea
+				ref="titleRef"
+				v-model="lesson.title"
+				:placeholder="__('Lesson title')"
+				rows="1"
+				class="lesson-title w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-3xl font-bold leading-tight text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
+				@input="onTitleInput"
+			/>
+
+			<!-- Instructor notes card (native disclosure) -->
+			<details
+				class="instructor-notes rounded-lg border border-outline-gray-2"
+				@toggle="onInstructorNotesToggle"
+			>
+				<summary
+					class="flex w-full cursor-pointer items-center gap-2 px-4 py-3 text-start"
+				>
+					<NotebookPen class="size-4 stroke-1.5 text-ink-gray-7" />
+					<span class="text-p-base font-medium text-ink-gray-8">
+						{{ __('Instructor notes') }}
+					</span>
+					<Badge
+						variant="subtle"
+						theme="gray"
+						size="sm"
+						:label="__('private')"
+					/>
+					<ChevronRight
+						class="instructor-notes-chevron ms-auto size-4 stroke-2 text-ink-gray-5"
+					/>
+				</summary>
+				<BlockEditor
+					ref="instructorEditor"
+					class="instructor-notes-editor border-t border-outline-gray-2 py-3"
+					:uploadContext="instructorUploadContext"
+					@change="markDirty"
+				/>
+			</details>
+
+			<!-- Lesson content -->
+			<BlockEditor
+				ref="editor"
+				:uploadContext="contentUploadContext"
+				@change="markDirty"
+			/>
 		</div>
 	</div>
 </template>
 <script setup>
-import { createResource, toast } from 'frappe-ui'
+import { Badge, Switch, createResource, toast } from 'frappe-ui'
 import {
 	reactive,
 	onMounted,
 	inject,
 	ref,
+	nextTick,
 	onBeforeUnmount,
-	computed,
 } from 'vue'
-import EditorJS from '@editorjs/editorjs'
-import { getEditorTools, enablePlyr, sanitizeEditorJs } from '@/utils'
+import { ChevronRight, NotebookPen } from 'lucide-vue-next'
+import { useDebounceFn } from '@vueuse/core'
+import { enablePlyr, sanitizeEditorJs } from '@/utils'
+import { hasInstructorContent, hasEditorContent } from '@/utils/lessonForm'
+import BlockEditor from '@/components/BlockEditor.vue'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 
 const editor = ref(null)
 const instructorEditor = ref(null)
 const user = inject('$user')
-const openInstructorEditor = ref(false)
+const titleRef = ref(null)
+
+function onTitleInput() {
+	autoGrowTitle()
+	markDirty()
+}
+
+// Put the caret in the instructor-notes editor when the card is opened, so it's
+// ready to type. EditorJS can't focus while the <details> is collapsed
+// (display: none), so this has to wait for the open toggle.
+function onInstructorNotesToggle(event) {
+	if (event.target.open) instructorEditor.value?.focus()
+}
+
+function autoGrowTitle() {
+	const el = titleRef.value
+	if (!el) return
+	el.style.height = 'auto'
+	el.style.height = `${el.scrollHeight}px`
+}
+
 const contentUploadContext = { docname: null, fieldname: 'content' }
 const instructorUploadContext = {
 	docname: null,
@@ -66,8 +115,13 @@ const instructorUploadContext = {
 }
 const { capture } = useTelemetry()
 const { updateOnboardingStep } = useOnboarding('learning')
-let autoSaveInterval
-let showSuccessMessage = false
+
+const emit = defineEmits(['saved'])
+
+// Set true only once the initial content has finished rendering, so the
+// onChange events EditorJS fires during programmatic render() don't trigger a
+// spurious autosave on load.
+let initialLoadComplete = false
 
 const props = defineProps({
 	courseName: {
@@ -85,12 +139,21 @@ const props = defineProps({
 })
 
 const isDirty = ref(false)
+
+// Debounced so a burst of keystrokes collapses into a single save shortly
+// after the user pauses.
+const autoSave = useDebounceFn(() => {
+	if (isDirty.value) saveLesson()
+}, 800)
+
 function markDirty() {
-	if (lessonDetails.data?.lesson) isDirty.value = true
+	if (!lessonDetails.data?.lesson || !initialLoadComplete) return
+	isDirty.value = true
+	autoSave()
 }
 
 defineExpose({
-	saveLesson: () => saveLesson({ showSuccessMessage: true }),
+	saveLesson,
 	isDirty,
 })
 
@@ -99,29 +162,9 @@ onMounted(() => {
 		window.location.href = '/login'
 	}
 	capture('lesson_form_opened')
-	editor.value = renderEditor('content', contentUploadContext)
-	instructorEditor.value = renderEditor(
-		'instructor-notes',
-		instructorUploadContext
-	)
 	window.addEventListener('keydown', keyboardShortcut)
 	enablePlyr()
 })
-
-const renderEditor = (holder, uploadContext = {}) => {
-	return new EditorJS({
-		holder: holder,
-		tools: getEditorTools(false, uploadContext),
-		defaultBlock: 'markdown',
-		i18n: {
-			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',
-		},
-		onChange: async () => {
-			enablePlyr()
-			markDirty()
-		},
-	})
-}
 
 const lesson = reactive({
 	title: '',
@@ -149,22 +192,34 @@ const lessonDetails = createResource({
 				: false
 			contentUploadContext.docname = data.lesson.name
 			instructorUploadContext.docname = data.lesson.name
-			addLessonContent(data)
-			addInstructorNotes(data)
-			enableAutoSave()
-			// Initial population isn't user input.
-			isDirty.value = false
+			nextTick(autoGrowTitle)
+			Promise.all([addLessonContent(data), addInstructorNotes(data)]).then(
+				() => {
+					nextTick(() => {
+						// Initial population isn't user input; only arm autosave
+						// once the editors have rendered the loaded content.
+						isDirty.value = false
+						initialLoadComplete = true
+						// Blinking caret ready in the lesson body on open.
+						editor.value?.focus()
+					})
+				}
+			)
 		}
 	},
 })
 
 const addLessonContent = (data) => {
-	editor.value.isReady.then(() => {
+	// Return the render promise so callers (autosave arming, autofocus) wait for
+	// the blocks to actually be in the DOM, not just for render() to be called.
+	return editor.value.isReady().then(() => {
 		if (data.lesson.content) {
-			editor.value.render(sanitizeEditorJs(JSON.parse(data.lesson.content)))
+			return editor.value.render(
+				sanitizeEditorJs(JSON.parse(data.lesson.content))
+			)
 		} else if (data.lesson.body) {
 			let blocks = convertToJSON(data.lesson)
-			editor.value.render({
+			return editor.value.render({
 				blocks: blocks,
 			})
 		}
@@ -172,24 +227,18 @@ const addLessonContent = (data) => {
 }
 
 const addInstructorNotes = (data) => {
-	instructorEditor.value.isReady.then(() => {
+	return instructorEditor.value.isReady().then(() => {
 		if (data.lesson.instructor_content) {
-			instructorEditor.value.render(
+			return instructorEditor.value.render(
 				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content))
 			)
 		} else if (data.lesson.instructor_notes) {
 			let blocks = convertToJSON(data.lesson)
-			instructorEditor.value.render({
+			return instructorEditor.value.render({
 				blocks: blocks,
 			})
 		}
 	})
-}
-
-const enableAutoSave = () => {
-	autoSaveInterval = setInterval(() => {
-		saveLesson({ showSuccessMessage: false })
-	}, 10000)
 }
 
 const keyboardShortcut = (e) => {
@@ -198,13 +247,14 @@ const keyboardShortcut = (e) => {
 		(e.ctrlKey || e.metaKey) &&
 		!e.target.classList.contains('ProseMirror')
 	) {
-		saveLesson({ showSuccessMessage: true })
+		saveLesson()
 		e.preventDefault()
 	}
 }
 
 onBeforeUnmount(() => {
-	clearInterval(autoSaveInterval)
+	// Best-effort flush of any unsaved edits before the editors are destroyed.
+	if (isDirty.value) saveLesson()
 	window.removeEventListener('keydown', keyboardShortcut)
 })
 
@@ -357,13 +407,18 @@ const convertToJSON = (lessonData) => {
 	return blocks
 }
 
-const saveLesson = (e) => {
-	showSuccessMessage = false
-	if (typeof e != 'undefined' && e.showSuccessMessage) {
-		showSuccessMessage = true
-	}
+function saveLesson() {
+	// The debounced autosave can fire as the component tears down; bail if the
+	// editors are already gone.
+	if (!editor.value || !instructorEditor.value) return
 	editor.value.save().then((outputData) => {
 		outputData = removeEmptyBlocks(outputData)
+		// Guard against wiping a lesson: a transient/empty editor (hot-reload
+		// remount, render race, mid lesson-switch) serialises to just an empty
+		// paragraph. Refuse to overwrite stored content with a blank doc. A
+		// genuinely new lesson with real content still has blocks, so this only
+		// blocks blank saves — which validateLesson would reject anyway.
+		if (!hasEditorContent(outputData)) return
 		lesson.content = JSON.stringify(outputData)
 		instructorEditor.value.save().then((outputData) => {
 			outputData = removeEmptyBlocks(outputData)
@@ -403,6 +458,7 @@ const createNewLesson = () => {
 							capture('lesson_created')
 							toast.success(__('Lesson created successfully'))
 							isDirty.value = false
+							emit('saved', { isNew: true })
 							lessonDetails.reload()
 						},
 					}
@@ -425,10 +481,13 @@ const editCurrentLesson = () => {
 				return validateLesson()
 			},
 			onSuccess() {
-				showSuccessMessage
-					? toast.success(__('Lesson updated successfully'))
-					: ''
 				isDirty.value = false
+				emit('saved', {
+					name: lessonDetails.data.lesson.name,
+					title: lesson.title,
+					include_in_preview: lesson.include_in_preview,
+					isNew: false,
+				})
 			},
 			onError(err) {
 				toast.error(err.message)
@@ -447,228 +506,38 @@ const validateLesson = () => {
 }
 </script>
 <style>
-.embed-tool__caption,
-.cdx-simple-image__caption {
+/* Native <details> disclosure: drop the default marker triangle and drive the
+   chevron rotation off the [open] state instead of a JS toggle. */
+.instructor-notes > summary {
+	list-style: none;
+}
+.instructor-notes > summary::-webkit-details-marker {
 	display: none;
 }
-
-.ce-block__content {
-	max-width: none;
+.instructor-notes-chevron {
+	transition: transform 200ms;
+}
+.instructor-notes[open] .instructor-notes-chevron {
+	transform: rotate(90deg);
+}
+[dir='rtl'] .instructor-notes:not([open]) .instructor-notes-chevron {
+	transform: rotate(180deg);
 }
 
-.ce-toolbar__actions,
-.codex-editor--narrow .ce-toolbar__actions {
-	right: auto;
-	left: auto;
-	inset-inline-end: 100%;
+/* Indent the instructor-notes editor so EditorJS's block controls (the +
+   add button and drag handle, which live in the left gutter and span ~70px)
+   sit fully inside the bordered card instead of spilling into the page
+   margin. Scoped so the full-width content editor is unaffected. */
+.instructor-notes-editor .ce-block__content,
+.instructor-notes-editor .ce-toolbar__content {
+	margin-inline-start: 4.5rem;
 }
 
-.codex-editor--narrow .codex-editor__redactor {
-	margin-inline: 0;
-}
-
-.ce-toolbar__content {
-	max-width: none;
-}
-
-.codeBoxHolder {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	align-items: flex-start;
-}
-
-.codeBoxTextArea {
-	width: 100%;
-	min-height: 30px;
-	padding: 10px;
-	border-radius: 2px 2px 2px 0;
-	border: none !important;
-	outline: none !important;
-	font: 14px monospace;
-}
-
-.codeBoxSelectDiv {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	align-items: flex-start;
-	position: relative;
-}
-
-.codeBoxSelectInput {
-	border-radius: 0 0 20px 2px;
-	padding: 2px 26px;
-	padding-top: 0;
-	padding-inline-end: 0;
-	text-align: start;
-	cursor: pointer;
-	border: none !important;
-	outline: none !important;
-}
-
-.codeBoxSelectDropIcon {
-	position: absolute !important;
-	inset-inline-start: 10px !important;
-	bottom: 0 !important;
-	width: unset !important;
-	height: unset !important;
-	font-size: 16px !important;
-}
-
-.codeBoxSelectPreview {
-	display: none;
-	flex-direction: column;
-	justify-content: flex-start;
-	align-items: flex-start;
-	border-radius: 2px;
-	box-shadow: 0 3px 15px -3px rgba(13, 20, 33, 0.13);
-	position: absolute;
-	top: 100%;
-	margin: 5px 0;
-	max-height: 30vh;
-	overflow-x: hidden;
-	overflow-y: auto;
-	z-index: 10000;
-}
-
-.codeBoxSelectItem {
-	width: 100%;
-	padding: 5px 20px;
-	margin: 0;
-	cursor: pointer;
-}
-
-.codeBoxSelectedItem {
-	background-color: lightblue !important;
-}
-
-.codeBoxShow {
-	display: flex !important;
-}
-
-.dark {
-	color: #abb2bf;
-	background-color: #282c34;
-}
-
-.light {
-	color: #383a42;
-	background-color: #fafafa;
-}
-
-.codeBoxTextArea {
-	line-height: 1.7;
-}
-
-.prose :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
-	overflow-x: unset;
-}
-
-iframe {
-	border: none !important;
-}
-
-.tc-table {
-	border-inline-start: 1px solid #e8e8eb;
-}
-
-.ce-toolbox__button[data-tool='markdown'] {
-	display: none !important;
-}
-
-.ce-popover-item[data-item-name='markdown'] {
-	display: none !important;
-}
-
-.plyr__volume input[type='range'] {
-	display: none;
-}
-
-.plyr__control--overlaid {
-	background: radial-gradient(
-		circle,
-		rgba(0, 0, 0, 0.4) 0%,
-		rgba(0, 0, 0, 0.5) 50%
-	);
-}
-
-.plyr__control:hover {
-	background: none;
-}
-
-.plyr--video {
-	border: 1px solid theme('colors.gray.200');
-	border-radius: 8px;
-}
-
-.ce-popover__container {
-	border-radius: 12px;
-	padding: 8px;
-}
-
-.ce-popover,
-.codex-editor--narrow .ce-toolbox .ce-popover,
-.codex-editor--narrow .ce-toolbar__actions .ce-popover {
-	border-radius: 12px;
-	right: auto;
-	left: auto;
-	inset-inline-start: 0;
-}
-
-.cdx-search-field {
-	border: none;
-}
-
-.cdx-search-field__input {
-	font-weight: 400;
-	font-size: 13px;
-}
-
-.cdx-search-field__input::before {
-	font-weight: 400;
-}
-
-.cdx-search-field__input:focus {
-	--tw-ring-color: theme('colors.gray.100');
-}
-
-.ce-popover-item__title {
-	font-size: 13px;
-	font-weight: 400;
-}
-
-.ce-popover-item__icon svg {
-	width: 15px;
-	height: 15px;
-}
-
-.ce-popover-item__icon {
-	margin-right: unset;
-	margin-inline-end: 10px;
-}
-
-.ce-popover--opened {
-	max-height: unset !important;
-}
-
-.cdx-search-field__icon svg {
-	width: 15px;
-	height: 15px;
-}
-
-.cdx-search-field__icon {
-	margin-inline-end: 5px;
-}
-
-.cdx-block.embed-tool {
-	position: relative;
-	display: inline-block;
-	width: 100%;
-}
-
-:root {
-	--plyr-range-fill-background: white;
-	--plyr-video-control-background-hover: transparent;
+/* Both editors are .codex-editor siblings with z-index: 1, so the content
+   editor (later in the DOM) paints over the instructor editor's popovers —
+   the popover's z-index: 4 is trapped inside its editor's stacking context.
+   Lift the instructor editor one level so its + menu renders on top. */
+.instructor-notes-editor .codex-editor {
+	z-index: 2;
 }
 </style>

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -4,17 +4,21 @@
 			<!-- Include-in-preview control row -->
 			<div class="flex items-center gap-3">
 				<Switch v-model="lesson.include_in_preview" @change="markDirty" />
-				<div class="flex items-baseline gap-1.5">
+				<div class="flex items-center gap-1.5">
 					<span class="text-p-base font-medium text-ink-gray-8">
 						{{ __('Include in preview') }}
 					</span>
-					<span class="text-p-sm text-ink-gray-5">
-						{{
-							lesson.include_in_preview
-								? __('Anyone can preview')
-								: __('Enrolled students only')
-						}}
-					</span>
+					<Tooltip
+						:text="
+							__(
+								'When on, anyone can preview this lesson without enrolling. Otherwise it is visible only to enrolled students.'
+							)
+						"
+					>
+						<span
+							class="lucide-help-circle size-4 shrink-0 text-ink-gray-5"
+						/>
+					</Tooltip>
 				</div>
 			</div>
 
@@ -68,7 +72,7 @@
 	</div>
 </template>
 <script setup>
-import { Badge, Switch, createResource, toast } from 'frappe-ui'
+import { Badge, Switch, createResource, toast, Tooltip } from 'frappe-ui'
 import {
 	reactive,
 	onMounted,
@@ -80,7 +84,7 @@ import {
 import { ChevronRight, NotebookPen } from 'lucide-vue-next'
 import { useDebounceFn } from '@vueuse/core'
 import { enablePlyr, sanitizeEditorJs } from '@/utils'
-import { hasInstructorContent, hasEditorContent } from '@/utils/lessonForm'
+import { hasEditorContent } from '@/utils/lessonForm'
 import BlockEditor from '@/components/BlockEditor.vue'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 
@@ -203,7 +207,7 @@ const lessonDetails = createResource({
 						// Blinking caret ready in the lesson body on open.
 						editor.value?.focus()
 					})
-				}
+				},
 			)
 		}
 	},
@@ -215,7 +219,7 @@ const addLessonContent = (data) => {
 	return editor.value.isReady().then(() => {
 		if (data.lesson.content) {
 			return editor.value.render(
-				sanitizeEditorJs(JSON.parse(data.lesson.content))
+				sanitizeEditorJs(JSON.parse(data.lesson.content)),
 			)
 		} else if (data.lesson.body) {
 			let blocks = convertToJSON(data.lesson)
@@ -230,7 +234,7 @@ const addInstructorNotes = (data) => {
 	return instructorEditor.value.isReady().then(() => {
 		if (data.lesson.instructor_content) {
 			return instructorEditor.value.render(
-				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content))
+				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content)),
 			)
 		} else if (data.lesson.instructor_notes) {
 			let blocks = convertToJSON(data.lesson)
@@ -461,13 +465,13 @@ const createNewLesson = () => {
 							emit('saved', { isNew: true })
 							lessonDetails.reload()
 						},
-					}
+					},
 				)
 			},
 			onError(err) {
 				toast.error(err.messages?.[0] || err)
 			},
-		}
+		},
 	)
 }
 
@@ -492,7 +496,7 @@ const editCurrentLesson = () => {
 			onError(err) {
 				toast.error(err.message)
 			},
-		}
+		},
 	)
 }
 

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -15,9 +15,7 @@
 							)
 						"
 					>
-						<span
-							class="lucide-help-circle size-4 shrink-0 text-ink-gray-5"
-						/>
+						<span class="lucide-help-circle size-4 shrink-0 text-ink-gray-5" />
 					</Tooltip>
 				</div>
 			</div>
@@ -207,7 +205,7 @@ const lessonDetails = createResource({
 						// Blinking caret ready in the lesson body on open.
 						editor.value?.focus()
 					})
-				},
+				}
 			)
 		}
 	},
@@ -219,7 +217,7 @@ const addLessonContent = (data) => {
 	return editor.value.isReady().then(() => {
 		if (data.lesson.content) {
 			return editor.value.render(
-				sanitizeEditorJs(JSON.parse(data.lesson.content)),
+				sanitizeEditorJs(JSON.parse(data.lesson.content))
 			)
 		} else if (data.lesson.body) {
 			let blocks = convertToJSON(data.lesson)
@@ -234,7 +232,7 @@ const addInstructorNotes = (data) => {
 	return instructorEditor.value.isReady().then(() => {
 		if (data.lesson.instructor_content) {
 			return instructorEditor.value.render(
-				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content)),
+				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content))
 			)
 		} else if (data.lesson.instructor_notes) {
 			let blocks = convertToJSON(data.lesson)
@@ -465,13 +463,13 @@ const createNewLesson = () => {
 							emit('saved', { isNew: true })
 							lessonDetails.reload()
 						},
-					},
+					}
 				)
 			},
 			onError(err) {
 				toast.error(err.messages?.[0] || err)
 			},
-		},
+		}
 	)
 }
 
@@ -496,7 +494,7 @@ const editCurrentLesson = () => {
 			onError(err) {
 				toast.error(err.message)
 			},
-		},
+		}
 	)
 }
 

--- a/frontend/src/styles/blockEditor.css
+++ b/frontend/src/styles/blockEditor.css
@@ -1,0 +1,365 @@
+/* Shared EditorJS chrome (toolbar, popover, codebox, plyr, embeds) used by
+ * every BlockEditor instance. Global on purpose: EditorJS renders outside
+ * Vue's scope-attribute reach. */
+
+.embed-tool__caption,
+.cdx-simple-image__caption {
+	display: none;
+}
+
+/* Colors use frappe-ui (Espresso) design tokens, so the editor follows the
+   app's light/dark theme automatically ([data-theme='dark'] flips them). */
+.ce-block__content {
+	max-width: none;
+}
+
+/* Block selection — neutralise EditorJS's native blue selection fill
+   (.ce-block--selected{background:#e1f2ff}) everywhere, since RectangleSelection
+   also fires in the readonly reader view where a block highlight makes no sense,
+   then re-apply a theme-gray fill only inside .bn-editor (the editing root).
+   Outline (not border) so there is no layout shift. */
+.ce-block--selected .ce-block__content {
+	background: transparent !important;
+}
+.bn-editor .ce-block--selected .ce-block__content {
+	background: var(--surface-gray-2) !important;
+	outline: 1px dotted var(--outline-gray-3);
+	border-radius: 6px;
+}
+
+.ce-toolbar__actions,
+.codex-editor--narrow .ce-toolbar__actions {
+	right: auto;
+	left: auto;
+	inset-inline-end: 100%;
+}
+
+.codex-editor--narrow .codex-editor__redactor {
+	margin-inline: 0;
+}
+
+.ce-toolbar__content {
+	max-width: none;
+}
+
+.codeBoxHolder {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	align-items: flex-start;
+}
+
+.codeBoxTextArea {
+	width: 100%;
+	min-height: 30px;
+	padding: 10px;
+	border-radius: 2px 2px 2px 0;
+	border: none !important;
+	outline: none !important;
+	font: 14px monospace;
+	line-height: 1.7;
+}
+
+.codeBoxSelectDiv {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	align-items: flex-start;
+	position: relative;
+}
+
+.codeBoxSelectInput {
+	border-radius: 0 0 20px 2px;
+	padding: 2px 26px;
+	padding-top: 0;
+	padding-inline-end: 0;
+	text-align: start;
+	cursor: pointer;
+	border: none !important;
+	outline: none !important;
+}
+
+.codeBoxSelectDropIcon {
+	position: absolute !important;
+	inset-inline-start: 10px !important;
+	bottom: 0 !important;
+	width: unset !important;
+	height: unset !important;
+	font-size: 16px !important;
+}
+
+.codeBoxSelectPreview {
+	display: none;
+	flex-direction: column;
+	justify-content: flex-start;
+	align-items: flex-start;
+	border-radius: 2px;
+	box-shadow: 0 3px 15px -3px rgba(13, 20, 33, 0.13);
+	position: absolute;
+	top: 100%;
+	margin: 5px 0;
+	max-height: 30vh;
+	overflow-x: hidden;
+	overflow-y: auto;
+	z-index: 10000;
+}
+
+.codeBoxSelectItem {
+	width: 100%;
+	padding: 5px 20px;
+	margin: 0;
+	cursor: pointer;
+}
+
+.codeBoxSelectedItem {
+	background-color: var(--surface-blue-2) !important;
+}
+
+.codeBoxShow {
+	display: flex !important;
+}
+
+.dark {
+	color: #abb2bf;
+	background-color: #282c34;
+}
+
+.light {
+	color: #383a42;
+	background-color: #fafafa;
+}
+
+.prose :where(pre):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+	overflow-x: unset;
+}
+
+iframe {
+	border: none !important;
+}
+
+/* Bridge @editorjs/table's own CSS variables onto our design tokens (automad's
+   pattern) so the table grid, toolbox and popover follow the app theme without
+   per-rule overrides. */
+.tc-wrap {
+	--color-background: var(--surface-gray-2);
+	--color-text-secondary: var(--ink-gray-5);
+	--color-border: var(--outline-gray-2);
+}
+
+.tc-popover {
+	--color-background: var(--surface-white);
+	--color-border: var(--outline-gray-2);
+}
+
+.tc-table {
+	border-inline-start: 1px solid var(--outline-gray-2);
+}
+
+.ce-toolbox__button[data-tool='markdown'] {
+	display: none !important;
+}
+
+.ce-popover-item[data-item-name='markdown'] {
+	display: none !important;
+}
+
+.plyr__volume input[type='range'] {
+	display: none;
+}
+
+.plyr__control--overlaid {
+	background: radial-gradient(
+		circle,
+		rgba(0, 0, 0, 0.4) 0%,
+		rgba(0, 0, 0, 0.5) 50%
+	);
+}
+
+.plyr__control:hover {
+	background: none;
+}
+
+.plyr--video {
+	border: 1px solid var(--outline-gray-2);
+	border-radius: 8px;
+}
+
+.ce-popover__container {
+	border-radius: 12px;
+	padding: 8px;
+}
+
+.ce-popover,
+.codex-editor--narrow .ce-toolbox .ce-popover,
+.codex-editor--narrow .ce-toolbar__actions .ce-popover {
+	border-radius: 12px;
+	right: auto;
+	left: auto;
+	inset-inline-start: 0;
+}
+
+.cdx-search-field {
+	border: none;
+}
+
+.cdx-search-field__input {
+	font-weight: 400;
+	font-size: 13px;
+}
+
+.cdx-search-field__input::before {
+	font-weight: 400;
+}
+
+.cdx-search-field__input:focus {
+	--tw-ring-color: theme('colors.gray.100');
+}
+
+.ce-popover-item__title {
+	font-size: 13px;
+	font-weight: 400;
+}
+
+.ce-popover-item__icon svg {
+	width: 15px;
+	height: 15px;
+}
+
+.ce-popover-item__icon {
+	margin-right: unset;
+	margin-inline-end: 10px;
+}
+
+.ce-popover--opened {
+	max-height: unset !important;
+}
+
+.cdx-search-field__icon svg {
+	width: 15px;
+	height: 15px;
+}
+
+.cdx-search-field__icon {
+	margin-inline-end: 5px;
+}
+
+.cdx-block.embed-tool {
+	position: relative;
+	display: inline-block;
+	width: 100%;
+}
+
+:root {
+	--plyr-range-fill-background: white;
+	--plyr-video-control-background-hover: transparent;
+}
+
+/* ── Inline toolbar (text-selection popover) ──────────────────────────────
+   automad's look, retokenised to the app's Espresso design tokens. */
+.ce-inline-toolbar {
+	border: 1px solid var(--outline-gray-2);
+	border-radius: 8px;
+	background: var(--surface-white);
+	box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.2);
+	color: var(--ink-gray-7);
+}
+
+.ce-inline-tool {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	margin: 2px;
+	padding: 0;
+	border-radius: 6px;
+	color: var(--ink-gray-7);
+	transition:
+		background-color 0.12s ease,
+		color 0.12s ease;
+}
+
+.ce-inline-tool svg {
+	width: 17px;
+	height: 17px;
+}
+
+.ce-inline-tool:hover,
+.ce-inline-tool--focused {
+	background: var(--surface-gray-3);
+	color: var(--ink-gray-8);
+}
+
+.ce-inline-tool--active {
+	background: var(--surface-gray-4);
+	color: var(--ink-gray-9);
+}
+
+/* Divider between the text-align group and the formatting tools (bold is the
+   first formatting tool after the three align buttons). */
+.ce-inline-tool--bold {
+	margin-inline-start: 6px;
+	border-inline-start: 1px solid var(--outline-gray-2);
+	border-start-start-radius: 0;
+	border-end-start-radius: 0;
+	padding-inline-start: 6px;
+	width: 36px;
+}
+
+/* Convert-to dropdown toggle + conversion popover. */
+.ce-inline-toolbar__dropdown {
+	border-inline-end: 1px solid var(--outline-gray-2);
+	color: var(--ink-gray-7);
+}
+
+.ce-inline-toolbar__dropdown:hover {
+	background: var(--surface-gray-3);
+}
+
+.ce-conversion-toolbar {
+	border: 1px solid var(--outline-gray-2);
+	border-radius: 8px;
+	background: var(--surface-white);
+	box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.2);
+}
+
+.ce-conversion-tool {
+	color: var(--ink-gray-7);
+}
+
+.ce-conversion-tool:hover,
+.ce-conversion-tool--focused {
+	background: var(--surface-gray-3);
+}
+
+.ce-conversion-tool__icon {
+	border: 1px solid var(--outline-gray-2);
+	border-radius: 6px;
+	background: var(--surface-white);
+}
+
+/* Color tool action panel (text color + highlight), shown under the buttons. */
+.lms-inline-color__panel {
+	display: flex;
+	gap: 10px;
+	padding: 8px 10px;
+	border-top: 1px solid var(--outline-gray-2);
+}
+
+.lms-inline-color__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 11px;
+	color: var(--ink-gray-6);
+}
+
+.lms-inline-color__field input[type='color'] {
+	width: 64px;
+	height: 24px;
+	padding: 0;
+	border: 1px solid var(--outline-gray-2);
+	border-radius: 6px;
+	background: none;
+	cursor: pointer;
+}

--- a/frontend/src/tests/blockEditor.test.ts
+++ b/frontend/src/tests/blockEditor.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import Paragraph from '@editorjs/paragraph'
+import BlockEditor from '@/components/BlockEditor.vue'
+
+vi.mock('@/utils', () => ({
+	getEditorTools: () => ({ paragraph: Paragraph }),
+	enablePlyr: () => {},
+}))
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string) => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+type BlockEditorApi = {
+	isReady: () => Promise<void>
+	render: (data: object) => Promise<void>
+	save: () => Promise<{ blocks: { data: { text: string } }[] }>
+	focus: (atEnd?: boolean) => void
+}
+
+const TWO_BLOCKS = {
+	blocks: [
+		{ type: 'paragraph', data: { text: 'first' } },
+		{ type: 'paragraph', data: { text: 'second' } },
+	],
+}
+
+describe('BlockEditor', () => {
+	let wrapper: VueWrapper
+	let editorApi: BlockEditorApi
+
+	beforeEach(async () => {
+		wrapper = mount(BlockEditor, { attachTo: document.body })
+		editorApi = wrapper.vm as unknown as BlockEditorApi
+		await editorApi.isReady()
+		await editorApi.render(TWO_BLOCKS)
+		await new Promise((r) => setTimeout(r, 50))
+	})
+
+	afterEach(() => {
+		wrapper.unmount()
+		document.body.innerHTML = ''
+	})
+
+	it('renders the native EditorJS toolbar (+ add and the ⋮⋮ settings menu)', () => {
+		expect(document.querySelector('.ce-toolbar__plus')).not.toBeNull()
+		expect(
+			document.querySelector('.ce-toolbar__settings-btn')
+		).not.toBeNull()
+	})
+
+	it('does not inject the old custom Notion-style handle or menu', () => {
+		expect(document.querySelector('.bn-drag-handle')).toBeNull()
+		expect(document.querySelector('.bn-block-menu')).toBeNull()
+	})
+
+	it('makes the native settings button draggable (editorjs-drag-drop)', () => {
+		const settings = document.querySelector('.ce-toolbar__settings-btn')
+		expect(settings?.getAttribute('draggable')).toBe('true')
+	})
+
+	it('round-trips block content through render() and save()', async () => {
+		const out = await editorApi.save()
+		expect(out.blocks.map((b) => b.data.text)).toEqual(['first', 'second'])
+	})
+
+	it('exposes a focus() method that places the caret without throwing', () => {
+		expect(() => editorApi.focus()).not.toThrow()
+	})
+})

--- a/frontend/src/tests/inlineTools.test.ts
+++ b/frontend/src/tests/inlineTools.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { API, InlineToolConstructorOptions } from '@editorjs/editorjs'
+import { Underline } from '@/utils/inline/Underline'
+import { Strikethrough } from '@/utils/inline/Strikethrough'
+import { AlignLeft, AlignCenter } from '@/utils/inline/TextAlign'
+import { Color } from '@/utils/inline/Color'
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+
+// Minimal EditorJS API surface the inline tools use, operating on the real
+// jsdom selection/DOM. Cast like the sibling BlockEditor test does.
+function makeApi(root: HTMLElement): API {
+	return {
+		styles: {
+			inlineToolButton: 'ce-inline-tool',
+			inlineToolButtonActive: 'ce-inline-tool--active',
+		},
+		selection: {
+			findParentTag(tagName: string): HTMLElement | null {
+				const selection = window.getSelection()
+				let node: Node | null =
+					selection && selection.rangeCount > 0
+						? selection.getRangeAt(0).commonAncestorContainer
+						: null
+				while (node && node !== root.parentNode) {
+					if (
+						node instanceof HTMLElement &&
+						node.tagName === tagName.toUpperCase()
+					) {
+						return node
+					}
+					node = node.parentNode
+				}
+				return null
+			},
+			expandToTag(node: HTMLElement): void {
+				const selection = window.getSelection()
+				const range = document.createRange()
+				range.selectNodeContents(node)
+				selection?.removeAllRanges()
+				selection?.addRange(range)
+			},
+		},
+	} as unknown as API
+}
+
+function options(root: HTMLElement): InlineToolConstructorOptions {
+	return { api: makeApi(root) } as unknown as InlineToolConstructorOptions
+}
+
+function selectWithin(textHost: HTMLElement, start: number, end: number): Range {
+	const textNode = textHost.firstChild as Node
+	const range = document.createRange()
+	range.setStart(textNode, start)
+	range.setEnd(textNode, end)
+	const selection = window.getSelection() as Selection
+	selection.removeAllRanges()
+	selection.addRange(range)
+	return range
+}
+
+describe('decoration inline tools', () => {
+	let root: HTMLElement
+
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="root"><div id="p">hello world</div></div>'
+		root = document.getElementById('root') as HTMLElement
+	})
+
+	it('wraps the selection in <u> and unwraps on toggle', () => {
+		const host = document.getElementById('p') as HTMLElement
+		const tool = new Underline(options(root))
+		tool.surround(selectWithin(host, 0, 5))
+		expect(host.querySelector('u')?.textContent).toBe('hello')
+
+		expect(tool.checkState()).toBe(true)
+		tool.surround(window.getSelection()!.getRangeAt(0))
+		expect(host.querySelector('u')).toBeNull()
+	})
+
+	it('reflects an existing wrapper in checkState and toggles the active class', () => {
+		const host = document.getElementById('p') as HTMLElement
+		const tool = new Underline(options(root))
+		const button = tool.render()
+		tool.surround(selectWithin(host, 0, 5))
+		tool.checkState()
+		expect(button.classList.contains('ce-inline-tool--active')).toBe(true)
+	})
+
+	it('wraps the selection in <s> for strikethrough', () => {
+		const host = document.getElementById('p') as HTMLElement
+		const tool = new Strikethrough(options(root))
+		tool.surround(selectWithin(host, 0, 5))
+		expect(host.querySelector('s')?.textContent).toBe('hello')
+	})
+
+	it('exposes a sanitize config that whitelists its tag', () => {
+		expect(Underline.sanitize).toEqual({ u: true })
+		expect(Strikethrough.sanitize).toEqual({ s: true })
+	})
+})
+
+describe('text-align inline tool', () => {
+	let root: HTMLElement
+
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="root"><div id="p">hello world</div></div>'
+		root = document.getElementById('root') as HTMLElement
+	})
+
+	it('wraps block content in <lms-align> and sets text-align', () => {
+		const host = document.getElementById('p') as HTMLElement
+		const tool = new AlignCenter(options(root))
+		selectWithin(host, 0, 5)
+		tool.surround()
+		const wrapper = host.querySelector('lms-align') as HTMLElement
+		expect(wrapper).not.toBeNull()
+		expect(wrapper.style.textAlign).toBe('center')
+		expect(wrapper.style.display).toBe('block')
+	})
+
+	it('checkState is true only for the matching alignment', () => {
+		const host = document.getElementById('p') as HTMLElement
+		const center = new AlignCenter(options(root))
+		const left = new AlignLeft(options(root))
+		selectWithin(host, 0, 5)
+		center.surround()
+		expect(center.checkState()).toBe(true)
+		expect(left.checkState()).toBe(false)
+	})
+
+	it('whitelists the lms-align tag in sanitize', () => {
+		expect(AlignLeft.sanitize).toEqual({ 'lms-align': true })
+	})
+})
+
+describe('color inline tool', () => {
+	let root: HTMLElement
+
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="root"><div id="p">hello world</div></div>'
+		root = document.getElementById('root') as HTMLElement
+	})
+
+	it('renders two native color inputs in its action panel', () => {
+		const tool = new Color(options(root))
+		const panel = tool.renderActions()
+		const inputs = panel.querySelectorAll('input[type="color"]')
+		expect(inputs.length).toBe(2)
+	})
+
+	it('writes the picked colors back onto the wrapper node', () => {
+		const tool = new Color(options(root))
+		const panel = tool.renderActions()
+		const node = document.createElement('lms-inline-color')
+		const exposed = tool as unknown as { showActions(n: HTMLElement): void }
+		exposed.showActions(node)
+
+		const [textInput, backgroundInput] = Array.from(
+			panel.querySelectorAll('input[type="color"]')
+		) as HTMLInputElement[]
+		textInput.value = '#ff0000'
+		textInput.dispatchEvent(new Event('input', { bubbles: true }))
+		backgroundInput.value = '#00ff00'
+		backgroundInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+		expect(node.style.color).not.toBe('')
+		expect(node.style.backgroundColor).not.toBe('')
+	})
+
+	it('whitelists the lms-inline-color tag in sanitize', () => {
+		expect(Color.sanitize).toEqual({ 'lms-inline-color': true })
+	})
+})

--- a/frontend/src/tests/lessonForm.test.ts
+++ b/frontend/src/tests/lessonForm.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { hasInstructorContent, hasEditorContent } from '@/utils/lessonForm'
+
+// Regression guard: a transient/empty editor (hot-reload remount, render race,
+// mid lesson-switch) must NOT be allowed to overwrite a saved lesson. saveLesson
+// calls hasEditorContent on the editor payload and refuses to persist when false.
+describe('hasEditorContent (anti-wipe guard)', () => {
+	it('is false for a missing / non-array blocks payload', () => {
+		expect(hasEditorContent(null)).toBe(false)
+		expect(hasEditorContent(undefined)).toBe(false)
+		expect(hasEditorContent({})).toBe(false)
+	})
+
+	it('is false for zero blocks', () => {
+		expect(hasEditorContent({ blocks: [] })).toBe(false)
+	})
+
+	it('is false for the exact wipe payload: one empty default paragraph', () => {
+		// This is what a freshly remounted EditorJS serialises to — the state that
+		// reduced real lessons to "1 block / ~109 chars".
+		expect(
+			hasEditorContent({ blocks: [{ type: 'paragraph', data: { text: '' } }] })
+		).toBe(false)
+		expect(
+			hasEditorContent({
+				blocks: [{ type: 'paragraph', data: { text: '   ' } }],
+			})
+		).toBe(false)
+	})
+
+	it('is true for a paragraph with real text', () => {
+		expect(
+			hasEditorContent({
+				blocks: [{ type: 'paragraph', data: { text: 'Real content' } }],
+			})
+		).toBe(true)
+	})
+
+	it('is true for a non-paragraph block (embed/image/quiz)', () => {
+		expect(
+			hasEditorContent({ blocks: [{ type: 'embed', data: { embed: '/v' } }] })
+		).toBe(true)
+	})
+})
+
+describe('hasInstructorContent', () => {
+	it('returns false for empty / nullish input', () => {
+		expect(hasInstructorContent(null, null)).toBe(false)
+		expect(hasInstructorContent('', '')).toBe(false)
+		expect(hasInstructorContent(undefined, undefined)).toBe(false)
+	})
+
+	it('returns true when legacy markdown notes are non-empty', () => {
+		expect(hasInstructorContent(null, '  some notes  ')).toBe(true)
+	})
+
+	it('returns false for legacy notes that are only whitespace', () => {
+		expect(hasInstructorContent(null, '   ')).toBe(false)
+	})
+
+	it('returns false for EditorJS JSON with no blocks', () => {
+		expect(hasInstructorContent(JSON.stringify({ blocks: [] }), null)).toBe(
+			false
+		)
+	})
+
+	it('returns false for a single empty paragraph block', () => {
+		const content = JSON.stringify({
+			blocks: [{ type: 'paragraph', data: { text: '   ' } }],
+		})
+		expect(hasInstructorContent(content, null)).toBe(false)
+	})
+
+	it('returns true for a paragraph block with text', () => {
+		const content = JSON.stringify({
+			blocks: [{ type: 'paragraph', data: { text: 'Hello' } }],
+		})
+		expect(hasInstructorContent(content, null)).toBe(true)
+	})
+
+	it('returns true for a non-paragraph block with data (e.g. image)', () => {
+		const content = JSON.stringify({
+			blocks: [{ type: 'upload', data: { file_url: '/x.png' } }],
+		})
+		expect(hasInstructorContent(content, null)).toBe(true)
+	})
+
+	it('returns false for malformed JSON', () => {
+		expect(hasInstructorContent('{not json', null)).toBe(false)
+	})
+})

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -13,6 +13,10 @@ import Paragraph from '@editorjs/paragraph'
 import { CodeBox } from '@/utils/code'
 import NestedList from '@editorjs/nested-list'
 import InlineCode from '@editorjs/inline-code'
+import { Underline } from '@/utils/inline/Underline'
+import { Strikethrough } from '@/utils/inline/Strikethrough'
+import { AlignLeft, AlignCenter, AlignRight } from '@/utils/inline/TextAlign'
+import { Color } from '@/utils/inline/Color'
 import dayjs from '@/utils/dayjs'
 import Embed from '@editorjs/embed'
 import SimpleImage from '@editorjs/simple-image'
@@ -117,6 +121,21 @@ export function htmlToText(html) {
 	return div.textContent || div.innerText || ''
 }
 
+// Visual order of the inline toolbar (automad layout). References registered
+// inline-tool names: EditorJS built-ins (bold/italic/link) + our custom tools.
+const INLINE_TOOLBAR_ORDER = [
+	'alignLeft',
+	'alignCenter',
+	'alignRight',
+	'bold',
+	'italic',
+	'link',
+	'inlineCode',
+	'underline',
+	'strikeThrough',
+	'color',
+]
+
 export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 	return {
 		header: {
@@ -127,7 +146,7 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 		},
 		list: {
 			class: NestedList,
-			inlineToolbar: true,
+			inlineToolbar: INLINE_TOOLBAR_ORDER,
 			config: {
 				defaultStyle: 'ordered',
 			},
@@ -138,19 +157,19 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 		},
 		table: {
 			class: Table,
-			inlineToolbar: true,
+			inlineToolbar: INLINE_TOOLBAR_ORDER,
 		},
 		quiz: Quiz,
 		assignment: Assignment,
 		program: Program,
 		markdown: {
 			class: Markdown,
-			inlineToolbar: true,
+			inlineToolbar: INLINE_TOOLBAR_ORDER,
 		},
 		image: SimpleImage,
 		paragraph: {
 			class: Paragraph,
-			inlineToolbar: true,
+			inlineToolbar: INLINE_TOOLBAR_ORDER,
 			config: {
 				preserveBlank: true,
 			},
@@ -165,6 +184,12 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 			class: InlineCode,
 			shortcut: 'CMD+SHIFT+M',
 		},
+		underline: Underline,
+		strikeThrough: Strikethrough,
+		alignLeft: AlignLeft,
+		alignCenter: AlignCenter,
+		alignRight: AlignRight,
+		color: Color,
 		embed: {
 			class: Embed,
 			inlineToolbar: false,

--- a/frontend/src/utils/inline/BaseInline.ts
+++ b/frontend/src/utils/inline/BaseInline.ts
@@ -1,0 +1,129 @@
+import type { API, InlineTool, InlineToolConstructorOptions } from '@editorjs/editorjs'
+
+/**
+ * Range-based inline tool base class, ported from automad's BaseInline. Wraps
+ * and unwraps the selection in `this.tag` using the Range API directly (no
+ * deprecated `document.execCommand`). Subclasses declare `tag` and `icon`;
+ * tools with an action panel (e.g. Color) override `renderActions`/`showActions`.
+ */
+export abstract class BaseInline implements InlineTool {
+	static get isInline(): boolean {
+		return true
+	}
+
+	protected abstract get tag(): string
+	protected abstract get icon(): string
+
+	protected readonly api: API
+	private readonly button: HTMLButtonElement
+	private removers: Array<() => void> = []
+	private savedRange: Range | null = null
+	private _state = false
+
+	get state(): boolean {
+		return this._state
+	}
+
+	set state(state: boolean) {
+		this._state = state
+		this.button.classList.toggle(this.api.styles.inlineToolButtonActive, state)
+	}
+
+	constructor({ api }: InlineToolConstructorOptions) {
+		this.api = api
+		this.button = document.createElement('button')
+		this.button.type = 'button'
+		this.button.classList.add(this.api.styles.inlineToolButton)
+		this.button.innerHTML = this.icon
+	}
+
+	render(): HTMLElement {
+		return this.button
+	}
+
+	surround(range: Range): void {
+		if (this.state) {
+			this.unwrap()
+			return
+		}
+		this.wrap(range)
+	}
+
+	wrap(range: Range): void {
+		const contents = range.extractContents()
+		const node = document.createElement(this.tag)
+		node.appendChild(contents)
+		range.insertNode(node)
+		this.api.selection.expandToTag(node)
+	}
+
+	unwrap(): void {
+		this.restoreSelection()
+		const node = this.api.selection.findParentTag(this.tag)
+		if (!node) {
+			return
+		}
+		this.api.selection.expandToTag(node)
+		const selection = window.getSelection()
+		if (!selection || selection.rangeCount === 0) {
+			return
+		}
+		const range = selection.getRangeAt(0)
+		const contents = range.extractContents()
+		node.remove()
+		range.insertNode(contents)
+	}
+
+	checkState(): boolean {
+		const node = this.api.selection.findParentTag(this.tag)
+		this.state = node !== null
+		if (this.state && node) {
+			this.saveSelection()
+			setTimeout((): void => {
+				this.showActions(node)
+			}, 0)
+		} else {
+			this.hideActions()
+		}
+		return this.state
+	}
+
+	clear(): void {
+		this.removers.forEach((remove): void => {
+			remove()
+		})
+		this.removers = []
+	}
+
+	protected listen(
+		element: HTMLElement | Document | Window,
+		events: string,
+		callback: (event: Event) => void
+	): void {
+		events.split(' ').forEach((event): void => {
+			element.addEventListener(event, callback)
+			this.removers.push((): void => {
+				element.removeEventListener(event, callback)
+			})
+		})
+	}
+
+	protected showActions(_node: HTMLElement): void {}
+
+	protected hideActions(): void {}
+
+	private saveSelection(): void {
+		const selection = window.getSelection()
+		this.savedRange =
+			selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
+	}
+
+	private restoreSelection(): void {
+		const selection = window.getSelection()
+		if (!selection || !this.savedRange) {
+			return
+		}
+		selection.removeAllRanges()
+		selection.addRange(this.savedRange)
+	}
+}

--- a/frontend/src/utils/inline/Color.ts
+++ b/frontend/src/utils/inline/Color.ts
@@ -1,0 +1,98 @@
+import { BaseInline } from './BaseInline'
+import { paintBucketIcon } from './icons'
+
+/**
+ * Convert a CSS `rgb(r, g, b)` string to `#rrggbb` so it can seed a native
+ * `<input type="color">` (which only accepts hex). Returns hex/empty unchanged.
+ */
+function rgbToHex(value: string): string {
+	const match = value.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/)
+	if (!match) {
+		return value
+	}
+	const toHex = (part: string): string =>
+		Number(part).toString(16).padStart(2, '0')
+	return `#${toHex(match[1])}${toHex(match[2])}${toHex(match[3])}`
+}
+
+/**
+ * Text-color + highlight inline tool. Wraps the selection in a sanitized
+ * `<lms-inline-color>` element carrying inline `color` / `background-color`,
+ * edited via two native color inputs in the toolbar action panel.
+ *
+ * frappe-ui ships no ColorPicker component, so native `<input type="color">`
+ * is used here (verified against node_modules/frappe-ui/src/components).
+ */
+export class Color extends BaseInline {
+	private panel: HTMLElement | null = null
+	private textInput: HTMLInputElement | null = null
+	private backgroundInput: HTMLInputElement | null = null
+
+	static get title(): string {
+		return __('Color')
+	}
+
+	static get sanitize(): Record<string, boolean> {
+		return { 'lms-inline-color': true }
+	}
+
+	protected get tag(): string {
+		return 'LMS-INLINE-COLOR'
+	}
+
+	protected get icon(): string {
+		return paintBucketIcon
+	}
+
+	renderActions(): HTMLElement {
+		this.panel = document.createElement('div')
+		this.panel.classList.add('lms-inline-color__panel')
+		this.panel.hidden = true
+
+		this.textInput = this.createInput(__('Text color'))
+		this.backgroundInput = this.createInput(__('Highlight'))
+
+		this.panel.append(this.textInput.parentElement as HTMLElement)
+		this.panel.append(this.backgroundInput.parentElement as HTMLElement)
+
+		return this.panel
+	}
+
+	protected showActions(node: HTMLElement): void {
+		if (!this.panel || !this.textInput || !this.backgroundInput) {
+			return
+		}
+		const { color, backgroundColor } = node.style
+		if (color) {
+			this.textInput.value = rgbToHex(color)
+		}
+		if (backgroundColor) {
+			this.backgroundInput.value = rgbToHex(backgroundColor)
+		}
+		this.listen(this.textInput, 'input change', (): void => {
+			node.style.color = (this.textInput as HTMLInputElement).value
+		})
+		this.listen(this.backgroundInput, 'input change', (): void => {
+			node.style.backgroundColor = (
+				this.backgroundInput as HTMLInputElement
+			).value
+		})
+		this.panel.hidden = false
+	}
+
+	protected hideActions(): void {
+		if (this.panel) {
+			this.panel.hidden = true
+		}
+	}
+
+	private createInput(label: string): HTMLInputElement {
+		const field = document.createElement('label')
+		field.classList.add('lms-inline-color__field')
+		field.textContent = label
+		const input = document.createElement('input')
+		input.type = 'color'
+		field.append(input)
+		return input
+	}
+}

--- a/frontend/src/utils/inline/Strikethrough.ts
+++ b/frontend/src/utils/inline/Strikethrough.ts
@@ -1,0 +1,20 @@
+import { BaseInline } from './BaseInline'
+import { strikethroughIcon } from './icons'
+
+export class Strikethrough extends BaseInline {
+	static get title(): string {
+		return __('Strikethrough')
+	}
+
+	static get sanitize(): Record<string, boolean> {
+		return { s: true }
+	}
+
+	protected get tag(): string {
+		return 'S'
+	}
+
+	protected get icon(): string {
+		return strikethroughIcon
+	}
+}

--- a/frontend/src/utils/inline/TextAlign.ts
+++ b/frontend/src/utils/inline/TextAlign.ts
@@ -1,0 +1,184 @@
+import type { API, InlineTool, InlineToolConstructorOptions } from '@editorjs/editorjs'
+import { alignLeftIcon, alignCenterIcon, alignRightIcon } from './icons'
+
+type AlignOption = 'left' | 'center' | 'right'
+
+interface AlignSelection {
+	start: number
+	end: number
+	div: HTMLElement | null
+}
+
+/**
+ * Text-align inline tool, ported from automad's TextAlign. Unlike the decoration
+ * tools it does not extend BaseInline: it wraps the whole block content in a
+ * sanitized `<lms-align>` block-level element and sets its `text-align`. The
+ * offset-based save/restore is copied verbatim from automad (fragile for richly
+ * formatted blocks, but matches the reference behaviour).
+ */
+abstract class BaseTextAlign implements InlineTool {
+	static get isInline(): boolean {
+		return true
+	}
+
+	static get sanitize(): Record<string, boolean> {
+		return { 'lms-align': true }
+	}
+
+	protected abstract get align(): AlignOption
+	protected abstract get icon(): string
+
+	protected readonly api: API
+	private readonly tag = 'LMS-ALIGN'
+	private readonly button: HTMLButtonElement
+	private selection: AlignSelection | null = null
+	private _state = false
+
+	get state(): boolean {
+		return this._state
+	}
+
+	set state(state: boolean) {
+		this._state = state
+		this.button.classList.toggle(this.api.styles.inlineToolButtonActive, state)
+	}
+
+	constructor({ api }: InlineToolConstructorOptions) {
+		this.api = api
+		this.button = document.createElement('button')
+		this.button.type = 'button'
+		this.button.classList.add(this.api.styles.inlineToolButton)
+	}
+
+	render(): HTMLElement {
+		this.button.innerHTML = this.icon
+		return this.button
+	}
+
+	surround(): void {
+		this.saveSelection()
+		if (this.state) {
+			this.removeWrapper()
+		} else {
+			const node = this.api.selection.findParentTag(this.tag) ?? this.createWrapper()
+			if (node) {
+				node.style.textAlign = this.align
+				node.style.display = 'block'
+			}
+		}
+		this.restoreSelection()
+	}
+
+	checkState(): boolean {
+		const node = this.api.selection.findParentTag(this.tag)
+		this.state = node !== null && node.style.textAlign === this.align
+		return this.state
+	}
+
+	private removeWrapper(): void {
+		const node = this.api.selection.findParentTag(this.tag)
+		if (!node) {
+			return
+		}
+		this.api.selection.expandToTag(node)
+		const selection = window.getSelection()
+		if (!selection || selection.rangeCount === 0) {
+			return
+		}
+		const range = selection.getRangeAt(0)
+		const contents = range.extractContents()
+		node.remove()
+		range.insertNode(contents)
+	}
+
+	private createWrapper(): HTMLElement | null {
+		const div = this.api.selection.findParentTag('DIV')
+		if (!div) {
+			return null
+		}
+		this.api.selection.expandToTag(div)
+		const selection = window.getSelection()
+		if (!selection || selection.rangeCount === 0) {
+			return null
+		}
+		const range = selection.getRangeAt(0)
+		const contents = range.extractContents()
+		const node = document.createElement(this.tag)
+		node.appendChild(contents)
+		range.insertNode(node)
+		return node
+	}
+
+	private saveSelection(): void {
+		const selection = window.getSelection()
+		this.selection = {
+			start: selection ? selection.anchorOffset : 0,
+			end: selection ? selection.focusOffset : 0,
+			div: this.api.selection.findParentTag('DIV'),
+		}
+	}
+
+	private restoreSelection(): void {
+		const selection = window.getSelection()
+		if (!selection || !this.selection || !this.selection.div) {
+			return
+		}
+		selection.removeAllRanges()
+		const wrapper = this.selection.div.querySelector(
+			`:scope > ${this.tag.toLowerCase()}`
+		)
+		const element = wrapper ?? this.selection.div
+		const anchor = element.childNodes[0]
+		if (!anchor) {
+			return
+		}
+		selection.setBaseAndExtent(
+			anchor,
+			this.selection.start,
+			anchor,
+			this.selection.end
+		)
+	}
+}
+
+export class AlignLeft extends BaseTextAlign {
+	static get title(): string {
+		return __('Align left')
+	}
+
+	protected get align(): AlignOption {
+		return 'left'
+	}
+
+	protected get icon(): string {
+		return alignLeftIcon
+	}
+}
+
+export class AlignCenter extends BaseTextAlign {
+	static get title(): string {
+		return __('Align center')
+	}
+
+	protected get align(): AlignOption {
+		return 'center'
+	}
+
+	protected get icon(): string {
+		return alignCenterIcon
+	}
+}
+
+export class AlignRight extends BaseTextAlign {
+	static get title(): string {
+		return __('Align right')
+	}
+
+	protected get align(): AlignOption {
+		return 'right'
+	}
+
+	protected get icon(): string {
+		return alignRightIcon
+	}
+}

--- a/frontend/src/utils/inline/Underline.ts
+++ b/frontend/src/utils/inline/Underline.ts
@@ -1,0 +1,20 @@
+import { BaseInline } from './BaseInline'
+import { underlineIcon } from './icons'
+
+export class Underline extends BaseInline {
+	static get title(): string {
+		return __('Underline')
+	}
+
+	static get sanitize(): Record<string, boolean> {
+		return { u: true }
+	}
+
+	protected get tag(): string {
+		return 'U'
+	}
+
+	protected get icon(): string {
+		return underlineIcon
+	}
+}

--- a/frontend/src/utils/inline/icons.ts
+++ b/frontend/src/utils/inline/icons.ts
@@ -1,0 +1,20 @@
+/**
+ * Raw lucide SVG strings for the inline-toolbar buttons. Inline tools need HTML
+ * (set via innerHTML), so the Vue components from lucide-vue-next can't be used;
+ * lucide-static is the same icon set shipped as plain SVG files.
+ */
+import underlineIcon from 'lucide-static/icons/underline.svg?raw'
+import strikethroughIcon from 'lucide-static/icons/strikethrough.svg?raw'
+import alignLeftIcon from 'lucide-static/icons/align-left.svg?raw'
+import alignCenterIcon from 'lucide-static/icons/align-center.svg?raw'
+import alignRightIcon from 'lucide-static/icons/align-right.svg?raw'
+import paintBucketIcon from 'lucide-static/icons/paint-bucket.svg?raw'
+
+export {
+	underlineIcon,
+	strikethroughIcon,
+	alignLeftIcon,
+	alignCenterIcon,
+	alignRightIcon,
+	paintBucketIcon,
+}

--- a/frontend/src/utils/lessonForm.ts
+++ b/frontend/src/utils/lessonForm.ts
@@ -1,0 +1,49 @@
+interface EditorJsBlock {
+	type?: string
+	data?: Record<string, unknown>
+}
+
+interface EditorJsOutput {
+	blocks?: EditorJsBlock[]
+}
+
+/**
+ * True when an EditorJS save payload has at least one block with real content.
+ * An empty paragraph (or a block with no data) does not count.
+ *
+ * This is the guard that stops a transient/empty editor from wiping a lesson:
+ * a hot-reload remount, a render race, or mid lesson-switch can leave the editor
+ * holding only EditorJS's default empty paragraph. Persisting that would
+ * overwrite stored content with a blank doc, so `saveLesson` refuses when this
+ * returns false.
+ */
+export function hasEditorContent(output?: EditorJsOutput | null): boolean {
+	const blocks = output?.blocks
+	if (!Array.isArray(blocks)) return false
+	return blocks.some((block) => {
+		const data = block?.data
+		if (!data || Object.keys(data).length === 0) return false
+		if (block.type === 'paragraph') {
+			return Boolean(String(data.text ?? '').trim())
+		}
+		return true
+	})
+}
+
+/**
+ * True when a lesson has instructor notes worth flagging — either legacy
+ * markdown (`instructor_notes`) or EditorJS JSON (`instructor_content`) with at
+ * least one non-empty block. An empty paragraph does not count.
+ */
+export function hasInstructorContent(
+	instructorContent?: string | null,
+	legacyNotes?: string | null
+): boolean {
+	if (legacyNotes && legacyNotes.trim()) return true
+	if (!instructorContent) return false
+	try {
+		return hasEditorContent(JSON.parse(instructorContent) as EditorJsOutput)
+	} catch {
+		return false
+	}
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3009,6 +3009,11 @@ editorconfig@^1.0.4:
     minimatch "^9.0.1"
     semver "^7.5.3"
 
+editorjs-drag-drop@1.1.16:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/editorjs-drag-drop/-/editorjs-drag-drop-1.1.16.tgz#428f44520272260e3d0e1ec7b7676ddf4a78d3a0"
+  integrity sha512-yOyKZqqZepkdbDQbAw1bZr3mQewkT4a9QgufWW3Aoy1qcTka8uHR01T/dGHqrpyYrF56ykyidPyp0LX79LEHHQ==
+
 ejs@^3.1.6:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"


### PR DESCRIPTION
## Summary
- Redesign lesson editor: move title and preview switch to editor
- Add drag feature in lesson editor
- Remove lesson edit button from course outline

## Changes

| Before | After |
| ----| ---- |
| | <img width="2784" height="1669" alt="image" src="https://github.com/user-attachments/assets/2af0248e-d5d6-4956-85c8-43b4bc17392f" /> |