### PR TITLE
fix: SCORM playback on mobile browsers (range requests, viewport, rotation)

### DIFF
--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -14,7 +14,7 @@
 	>
 		<iframe
 			:src="chapter.doc.launch_file"
-			class="w-full h-[calc(100vh-3.00rem)]"
+			class="w-full h-[calc(100dvh-3.00rem)]"
 		/>
 	</div>
 	<div v-else-if="!enrollment.data?.length">
@@ -44,7 +44,7 @@ import {
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
-import { computed, inject, onBeforeMount, ref } from 'vue'
+import { computed, inject, onBeforeMount, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useSidebar } from '@/stores/sidebar'
 import { sessionStore } from '../stores/session'
 
@@ -53,6 +53,21 @@ const sidebarStore = useSidebar()
 const user = inject('$user')
 const readyToRender = ref(false)
 const isSuccessfullyCompleted = ref(false)
+
+let scormRotateHandled = false
+const handleScormRotate = () => {
+	if (scormRotateHandled) return
+	scormRotateHandled = true
+	setTimeout(() => {
+		window.location.reload()
+	}, 500)
+}
+onMounted(() => {
+	window.addEventListener('orientationchange', handleScormRotate)
+})
+onBeforeUnmount(() => {
+	window.removeEventListener('orientationchange', handleScormRotate)
+})
 
 // If courseRestartOnFailure is true, student has to restart the whole course if failed.
 // Otherwise, student could retake the final quiz portion.

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -67,6 +67,8 @@ class SCORMRenderer(BaseRenderer):
 		f = open(path, "rb")
 		response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
 		response.mimetype = mimetypes.guess_type(path)[0]
+		response.headers["Accept-Ranges"] = "bytes"
+		response.make_conditional(frappe.local.request, accept_ranges=True, complete_length=os.path.getsize(path))
 		return response
 
 	def render(self):


### PR DESCRIPTION
## Summary

Three fixes for SCORM chapter playback on mobile browsers, found while testing an Articulate Storyline (SCORM 1.2) package on iOS Safari and Android Chrome. On desktop everything worked; the issues were mobile-specific.

### 1. SCORM media doesn't play on iOS Safari — HTTP Range support
`SCORMRenderer._serve_file` streamed the whole file with `200` and no `Accept-Ranges`/`206` handling. iOS Safari **requires** HTTP range requests to play `<audio>`/`<video>`, so all `mp3`/`mp4` in a package were silent/blank on iPhone (desktop Chrome tolerates a `200`, which is why it only showed on mobile).

Fix: make the response range-aware via `Response.make_conditional(...)`. Range requests now return `206` + `Content-Range`; non-range requests still return `200` and advertise `Accept-Ranges`. Also enables media seeking.

### 2. Player mis-sized on mobile — `100vh` → `100dvh`
`100vh` is unreliable on mobile across toolbar/orientation changes. Switched the SCORM iframe to `100dvh`.

### 3. SCORM iframe blanks on rotation
On orientation change, mobile browsers blank the SCORM iframe and (on iOS) do not repaint newly-added DOM until a full reload — so in-page recovery UI (overlay/button) never paints. Recover by reloading on `orientationchange`; existing resume support restores the learner's position. A short delay lets the debounced `suspend_data` save flush first.

> Note: #3 is a pragmatic workaround for an iOS WebKit repaint limitation (a full reload was the only reliable recovery in testing). Happy to iterate toward a lighter approach if maintainers prefer.

## Testing
Verified on a self-hosted v15 bench with a SCORM 1.2 package containing mp3/mp4:
- iOS Safari + Android Chrome: media now plays; portrait completion + resume work.
- Range requests return `206` with correct `Content-Range`; non-range `200` with `Accept-Ranges`.
- Rotation now auto-recovers and resumes instead of showing a blank screen needing a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)