### PR TITLE
fix: show chapter title in lesson editor breadcrumb

### DIFF
--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -182,6 +182,7 @@ interface EditorSelection {
 	chapterNumber: string
 	lessonNumber: string
 	number: string
+	chapterTitle?: string
 	title?: string
 }
 
@@ -347,12 +348,22 @@ const isAdmin = computed<boolean>(() => {
 const breadcrumbs = computed(() => {
 	const crumbs: {
 		label: string
-		route: { name: string; params?: Record<string, string> }
+		route?: { name: string; params?: Record<string, string> }
 	}[] = [{ label: __('Courses'), route: { name: 'Courses' } }]
 	if (course.data) {
 		crumbs.push({
 			label: course.data.title,
 			route: { name: 'CourseDetail', params: { courseName: course.data.name } },
+		})
+	}
+	if (tabIndex.value === 2 && editorSelected.value?.chapterTitle) {
+		crumbs.push({
+			label: editorSelected.value.chapterTitle,
+		})
+	}
+	if (tabIndex.value === 2 && editorSelected.value?.title) {
+		crumbs.push({
+			label: editorSelected.value.title,
 		})
 	}
 	return crumbs

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -166,13 +166,35 @@ function storeLesson(courseName, number) {
 function setSelectedFromNumber(number) {
 	const [chapterNumber, lessonNumber] = number.split('-')
 	if (!chapterNumber || !lessonNumber) return
+	const lessonMeta = getLessonMeta(number)
 	selected.value = {
 		chapterNumber,
 		lessonNumber,
 		number,
-		title: '',
+		chapterTitle: lessonMeta?.chapterTitle,
+		title: lessonMeta?.lessonTitle || '',
 	}
 	syncSelectedToUrl(number)
+}
+
+function getLessonMeta(number) {
+	const [chapterNumber] = number.split('-')
+	for (const chapter of outline.data ?? []) {
+		const lesson = chapter.lessons?.find((item) => item.number === number)
+		if (lesson) {
+			return {
+				chapterTitle: chapter.title,
+				lessonTitle: lesson.title,
+			}
+		}
+		if (String(chapter.idx) === chapterNumber) {
+			return {
+				chapterTitle: chapter.title,
+				lessonTitle: '',
+			}
+		}
+	}
+	return null
 }
 
 // Reflect an autosaved lesson title/preview-flag in the shared outline
@@ -189,6 +211,13 @@ function onLessonSaved({ name, title, include_in_preview, isNew }) {
 		if (lesson) {
 			lesson.title = title
 			lesson.include_in_preview = include_in_preview ? 1 : 0
+			if (selected.value?.number === lesson.number) {
+				selected.value = {
+					...selected.value,
+					title,
+					chapterTitle: chapter.title,
+				}
+			}
 			break
 		}
 	}
@@ -196,7 +225,14 @@ function onLessonSaved({ name, title, include_in_preview, isNew }) {
 
 function onSelectLesson({ chapterNumber, lessonNumber }) {
 	const number = `${chapterNumber}-${lessonNumber}`
-	selected.value = { chapterNumber, lessonNumber, number, title: '' }
+	const lessonMeta = getLessonMeta(number)
+	selected.value = {
+		chapterNumber,
+		lessonNumber,
+		number,
+		chapterTitle: lessonMeta?.chapterTitle,
+		title: lessonMeta?.lessonTitle || '',
+	}
 	if (props.course?.data?.name) {
 		storeLesson(props.course.data.name, number)
 	}


### PR DESCRIPTION
### What changed

Adds the selected chapter title and lesson title to the Course Editor breadcrumb so instructors can tell which chapter's lesson they are editing.

The chapter breadcrumb item is intentionally not routed because chapters are outline sections, not standalone pages.

A follow-up improvement could update frappe-ui's Breadcrumbs component to render non-actionable items as plain text instead of button elements.

Closes #635 

### Screenshots

Before:

<img width="1512" height="754" alt="before-lesson-editor-breadcrumb" src="https://github.com/user-attachments/assets/d15d2ed1-d3ff-4c63-8b66-a7d06f849162" />

After:

<img width="1510" height="756" alt="after-lesson-editor-breadcrumb" src="https://github.com/user-attachments/assets/82f74bad-5fd2-419e-b9c6-8dffa50c6f0e" />


### Tests

- `git diff --check`
- `cd frontend && ./node_modules/.bin/vitest run`