### PR TITLE
perf(video-watch): add (member, lesson, source) index

### DIFF
--- a/lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.py
+++ b/lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.py
@@ -1,9 +1,16 @@
 # Copyright (c) 2025, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class LMSVideoWatchDuration(Document):
 	pass
+
+
+def on_doctype_update():
+	# Backs the (member, lesson, source) lookup in track_video_watch_duration.
+	# Runs on every doctype sync (fresh install + re-sync), so new sites get the
+	# index that the one-time patch only adds to existing sites. Idempotent.
+	frappe.db.add_index("LMS Video Watch Duration", ["member", "lesson", "source"])

--- a/lms/lms/doctype/lms_video_watch_duration/test_lms_video_watch_duration.py
+++ b/lms/lms/doctype/lms_video_watch_duration/test_lms_video_watch_duration.py
@@ -1,20 +1,25 @@
 # Copyright (c) 2025, Frappe and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase
+import frappe
+from frappe.tests import UnitTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+from lms.lms.doctype.lms_video_watch_duration.lms_video_watch_duration import on_doctype_update
 
 
-class IntegrationTestLMSVideoWatchDuration(IntegrationTestCase):
-	"""
-	Integration tests for LMSVideoWatchDuration.
-	Use this class for testing interactions between multiple components.
-	"""
+class UnitTestLMSVideoWatchDuration(UnitTestCase):
+	"""Schema-level tests for LMS Video Watch Duration (no fixtures required)."""
 
-	pass
+	def test_lookup_index_exists(self):
+		"""The (member, lesson, source) lookup in track_video_watch_duration
+		must be index-backed; guards against the index being dropped."""
+		self.assertTrue(frappe.db.has_index("tabLMS Video Watch Duration", "member_lesson_source_index"))
+
+	def test_on_doctype_update_creates_index(self):
+		"""on_doctype_update backs the new-site path (the one-time patch is
+		marked complete-without-running on fresh installs). Drop the index and
+		confirm a doctype sync recreates it."""
+		frappe.db.sql_ddl("DROP INDEX IF EXISTS member_lesson_source_index ON `tabLMS Video Watch Duration`")
+		self.assertFalse(frappe.db.has_index("tabLMS Video Watch Duration", "member_lesson_source_index"))
+		on_doctype_update()
+		self.assertTrue(frappe.db.has_index("tabLMS Video Watch Duration", "member_lesson_source_index"))

--- a/lms/lms/patches/v2_0/add_video_watch_duration_index.py
+++ b/lms/lms/patches/v2_0/add_video_watch_duration_index.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	"""Add a composite index backing the (member, lesson, source) lookup in
+	track_video_watch_duration. Without it every call is a full table scan and
+	the table grows one row per user x lesson x video. Idempotent: add_index
+	checks has_index and uses ADD INDEX IF NOT EXISTS."""
+	if not frappe.db.table_exists("LMS Video Watch Duration"):
+		return
+
+	frappe.db.add_index("LMS Video Watch Duration", ["member", "lesson", "source"])

--- a/lms/lms/test_api.py
+++ b/lms/lms/test_api.py
@@ -4,12 +4,14 @@ import re
 import zipfile
 
 import frappe
+from frappe.utils import flt
 
 from lms.lms.api import (
 	export_course_as_zip,
 	get_certified_participants,
 	get_course_assessment_progress,
 	import_course_from_zip,
+	track_video_watch_duration,
 )
 from lms.lms.course_import_export import sanitize_string
 from lms.lms.test_helpers import BaseTestUtils
@@ -177,3 +179,56 @@ class TestLMSAPI(BaseTestUtils):
 			"John#Doe$", allow_spaces=True, max_length=50, replacement_char=None, escape_html_content=True
 		)
 		self.assertEqual(result, "JohnDoe")
+
+
+class TestTrackVideoWatchDuration(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		self.instructor = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Course Creator", "Moderator"]
+		)
+		self.student = self._create_user("student1@example.com", "Ashley", "Smith", ["LMS Student"])
+		self.course = self._create_course()
+		self.chapter = self._create_chapter("Chapter 1", self.course.name)
+		self.lesson = self._create_lesson("Lesson 1", self.chapter.name, self.course.name)
+		self._original_user = frappe.session.user
+		frappe.set_user(self.student.email)
+
+	def tearDown(self):
+		frappe.set_user(self._original_user)
+		frappe.db.delete("LMS Video Watch Duration", {"member": self.student.email})
+		super().tearDown()
+
+	def _watch_rows(self, source=None):
+		filters = {"lesson": self.lesson.name, "member": self.student.email}
+		if source:
+			filters["source"] = source
+		return frappe.get_all("LMS Video Watch Duration", filters=filters, fields=["name", "watch_time"])
+
+	def test_creates_row_when_none_exists(self):
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 12}])
+		rows = self._watch_rows("a.mp4")
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(flt(rows[0].watch_time), 12)
+
+	def test_updates_only_when_greater(self):
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 10}])
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 5}])
+		self.assertEqual(flt(self._watch_rows("a.mp4")[0].watch_time), 10)
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 20}])
+		self.assertEqual(flt(self._watch_rows("a.mp4")[0].watch_time), 20)
+
+	def test_no_duplicate_on_repeat(self):
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 10}])
+		track_video_watch_duration(self.lesson.name, [{"source": "a.mp4", "watch_time": 15}])
+		self.assertEqual(len(self._watch_rows("a.mp4")), 1)
+
+	def test_tracks_multiple_videos(self):
+		track_video_watch_duration(
+			self.lesson.name,
+			[
+				{"source": "a.mp4", "watch_time": 3},
+				{"source": "b.mp4", "watch_time": 7},
+			],
+		)
+		self.assertEqual(len(self._watch_rows()), 2)

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -127,3 +127,4 @@ lms.patches.v2_0.give_event_permission #10-03-2026
 lms.patches.v2_0.delete_duplicate_course_progress #13-05-2026
 lms.patches.v2_0.restore_system_manager_perms #13-05-2026
 lms.patches.v2_0.set_course_progress_defaults #02-06-2026
+lms.patches.v2_0.add_video_watch_duration_index #18-06-2026


### PR DESCRIPTION
## Problem
- In `LMS Video Watch Duration` doctype had no index , every call was a full table scan over a table that grows one row per user × lesson × video.

## Fix
- **`on_doctype_update()`** — runs on every doctype sync, so fresh installs get  the index. 
- **`v2_0/add_video_watch_duration_index` post_model_sync patch** — creates it on existing sites, whose doctype JSON is unchanged on upgrade and so skip the doctype re-sync.
