### PR TITLE
fix: cypress test, lesson editor autosave crash

### DIFF
--- a/cypress/e2e/course_creation.cy.js
+++ b/cypress/e2e/course_creation.cy.js
@@ -2,6 +2,20 @@ describe("Course Creation", () => {
 	const courseTitle = "Test Course";
 	const courseSlug = "test-course";
 
+	// Start from a clean slate so leftover chapters/lessons from an earlier
+	// (possibly failed) run don't accumulate duplicate "Untitled lesson" rows in
+	// the outline and break the rename/delete assertions. Best-effort: the course
+	// may not exist yet, and a link-protected delete is ignored.
+	before(() => {
+		cy.login();
+		cy.request({
+			url: "/api/method/frappe.client.delete",
+			method: "POST",
+			body: { doctype: "LMS Course", name: courseSlug },
+			failOnStatusCode: false,
+		});
+	});
+
 	it("creates a new course with settings", () => {
 		cy.login();
 		cy.visit("/lms/courses");
@@ -157,14 +171,21 @@ describe("Course Creation", () => {
 		// the editor; the title is edited inline on the lesson itself and the
 		// debounced autosave persists it (no modal).
 		cy.button("Add Lesson", { timeout: 10000 }).click();
+		// "Add Lesson" prefills the title with "Untitled lesson", so clear it by
+		// selecting all + backspace (a plain .clear() doesn't reliably overwrite
+		// the prefilled default) before typing the real title.
 		cy.get("textarea.lesson-title", { timeout: 15000 })
 			.should("have.value", "Untitled lesson")
-			.clear()
+			.type("{selectall}{backspace}")
 			.type("Test Lesson");
 
-		// Verify the autosaved title landed in the editor outline. (The public
-		// overview collapses chapters, so the lesson title isn't asserted there.)
-		cy.contains("Test Lesson", { timeout: 15000 }).should("exist");
+		// The title edit arms a debounced autosave; once it persists, CourseEditor
+		// reflects the new title in the shared outline. Assert against the outline
+		// row specifically (deterministic via Cypress retry) so the later delete
+		// targets the throwaway "Untitled lesson", not this renamed one.
+		cy.contains(".outline-lesson", "Test Lesson", {
+			timeout: 15000,
+		}).should("exist");
 
 		// Regression: deleting the lesson that's open in the editor must drop back
 		// to the empty "choose a lesson" state, not keep showing the deleted
@@ -186,10 +207,11 @@ describe("Course Creation", () => {
 		);
 		cy.contains(".outline-lesson", "Untitled lesson").should("not.exist");
 
-		// Navigate to course overview
-		cy.visit("/lms/courses");
+		// Navigate to course overview. Visit the detail page directly (same as the
+		// delete test) rather than clicking through the course list — the list's
+		// tab/filter rendering is a separate concern and made this flaky.
+		cy.visit(`/lms/courses/${courseSlug}`);
 		cy.closeOnboardingModal();
-		cy.contains("a", courseTitle).click();
 
 		// Verify overview content
 		cy.url({ timeout: 10000 }).should(

--- a/cypress/e2e/course_creation.cy.js
+++ b/cypress/e2e/course_creation.cy.js
@@ -147,8 +147,9 @@ describe("Course Creation", () => {
 		// the editor enters edit mode, but it delegates to CourseOutline
 		// (openChapterModal), which isn't mounted until the outline resource
 		// resolves. Clicking "Add" during the loading skeleton silently no-ops, so
-		// first wait for the loaded outline — the "No chapters yet" empty state
-		// only renders once outline.data has resolved and CourseOutline is mounted.
+		// first wait for the loaded outline — the "No chapters yet" empty state is
+		// rendered by CourseOutline itself, so its visibility proves the component
+		// (and its chapter modal) is mounted.
 		cy.contains("No chapters yet", { timeout: 20000 }).should("be.visible");
 
 		// Add a chapter via the toolbar "Add" button (CourseEditor hides

--- a/cypress/e2e/course_creation.cy.js
+++ b/cypress/e2e/course_creation.cy.js
@@ -143,12 +143,21 @@ describe("Course Creation", () => {
 		// toolbar — dismiss it again before adding a chapter.
 		cy.closeOnboardingModal();
 
-		// Add a chapter. In the editor the chapter button is the "Add" button in
-		// the CourseDetail toolbar (CourseEditor hides CourseOutline's own
-		// header), present whenever the editor is in edit mode — unlike the
-		// load-dependent "Create chapter" empty-state button.
-		cy.contains("button", "Add", { timeout: 20000 }).click();
+		// The chapter "Add" button in the CourseDetail toolbar appears as soon as
+		// the editor enters edit mode, but it delegates to CourseOutline
+		// (openChapterModal), which isn't mounted until the outline resource
+		// resolves. Clicking "Add" during the loading skeleton silently no-ops, so
+		// first wait for the loaded outline — the "No chapters yet" empty state
+		// only renders once outline.data has resolved and CourseOutline is mounted.
+		cy.contains("No chapters yet", { timeout: 20000 }).should("be.visible");
+
+		// Add a chapter via the toolbar "Add" button (CourseEditor hides
+		// CourseOutline's own header).
+		cy.contains("button", "Add").click();
+		// Scope to the chapter dialog by its Title field — the onboarding "Getting
+		// started" panel is also a dismissable layer, but it has no Title input.
 		cy.get("[data-dismissable-layer]")
+			.filter(':has(label:contains("Title"))')
 			.should("be.visible")
 			.within(() => {
 				cy.get("label")

--- a/frontend/src/components/BlockEditor.vue
+++ b/frontend/src/components/BlockEditor.vue
@@ -91,6 +91,11 @@ onMounted(() => {
 			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',
 		},
 		onReady: () => {
+			// onReady can fire after the component unmounted (fast nav / deleting
+			// the open lesson) — by then onBeforeUnmount has nulled `editor`. Bail
+			// so we don't call `new DragDrop(null)`, whose constructor reads
+			// editor.configuration and throws.
+			if (!editor) return
 			// Native EditorJS block menu (the ⋮⋮ settings button → Convert to
 			// H1/H2/…, Move up/down, Delete) plus editorjs-drag-drop, which makes
 			// that settings button a drag handle so blocks reorder by dragging.
@@ -117,12 +122,16 @@ onBeforeUnmount(() => {
 })
 
 defineExpose({
-	isReady: () => editor.isReady,
+	// All editor-instance access below is null-guarded: a debounced parent
+	// autosave can call these after onBeforeUnmount has nulled `editor`.
+	isReady: () => editor?.isReady ?? Promise.resolve(),
 	render: async (data) => {
+		if (!editor) return
 		await editor.render(data)
 		ensureTrailingBlock()
 	},
 	save: async () => {
+		if (!editor) return null
 		const data = await editor.save()
 		// Drop the synthetic trailing empty block so it's never persisted.
 		if (

--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -133,6 +133,11 @@ const { $dialog } = getCurrentInstance()!.appContext.config
 
 const emit = defineEmits<{
 	'select-lesson': [{ chapterNumber: string; lessonNumber: string }]
+	// Keyed delete signals so the parent can match the open lesson precisely. The
+	// name is carried per emit (no shared slot), so concurrent deletes can't name
+	// the wrong doc and an unrelated reload can't consume the signal.
+	'lesson-deleted': [{ lesson: string }]
+	'chapter-deleted': [{ chapter: string }]
 }>()
 
 // The lesson currently being named inline (its docname), and the chapter whose
@@ -337,7 +342,13 @@ function trashLesson(lessonName: string, chapterName: string) {
 				theme: 'red',
 				variant: 'solid',
 				onClick(close) {
-					deleteLesson.submit({ lesson: lessonName, chapter: chapterName })
+					// Per-call onSuccess closes over this lessonName, so the editor is
+					// told exactly which lesson went — no shared slot to drift on
+					// concurrent deletes. Runs alongside the resource-level reload.
+					deleteLesson.submit(
+						{ lesson: lessonName, chapter: chapterName },
+						{ onSuccess: () => emit('lesson-deleted', { lesson: lessonName }) }
+					)
 					close()
 				},
 			},
@@ -357,7 +368,13 @@ function trashChapter(chapterName: string) {
 				theme: 'red',
 				variant: 'solid',
 				onClick(close) {
-					deleteChapter.submit({ chapter: chapterName })
+					deleteChapter.submit(
+						{ chapter: chapterName },
+						{
+							onSuccess: () =>
+								emit('chapter-deleted', { chapter: chapterName }),
+						}
+					)
 					close()
 				},
 			},

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -64,6 +64,8 @@
 				:inlineSelect="true"
 				:selectedLessonNumber="selected?.number"
 				@select-lesson="onSelectLesson"
+				@lesson-deleted="onLessonDeleted"
+				@chapter-deleted="onChapterDeleted"
 			/>
 		</aside>
 		<VideoStatistics
@@ -89,6 +91,7 @@ import {
 	findLessonNameByNumber,
 	lessonExistsByNumber,
 	isSelectionStale,
+	isLessonInChapter,
 } from '@/utils/courseOutline'
 
 const props = defineProps({
@@ -191,6 +194,26 @@ function onLessonSaved({ name, title, include_in_preview, isNew }) {
 			lesson.include_in_preview = include_in_preview ? 1 : 0
 			break
 		}
+	}
+}
+
+// The outline reports a specific lesson/chapter delete. If the lesson open in the
+// editor is the one removed, tell the form before the stale-selection watcher
+// unmounts it, so its teardown flush doesn't set_value the now-deleted document.
+// Keyed by docname (not a generic "selection went stale" signal, which is also
+// true on a course switch or transient outline) and applied synchronously here,
+// so it can't be mis-bound to whichever reload happens to land next.
+function onLessonDeleted({ lesson }) {
+	if (lessonFormRef.value?.lessonName?.() === lesson) {
+		lessonFormRef.value?.markDeleted?.()
+	}
+}
+function onChapterDeleted({ chapter }) {
+	// Deleting a chapter takes its lessons too. Resolve membership against the
+	// still-current outline (the delete's reload hasn't applied yet).
+	const openLesson = lessonFormRef.value?.lessonName?.()
+	if (openLesson && isLessonInChapter(outline.data, chapter, openLesson)) {
+		lessonFormRef.value?.markDeleted?.()
 	}
 }
 

--- a/frontend/src/pages/Courses/StudentCourseProgress.vue
+++ b/frontend/src/pages/Courses/StudentCourseProgress.vue
@@ -38,9 +38,7 @@
 						v-if="lessons.data"
 						class="border border-outline-elevation-2 rounded-lg px-3 max-h-[60vh] overflow-y-auto"
 					>
-						<div
-							class="sticky top-0 z-10 bg-surface-base py-3 text-ink-gray-5"
-						>
+						<div class="sticky top-0 z-10 bg-surface-base py-3 text-ink-gray-5">
 							{{ __('Lesson Progress') }}
 						</div>
 						<div

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -162,16 +162,25 @@ const isDirty = ref(false)
 // only resolves during teardown doesn't persist a stale (possibly deleted)
 // lesson — only the explicit unmount flush may persist then.
 let isUnmounting = false
+// Set when the open lesson is deleted elsewhere: CourseEditor's stale-selection
+// watcher calls markDeleted() before this form unmounts. Suppresses every
+// autosave/flush path so we never set_value a document that no longer exists.
+let lessonDeleted = false
+function markDeleted() {
+	lessonDeleted = true
+}
 
 // Debounced so a burst of keystrokes collapses into a single save shortly
-// after the user pauses. Gate on a still-loaded lesson: if it was deleted while
-// the debounce was pending, saveLesson would hit its createNewLesson branch and
-// resurrect the just-deleted lesson.
+// after the user pauses. Gate on a still-loaded, undeleted lesson: if it was
+// deleted while the debounce was pending, saveLesson would write to the gone
+// document (or hit createNewLesson and resurrect it).
 const autoSave = useDebounceFn(() => {
+	if (lessonDeleted) return
 	if (isDirty.value && lessonDetails.data?.lesson) saveLesson()
 }, 800)
 
 function markDirty({ fromTitle = false } = {}) {
+	if (lessonDeleted) return
 	if (!lessonDetails.data?.lesson) return
 	// The editor fires onChange during programmatic render() too, so gate those
 	// on initialLoadComplete to avoid a spurious autosave on load. Title @input
@@ -184,6 +193,7 @@ function markDirty({ fromTitle = false } = {}) {
 
 defineExpose({
 	saveLesson,
+	markDeleted,
 	isDirty,
 	lessonHasVideo: () => lessonHasVideo.value,
 	lessonName: () => lessonDetails.data?.lesson?.name,
@@ -297,9 +307,10 @@ const addInstructorNotes = (data) => {
 onBeforeUnmount(() => {
 	isUnmounting = true
 	// Best-effort flush of any unsaved edits before the editors are destroyed.
-	// Only when the lesson still exists — flushing after a delete would resurrect
-	// it via saveLesson's createNewLesson branch. flush:true so this explicit
+	// Skip when the lesson was deleted — flushing would set_value a gone document
+	// (or resurrect it via createNewLesson). flush:true so a genuine navigate-away
 	// flush isn't suppressed by the in-flight-autosave teardown guard.
+	if (lessonDeleted) return
 	if (isDirty.value && lessonDetails.data?.lesson) saveLesson({ flush: true })
 })
 
@@ -468,66 +479,64 @@ const storedContentHasBody = () => {
 }
 
 function saveLesson({ flush = false } = {}) {
-	const persistLesson = () => {
-		// During teardown, only the explicit unmount flush may persist. A
-		// debounced autosave that was already in flight when the lesson was
-		// deleted/left must not write a stale (possibly deleted) document.
+	// Capture both editors and kick off their serialisation up front, while both
+	// are still alive. During an unmount flush Vue destroys the child editors
+	// right after this returns, so the old body-then-instructor chain ran the
+	// instructor save() against an already-null editor and silently dropped the
+	// notes. Serialise concurrently so a dirty unmount captures both.
+	// .catch(() => null): an editor whose EditorJS instance is being destroyed
+	// mid-save can reject. Without this Promise.all would reject and the whole
+	// persist — including the stored-content fallback below and the staged title —
+	// is skipped, silently dropping the edit on navigation. A rejected save
+	// degrades to "editor unavailable" (null), so the lesson is still written.
+	const serialise = (ed) =>
+		ed ? Promise.resolve(ed.save()).catch(() => null) : Promise.resolve(null)
+	const bodyPromise = serialise(editor.value)
+	const notesPromise = serialise(instructorEditor.value)
+
+	Promise.all([bodyPromise, notesPromise]).then(([bodyData, notesData]) => {
+		// Body: if the editor was gone (torn down mid-flush) or resolved null, we
+		// can't re-serialise it — fall back to the stored content for the skip
+		// check and leave lesson.content untouched so a staged title edit still
+		// persists. Otherwise only overwrite stored content when the body has real
+		// content: a transient/empty editor (hot-reload remount, render race, mid
+		// lesson-switch) serialises to just an empty paragraph and must not wipe
+		// what's saved.
+		let bodyHasContent = storedContentHasBody()
+		if (bodyData) {
+			bodyData = removeEmptyBlocks(bodyData)
+			bodyHasContent = hasEditorContent(bodyData)
+			if (bodyHasContent) lesson.content = JSON.stringify(bodyData)
+		}
+
+		// Instructor notes: fold in only once the editor has loaded its saved
+		// notes (initialLoadComplete). A title-only autosave can fire before then
+		// (a title @input arms autosave ahead of the editors finishing render), at
+		// which point notesEditor.save() returns its empty default — folding that
+		// would wipe an existing lesson's stored notes. Before load, and when the
+		// editor has torn down (notesData null), keep the stored instructor_content.
+		if (initialLoadComplete && notesData) {
+			notesData = removeEmptyBlocks(notesData)
+			lesson.instructor_content = JSON.stringify(notesData)
+			// instructor_content is now the source of truth; clear the legacy
+			// instructor_notes field so removed notes don't reappear on the
+			// lesson page via the fallback render path.
+			lesson.instructor_notes = ''
+		}
+
+		// Skip only when there's nothing worth saving — no title and no body.
+		if (shouldSkipLessonSave(lesson.title, bodyHasContent)) return
+
+		// During teardown, only the explicit unmount flush may persist. A debounced
+		// autosave already in flight when the lesson was deleted/left must not write
+		// a stale (possibly deleted) document.
 		if (isUnmounting && !flush) return
+		if (lessonDeleted) return
 		if (lessonDetails.data?.lesson) {
 			editCurrentLesson()
 		} else {
 			createNewLesson()
 		}
-	}
-	// Fold in the instructor notes when that editor is still alive. If it has
-	// already torn down (dirty unmount), keep the stored instructor_content and
-	// still persist the staged title/body — don't drop the edit.
-	const saveInstructorThenPersist = () => {
-		if (!instructorEditor.value) {
-			persistLesson()
-			return
-		}
-		instructorEditor.value.save().then((instructorData) => {
-			if (instructorData) {
-				instructorData = removeEmptyBlocks(instructorData)
-				lesson.instructor_content = JSON.stringify(instructorData)
-				// instructor_content is now the source of truth; clear the legacy
-				// instructor_notes field so removed notes don't reappear on the
-				// lesson page via the fallback render path.
-				lesson.instructor_notes = ''
-			}
-			persistLesson()
-		})
-	}
-	const finalize = (bodyHasContent) => {
-		// Skip only when there's nothing worth saving — no title and no body.
-		if (shouldSkipLessonSave(lesson.title, bodyHasContent)) return
-		saveInstructorThenPersist()
-	}
-
-	// If the body editor is gone (torn down mid-flush), we can't re-serialise the
-	// body — but a staged title edit must still persist. Fall back to the stored
-	// content for the skip check and leave lesson.content untouched.
-	if (!editor.value) {
-		finalize(storedContentHasBody())
-		return
-	}
-	editor.value.save().then((outputData) => {
-		// save() resolves null if the editor tore down between the guard and here.
-		if (!outputData) {
-			finalize(storedContentHasBody())
-			return
-		}
-		outputData = removeEmptyBlocks(outputData)
-		const bodyHasContent = hasEditorContent(outputData)
-		// Only overwrite stored content when the body has real content. A
-		// transient/empty editor (hot-reload remount, render race, mid
-		// lesson-switch) serialises to just an empty paragraph and must not wipe
-		// what's saved.
-		if (bodyHasContent) {
-			lesson.content = JSON.stringify(outputData)
-		}
-		finalize(bodyHasContent)
 	})
 }
 

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -110,7 +110,7 @@ const titleRef = ref(null)
 
 function onTitleInput() {
 	autoGrowTitle()
-	markDirty()
+	markDirty({ fromTitle: true })
 }
 
 // Put the caret in the instructor-notes editor when the card is opened, so it's
@@ -158,15 +158,26 @@ const props = defineProps({
 })
 
 const isDirty = ref(false)
+// Set once the component is tearing down, so an in-flight debounced autosave that
+// only resolves during teardown doesn't persist a stale (possibly deleted)
+// lesson — only the explicit unmount flush may persist then.
+let isUnmounting = false
 
 // Debounced so a burst of keystrokes collapses into a single save shortly
-// after the user pauses.
+// after the user pauses. Gate on a still-loaded lesson: if it was deleted while
+// the debounce was pending, saveLesson would hit its createNewLesson branch and
+// resurrect the just-deleted lesson.
 const autoSave = useDebounceFn(() => {
-	if (isDirty.value) saveLesson()
+	if (isDirty.value && lessonDetails.data?.lesson) saveLesson()
 }, 800)
 
-function markDirty() {
-	if (!lessonDetails.data?.lesson || !initialLoadComplete) return
+function markDirty({ fromTitle = false } = {}) {
+	if (!lessonDetails.data?.lesson) return
+	// The editor fires onChange during programmatic render() too, so gate those
+	// on initialLoadComplete to avoid a spurious autosave on load. Title @input
+	// is always real user input (a programmatic v-model set doesn't fire it), so
+	// it arms autosave even before the editors finish their initial render.
+	if (!fromTitle && !initialLoadComplete) return
 	isDirty.value = true
 	autoSave()
 }
@@ -245,9 +256,14 @@ const lessonDetails = createResource({
 })
 
 const addLessonContent = (data) => {
+	// The editor component can unmount mid-load (fast nav / lesson delete), so
+	// guard both the entry and inside the isReady().then() — the ref can go null
+	// between them, and render() on null throws.
+	if (!editor.value) return Promise.resolve()
 	// Return the render promise so callers (autosave arming, autofocus) wait for
 	// the blocks to actually be in the DOM, not just for render() to be called.
 	return editor.value.isReady().then(() => {
+		if (!editor.value) return
 		if (data.lesson.content) {
 			return editor.value.render(
 				sanitizeEditorJs(JSON.parse(data.lesson.content))
@@ -262,7 +278,9 @@ const addLessonContent = (data) => {
 }
 
 const addInstructorNotes = (data) => {
+	if (!instructorEditor.value) return Promise.resolve()
 	return instructorEditor.value.isReady().then(() => {
+		if (!instructorEditor.value) return
 		if (data.lesson.instructor_content) {
 			return instructorEditor.value.render(
 				sanitizeEditorJs(JSON.parse(data.lesson.instructor_content))
@@ -277,8 +295,12 @@ const addInstructorNotes = (data) => {
 }
 
 onBeforeUnmount(() => {
+	isUnmounting = true
 	// Best-effort flush of any unsaved edits before the editors are destroyed.
-	if (isDirty.value) saveLesson()
+	// Only when the lesson still exists — flushing after a delete would resurrect
+	// it via saveLesson's createNewLesson branch. flush:true so this explicit
+	// flush isn't suppressed by the in-flight-autosave teardown guard.
+	if (isDirty.value && lessonDetails.data?.lesson) saveLesson({ flush: true })
 })
 
 const newLessonResource = createResource({
@@ -433,14 +455,71 @@ const convertToJSON = (lessonData) => {
 	return blocks
 }
 
-function saveLesson() {
-	// The debounced autosave can fire as the component tears down; bail if the
-	// editors are already gone.
-	if (!editor.value || !instructorEditor.value) return
+// Whether the already-stored (serialised) lesson body has real content. Used
+// when the live body editor is unavailable so a title-only edit can still be
+// persisted without re-serialising — or wiping — the body.
+const storedContentHasBody = () => {
+	if (!lesson.content) return false
+	try {
+		return hasEditorContent(JSON.parse(lesson.content))
+	} catch {
+		return false
+	}
+}
+
+function saveLesson({ flush = false } = {}) {
+	const persistLesson = () => {
+		// During teardown, only the explicit unmount flush may persist. A
+		// debounced autosave that was already in flight when the lesson was
+		// deleted/left must not write a stale (possibly deleted) document.
+		if (isUnmounting && !flush) return
+		if (lessonDetails.data?.lesson) {
+			editCurrentLesson()
+		} else {
+			createNewLesson()
+		}
+	}
+	// Fold in the instructor notes when that editor is still alive. If it has
+	// already torn down (dirty unmount), keep the stored instructor_content and
+	// still persist the staged title/body — don't drop the edit.
+	const saveInstructorThenPersist = () => {
+		if (!instructorEditor.value) {
+			persistLesson()
+			return
+		}
+		instructorEditor.value.save().then((instructorData) => {
+			if (instructorData) {
+				instructorData = removeEmptyBlocks(instructorData)
+				lesson.instructor_content = JSON.stringify(instructorData)
+				// instructor_content is now the source of truth; clear the legacy
+				// instructor_notes field so removed notes don't reappear on the
+				// lesson page via the fallback render path.
+				lesson.instructor_notes = ''
+			}
+			persistLesson()
+		})
+	}
+	const finalize = (bodyHasContent) => {
+		// Skip only when there's nothing worth saving — no title and no body.
+		if (shouldSkipLessonSave(lesson.title, bodyHasContent)) return
+		saveInstructorThenPersist()
+	}
+
+	// If the body editor is gone (torn down mid-flush), we can't re-serialise the
+	// body — but a staged title edit must still persist. Fall back to the stored
+	// content for the skip check and leave lesson.content untouched.
+	if (!editor.value) {
+		finalize(storedContentHasBody())
+		return
+	}
 	editor.value.save().then((outputData) => {
+		// save() resolves null if the editor tore down between the guard and here.
+		if (!outputData) {
+			finalize(storedContentHasBody())
+			return
+		}
 		outputData = removeEmptyBlocks(outputData)
 		const bodyHasContent = hasEditorContent(outputData)
-		if (shouldSkipLessonSave(lesson.title, bodyHasContent)) return
 		// Only overwrite stored content when the body has real content. A
 		// transient/empty editor (hot-reload remount, render race, mid
 		// lesson-switch) serialises to just an empty paragraph and must not wipe
@@ -448,19 +527,7 @@ function saveLesson() {
 		if (bodyHasContent) {
 			lesson.content = JSON.stringify(outputData)
 		}
-		instructorEditor.value.save().then((outputData) => {
-			outputData = removeEmptyBlocks(outputData)
-			lesson.instructor_content = JSON.stringify(outputData)
-			// instructor_content is now the source of truth; clear the legacy
-			// instructor_notes field so removed notes don't reappear on the
-			// lesson page via the fallback render path.
-			lesson.instructor_notes = ''
-			if (lessonDetails.data?.lesson) {
-				editCurrentLesson()
-			} else {
-				createNewLesson()
-			}
-		})
+		finalize(bodyHasContent)
 	})
 }
 

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -188,6 +188,11 @@ function markDirty({ fromTitle = false } = {}) {
 	// it arms autosave even before the editors finish their initial render.
 	if (!fromTitle && !initialLoadComplete) return
 	isDirty.value = true
+	// An editor change carries new block data — capture it into the local lesson
+	// now, while the editor is alive, so an unmount flush whose save() rejects
+	// mid-destroy still persists this edit rather than stale content. A title edit
+	// carries no block data, so there's nothing to serialise there.
+	if (!fromTitle) captureEditors()
 	autoSave()
 }
 
@@ -478,51 +483,79 @@ const storedContentHasBody = () => {
 	}
 }
 
+// .catch(() => null): an editor whose EditorJS instance is being destroyed
+// mid-save can reject. Without this Promise.all would reject and the whole
+// persist — including the stored-content fallback and the staged title — is
+// skipped, silently dropping the edit on navigation. A rejected save degrades to
+// "editor unavailable" (null), so the lesson is still written from whatever was
+// last captured.
+const serialise = (ed) =>
+	ed ? Promise.resolve(ed.save()).catch(() => null) : Promise.resolve(null)
+
+// Fold freshly-serialised editor output into the local lesson, applying the same
+// guards the persist path needs, and return whether the body (fresh or stored)
+// has real content. Shared by the persist path and the on-change capture so
+// lesson.content / instructor_content stay current even before a persist runs —
+// which is what lets a teardown flush whose save() rejects still write the latest
+// edits instead of stale initial-load content.
+const foldEditorData = (bodyData, notesData) => {
+	// Body: if the editor was gone (torn down mid-flush) or resolved null, we
+	// can't re-serialise it — fall back to the stored content for the skip check
+	// and leave lesson.content untouched so a staged title edit still persists.
+	// Otherwise only overwrite stored content when the body has real content: a
+	// transient/empty editor (hot-reload remount, render race, mid lesson-switch)
+	// serialises to just an empty paragraph and must not wipe what's saved.
+	let bodyHasContent = storedContentHasBody()
+	if (bodyData) {
+		bodyData = removeEmptyBlocks(bodyData)
+		bodyHasContent = hasEditorContent(bodyData)
+		if (bodyHasContent) lesson.content = JSON.stringify(bodyData)
+	}
+
+	// Instructor notes: fold in only once the editor has loaded its saved notes
+	// (initialLoadComplete). A capture/autosave can fire before then (a title
+	// @input arms autosave ahead of the editors finishing render), at which point
+	// notesEditor.save() returns its empty default — folding that would wipe an
+	// existing lesson's stored notes. Before load, and when the editor has torn
+	// down (notesData null), keep the stored instructor_content.
+	if (initialLoadComplete && notesData) {
+		notesData = removeEmptyBlocks(notesData)
+		lesson.instructor_content = JSON.stringify(notesData)
+		// instructor_content is now the source of truth; clear the legacy
+		// instructor_notes field so removed notes don't reappear on the lesson
+		// page via the fallback render path.
+		lesson.instructor_notes = ''
+	}
+
+	return bodyHasContent
+}
+
+// Serialise the live editors into the local lesson without persisting. Runs on
+// every editor @change, while the editors are still alive (no teardown race), so
+// a later unmount flush whose save() rejects mid-destroy still has the latest
+// content folded in. Without this, a rejected teardown save falls back to the
+// stale initial-load content, and the persist below reports success while
+// dropping the user's most recent edits.
+const captureEditors = async () => {
+	if (lessonDeleted) return
+	const [bodyData, notesData] = await Promise.all([
+		serialise(editor.value),
+		serialise(instructorEditor.value),
+	])
+	foldEditorData(bodyData, notesData)
+}
+
 function saveLesson({ flush = false } = {}) {
 	// Capture both editors and kick off their serialisation up front, while both
 	// are still alive. During an unmount flush Vue destroys the child editors
 	// right after this returns, so the old body-then-instructor chain ran the
 	// instructor save() against an already-null editor and silently dropped the
 	// notes. Serialise concurrently so a dirty unmount captures both.
-	// .catch(() => null): an editor whose EditorJS instance is being destroyed
-	// mid-save can reject. Without this Promise.all would reject and the whole
-	// persist — including the stored-content fallback below and the staged title —
-	// is skipped, silently dropping the edit on navigation. A rejected save
-	// degrades to "editor unavailable" (null), so the lesson is still written.
-	const serialise = (ed) =>
-		ed ? Promise.resolve(ed.save()).catch(() => null) : Promise.resolve(null)
 	const bodyPromise = serialise(editor.value)
 	const notesPromise = serialise(instructorEditor.value)
 
 	Promise.all([bodyPromise, notesPromise]).then(([bodyData, notesData]) => {
-		// Body: if the editor was gone (torn down mid-flush) or resolved null, we
-		// can't re-serialise it — fall back to the stored content for the skip
-		// check and leave lesson.content untouched so a staged title edit still
-		// persists. Otherwise only overwrite stored content when the body has real
-		// content: a transient/empty editor (hot-reload remount, render race, mid
-		// lesson-switch) serialises to just an empty paragraph and must not wipe
-		// what's saved.
-		let bodyHasContent = storedContentHasBody()
-		if (bodyData) {
-			bodyData = removeEmptyBlocks(bodyData)
-			bodyHasContent = hasEditorContent(bodyData)
-			if (bodyHasContent) lesson.content = JSON.stringify(bodyData)
-		}
-
-		// Instructor notes: fold in only once the editor has loaded its saved
-		// notes (initialLoadComplete). A title-only autosave can fire before then
-		// (a title @input arms autosave ahead of the editors finishing render), at
-		// which point notesEditor.save() returns its empty default — folding that
-		// would wipe an existing lesson's stored notes. Before load, and when the
-		// editor has torn down (notesData null), keep the stored instructor_content.
-		if (initialLoadComplete && notesData) {
-			notesData = removeEmptyBlocks(notesData)
-			lesson.instructor_content = JSON.stringify(notesData)
-			// instructor_content is now the source of truth; clear the legacy
-			// instructor_notes field so removed notes don't reappear on the
-			// lesson page via the fallback render path.
-			lesson.instructor_notes = ''
-		}
+		const bodyHasContent = foldEditorData(bodyData, notesData)
 
 		// Skip only when there's nothing worth saving — no title and no body.
 		if (shouldSkipLessonSave(lesson.title, bodyHasContent)) return

--- a/frontend/src/tests/blockEditor.test.ts
+++ b/frontend/src/tests/blockEditor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import Paragraph from '@editorjs/paragraph'
 import BlockEditor from '@/components/BlockEditor.vue'
 
@@ -28,7 +28,7 @@ window.matchMedia ??= (() => ({
 type BlockEditorApi = {
 	isReady: () => Promise<void>
 	render: (data: object) => Promise<void>
-	save: () => Promise<{ blocks: { data: { text: string } }[] }>
+	save: () => Promise<{ blocks: { data: { text: string } }[] } | null>
 	focus: (atEnd?: boolean) => void
 }
 
@@ -52,7 +52,11 @@ describe('BlockEditor', () => {
 	})
 
 	afterEach(() => {
-		wrapper.unmount()
+		try {
+			wrapper.unmount()
+		} catch {
+			// a test may have unmounted already (teardown-guard case)
+		}
 		document.body.innerHTML = ''
 	})
 
@@ -79,6 +83,17 @@ describe('BlockEditor', () => {
 	})
 
 	it('exposes a focus() method that places the caret without throwing', () => {
+		expect(() => editorApi.focus()).not.toThrow()
+	})
+
+	it('null-guards exposed methods after unmount (teardown autosave)', async () => {
+		wrapper.unmount()
+		// A debounced parent autosave (LessonForm.saveLesson) can call these
+		// after onBeforeUnmount has nulled the editor instance. They must no-op
+		// instead of throwing "Cannot read properties of null (reading 'save')".
+		await expect(editorApi.save()).resolves.toBeNull()
+		await expect(editorApi.render(TWO_BLOCKS)).resolves.toBeUndefined()
+		await expect(editorApi.isReady()).resolves.toBeUndefined()
 		expect(() => editorApi.focus()).not.toThrow()
 	})
 })

--- a/frontend/src/tests/blockEditorTeardown.test.ts
+++ b/frontend/src/tests/blockEditorTeardown.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+
+// vi.mock factories are hoisted above module init, so the shared refs they close
+// over must be created via vi.hoisted. `state.onReady` captures the onReady
+// config callback EditorJS would invoke once initialised, letting the test
+// control *when* onReady fires relative to mount/unmount.
+const mocks = vi.hoisted(() => ({
+	DragDrop: vi.fn(),
+	destroy: vi.fn(),
+	state: { onReady: null as null | (() => void) },
+}))
+
+vi.mock('@editorjs/editorjs', () => ({
+	default: class {
+		isReady = Promise.resolve()
+		destroy = mocks.destroy
+		constructor(config: { onReady?: () => void }) {
+			mocks.state.onReady = config.onReady ?? null
+		}
+	},
+}))
+
+// DragDrop's real constructor reads `editor.configuration`; here we only need to
+// know whether BlockEditor tried to construct it.
+vi.mock('editorjs-drag-drop', () => ({ default: mocks.DragDrop }))
+
+vi.mock('@/utils', () => ({
+	getEditorTools: () => ({}),
+	getEditorTunes: () => [],
+	enablePlyr: () => {},
+}))
+
+vi.mock('@/utils/blockTunes/clipboardTunes', () => ({
+	handleBlockClipboardShortcut: () => {},
+}))
+
+import BlockEditor from '@/components/BlockEditor.vue'
+
+describe('BlockEditor onReady teardown race', () => {
+	let wrapper: VueWrapper
+
+	beforeEach(() => {
+		mocks.state.onReady = null
+		mocks.DragDrop.mockClear()
+		mocks.destroy.mockClear()
+	})
+
+	afterEach(() => {
+		try {
+			wrapper?.unmount()
+		} catch {
+			// already unmounted by the test
+		}
+		document.body.innerHTML = ''
+	})
+
+	it('does not construct DragDrop(null) when onReady fires after unmount', () => {
+		wrapper = mount(BlockEditor, { attachTo: document.body })
+		expect(mocks.state.onReady).toBeTypeOf('function')
+
+		// onBeforeUnmount nulls the internal editor ref...
+		wrapper.unmount()
+		// ...and EditorJS only now resolves and invokes the queued onReady. With
+		// the guard this is a no-op; without it, BlockEditor would call
+		// `new DragDrop(null)`, whose constructor reads null.configuration.
+		expect(() => mocks.state.onReady?.()).not.toThrow()
+		expect(mocks.DragDrop).not.toHaveBeenCalled()
+	})
+
+	it('constructs DragDrop once when onReady fires while still mounted', () => {
+		wrapper = mount(BlockEditor, { attachTo: document.body })
+		expect(mocks.state.onReady).toBeTypeOf('function')
+
+		mocks.state.onReady?.()
+		expect(mocks.DragDrop).toHaveBeenCalledTimes(1)
+	})
+})

--- a/frontend/src/tests/courseOutline.test.ts
+++ b/frontend/src/tests/courseOutline.test.ts
@@ -4,6 +4,7 @@ import {
 	lessonExistsByNumber,
 	lessonExistsByName,
 	isSelectionStale,
+	isLessonInChapter,
 } from '@/utils/courseOutline'
 
 // Two lessons in one chapter. `number` is positional ("chapterIdx-lessonIdx")
@@ -84,5 +85,32 @@ describe('isSelectionStale (delete clears the editor)', () => {
 	it('is never stale with no selection or no outline', () => {
 		expect(isSelectionStale(null, outline)).toBe(false)
 		expect(isSelectionStale({ name: 'LESSON-A' }, null)).toBe(false)
+	})
+})
+
+describe('isLessonInChapter (chapter delete takes its lessons)', () => {
+	it('is true when the lesson belongs to the named chapter', () => {
+		expect(isLessonInChapter(outline, 'CH-1', 'LESSON-B')).toBe(true)
+	})
+
+	it('is false when the lesson is in a different chapter', () => {
+		const twoChapters = [
+			...outline,
+			{
+				name: 'CH-2',
+				title: 'Chapter 2',
+				idx: 2,
+				lessons: [{ name: 'LESSON-C', title: 'Outro', number: '2-1' }],
+			},
+		]
+		expect(isLessonInChapter(twoChapters, 'CH-2', 'LESSON-A')).toBe(false)
+		expect(isLessonInChapter(twoChapters, 'CH-2', 'LESSON-C')).toBe(true)
+	})
+
+	it('is false for an unknown chapter, missing lesson, or empty outline', () => {
+		expect(isLessonInChapter(outline, 'CH-9', 'LESSON-A')).toBe(false)
+		expect(isLessonInChapter(outline, 'CH-1', null)).toBe(false)
+		expect(isLessonInChapter(outline, 'CH-1', undefined)).toBe(false)
+		expect(isLessonInChapter(null, 'CH-1', 'LESSON-A')).toBe(false)
 	})
 })

--- a/frontend/src/tests/lessonFormTeardown.test.ts
+++ b/frontend/src/tests/lessonFormTeardown.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+
+// Shared, hoisted state the (hoisted) vi.mock factories close over.
+// - `created.list` records every createResource() the component makes, so a test
+//   can find a specific resource by its url and inspect/submit it.
+// - `editorState.saveData` is what each mocked BlockEditor.save() returns, keyed
+//   by the editor's uploadContext.fieldname ('content' vs 'instructor_content').
+const created = vi.hoisted(() => ({ list: [] as any[] }))
+const editorState = vi.hoisted(() => ({
+	saveData: {} as Record<string, any>,
+	// When true, the instructor editor's isReady() never resolves, so the form's
+	// initial load never completes (initialLoadComplete stays false) — modelling a
+	// title autosave that fires before the saved notes have rendered.
+	holdInstructorReady: false,
+	// When true, the body editor's save() rejects — modelling an EditorJS instance
+	// being destroyed mid-save during teardown.
+	rejectBodySave: false,
+}))
+
+vi.mock('frappe-ui', async () => {
+	const { reactive } = await import('vue')
+	const stub = (name: string) => ({ name, render: () => null })
+	return {
+		createResource: (config: any) => {
+			const r: any = reactive({
+				data: null,
+				loading: false,
+				_config: config,
+				lastParams: null,
+				lastHandlers: null,
+			})
+			// Run the real makeParams so the recorded params reflect production
+			// serialisation (e.g. set_value's `fieldname` is the live lesson object).
+			r.submit = vi.fn((params: any, handlers: any) => {
+				r.lastParams = config.makeParams ? config.makeParams(params) : params
+				r.lastHandlers = handlers
+				return Promise.resolve()
+			})
+			r.reload = vi.fn()
+			r.fetch = vi.fn()
+			created.list.push(r)
+			return r
+		},
+		toast: { success: vi.fn(), error: vi.fn() },
+		Badge: stub('Badge'),
+		Button: stub('Button'),
+		Switch: stub('Switch'),
+		Tooltip: stub('Tooltip'),
+	}
+})
+
+// BlockEditor mock: faithful to the teardown contract — onBeforeUnmount nulls the
+// instance, after which save() returns null (matching the real null guard). save()
+// reads `editorState.saveData[fieldname]` so a test can stage "edited" content.
+vi.mock('@/components/BlockEditor.vue', async () => {
+	const { defineComponent, h, onBeforeUnmount } = await import('vue')
+	return {
+		default: defineComponent({
+			props: { uploadContext: { type: Object, default: () => ({}) } },
+			emits: ['change'],
+			setup(props, { expose }) {
+				let alive = true
+				onBeforeUnmount(() => {
+					alive = false
+				})
+				const field = props.uploadContext?.fieldname
+				expose({
+					isReady: () =>
+						field === 'instructor_content' && editorState.holdInstructorReady
+							? new Promise(() => {})
+							: Promise.resolve(),
+					render: async () => {},
+					focus: () => {},
+					save: async () => {
+						if (field === 'content' && editorState.rejectBodySave) {
+							throw new Error('editor torn down mid-save')
+						}
+						return alive ? (editorState.saveData[field] ?? null) : null
+					},
+				})
+				return () => h('div', { class: 'block-editor-stub' })
+			},
+		}),
+	}
+})
+
+vi.mock('lucide-vue-next', () => ({
+	ChevronRight: { render: () => null },
+	NotebookPen: { render: () => null },
+}))
+
+vi.mock('frappe-ui/frappe', () => ({
+	useOnboarding: () => ({ updateOnboardingStep: vi.fn() }),
+	useTelemetry: () => ({ capture: vi.fn() }),
+}))
+
+vi.mock('@/composables/useKeyboardShortcuts', () => ({
+	useKeyboardShortcuts: () => {},
+	saveShortcut: (fn: () => void) => ({ key: 's', handler: fn }),
+}))
+
+vi.mock('@/utils', () => ({
+	enablePlyr: () => {},
+	sanitizeEditorJs: (x: any) => x,
+}))
+
+vi.mock('@/utils/video', () => ({ hasVideoContent: () => false }))
+
+import LessonForm from '@/pages/LessonForm.vue'
+
+const LESSON_NAME = 'LESSON-1'
+const paragraph = (text: string) => ({
+	blocks: [{ type: 'paragraph', data: { text } }],
+})
+
+const findResource = (url: string, doctype?: string) =>
+	created.list.find(
+		(r) =>
+			r._config.url === url &&
+			(!doctype ||
+				r._config.makeParams?.({})?.doc?.doctype === doctype ||
+				r._config.makeParams?.({ lesson: '' })?.doctype === doctype)
+	)
+
+// Mount LessonForm and drive its lessonDetails resource to "loaded" so the
+// editors render and autosave is armed, mirroring a real open lesson.
+async function mountLoaded(lessonOverrides: Record<string, any> = {}) {
+	const wrapper = mount(LessonForm, {
+		props: { courseName: 'C1', chapterNumber: '1', lessonNumber: '1' },
+		global: {
+			config: { globalProperties: { __: (s: string) => s } as any },
+			provide: {
+				$user: {
+					data: {
+						is_moderator: true,
+						is_instructor: true,
+						is_system_manager: false,
+					},
+				},
+			},
+		},
+		attachTo: document.body,
+	})
+	const details = created.list.find(
+		(r) => r._config.url === 'lms.lms.utils.get_lesson_creation_details'
+	)
+	const data = {
+		lesson: {
+			name: LESSON_NAME,
+			title: 'Existing title',
+			include_in_preview: 0,
+			content: '',
+			instructor_content: '',
+			...lessonOverrides,
+		},
+		chapter: { name: 'CH-1' },
+	}
+	details.data = data
+	details._config.onSuccess(data)
+	await flushPromises()
+	return wrapper
+}
+
+// A title @input is real user input, so it both updates v-model and arms autosave.
+async function editTitle(wrapper: VueWrapper, title: string) {
+	await wrapper.find('textarea.lesson-title').setValue(title)
+}
+
+describe('LessonForm teardown autosave', () => {
+	let wrapper: VueWrapper
+
+	beforeEach(() => {
+		created.list.length = 0
+		editorState.saveData = {}
+		editorState.holdInstructorReady = false
+		editorState.rejectBodySave = false
+	})
+
+	afterEach(() => {
+		try {
+			wrapper?.unmount()
+		} catch {
+			// already unmounted by the test
+		}
+		document.body.innerHTML = ''
+	})
+
+	it('folds in instructor-note edits even when unmount flushes during the body save', async () => {
+		wrapper = await mountLoaded()
+		// Body has real content (so the save isn't skipped) and the instructor
+		// editor holds a fresh, unsaved note.
+		editorState.saveData.content = paragraph('Body text')
+		editorState.saveData.instructor_content = paragraph('Edited note')
+		await editTitle(wrapper, 'Edited title')
+
+		// Unmount flush: the body save resolves on a microtask, by which point the
+		// instructor editor has torn down. The instructor note must NOT be dropped.
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		expect(editLesson.lastParams.name).toBe(LESSON_NAME)
+		expect(editLesson.lastParams.fieldname.instructor_content).toContain(
+			'Edited note'
+		)
+	})
+
+	it('still persists the lesson when an editor save rejects during teardown', async () => {
+		wrapper = await mountLoaded()
+		// The body editor's save() rejects (its EditorJS instance is being torn
+		// down). The title edit must still be written — not lost to a rejected
+		// Promise.all.
+		editorState.rejectBodySave = true
+		await editTitle(wrapper, 'Edited title')
+
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		expect(editLesson.lastParams.fieldname.title).toBe('Edited title')
+	})
+
+	it('does not wipe stored instructor notes on a title-only flush before the notes finish loading', async () => {
+		// The instructor editor never finishes loading its saved notes, so the
+		// form's initial load stays incomplete and the editor still serialises to
+		// its empty default.
+		editorState.holdInstructorReady = true
+		const STORED_NOTES = JSON.stringify(paragraph('Saved notes'))
+		wrapper = await mountLoaded({ instructor_content: STORED_NOTES })
+
+		editorState.saveData.content = paragraph('Body text')
+		editorState.saveData.instructor_content = { blocks: [] } // empty default
+		// A title edit arms autosave even before the editors finish rendering.
+		await editTitle(wrapper, 'Edited title')
+
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		// The stored notes must survive — folding the empty default would wipe them.
+		expect(editLesson.lastParams.fieldname.instructor_content).toBe(STORED_NOTES)
+	})
+
+	it('does not save the lesson on teardown once it has been marked deleted', async () => {
+		wrapper = await mountLoaded()
+		editorState.saveData.content = paragraph('Body text')
+		await editTitle(wrapper, 'Edited title')
+
+		// The open lesson was deleted elsewhere; CourseEditor signals this before
+		// the form unmounts. The flush must not write to the deleted document.
+		;(wrapper.vm as any).markDeleted()
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).not.toHaveBeenCalled()
+	})
+
+	it('still flushes a dirty lesson on genuine navigation (not deleted)', async () => {
+		wrapper = await mountLoaded()
+		editorState.saveData.content = paragraph('Body text')
+		await editTitle(wrapper, 'Edited title')
+
+		// No deletion signal — a normal navigate-away must still persist the edit.
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		expect(editLesson.lastParams.name).toBe(LESSON_NAME)
+	})
+})

--- a/frontend/src/tests/lessonFormTeardown.test.ts
+++ b/frontend/src/tests/lessonFormTeardown.test.ts
@@ -16,6 +16,8 @@ const editorState = vi.hoisted(() => ({
 	// When true, the body editor's save() rejects — modelling an EditorJS instance
 	// being destroyed mid-save during teardown.
 	rejectBodySave: false,
+	// Same, for the instructor-notes editor.
+	rejectNotesSave: false,
 }))
 
 vi.mock('frappe-ui', async () => {
@@ -76,6 +78,12 @@ vi.mock('@/components/BlockEditor.vue', async () => {
 						if (field === 'content' && editorState.rejectBodySave) {
 							throw new Error('editor torn down mid-save')
 						}
+						if (
+							field === 'instructor_content' &&
+							editorState.rejectNotesSave
+						) {
+							throw new Error('editor torn down mid-save')
+						}
 						return alive ? (editorState.saveData[field] ?? null) : null
 					},
 				})
@@ -108,6 +116,7 @@ vi.mock('@/utils', () => ({
 vi.mock('@/utils/video', () => ({ hasVideoContent: () => false }))
 
 import LessonForm from '@/pages/LessonForm.vue'
+import BlockEditorStub from '@/components/BlockEditor.vue'
 
 const LESSON_NAME = 'LESSON-1'
 const paragraph = (text: string) => ({
@@ -167,6 +176,16 @@ async function editTitle(wrapper: VueWrapper, title: string) {
 	await wrapper.find('textarea.lesson-title').setValue(title)
 }
 
+// Fire a @change from a specific BlockEditor (body vs instructor), modelling an
+// edit inside that editor while it is still alive.
+async function editEditor(wrapper: VueWrapper, fieldname: string) {
+	const editor = wrapper
+		.findAllComponents(BlockEditorStub)
+		.find((c) => (c.props('uploadContext') as any)?.fieldname === fieldname)
+	editor!.vm.$emit('change')
+	await flushPromises()
+}
+
 describe('LessonForm teardown autosave', () => {
 	let wrapper: VueWrapper
 
@@ -175,6 +194,7 @@ describe('LessonForm teardown autosave', () => {
 		editorState.saveData = {}
 		editorState.holdInstructorReady = false
 		editorState.rejectBodySave = false
+		editorState.rejectNotesSave = false
 	})
 
 	afterEach(() => {
@@ -221,6 +241,57 @@ describe('LessonForm teardown autosave', () => {
 		const editLesson = findResource('frappe.client.set_value')
 		expect(editLesson.submit).toHaveBeenCalledTimes(1)
 		expect(editLesson.lastParams.fieldname.title).toBe('Edited title')
+	})
+
+	it('persists the latest body edit captured before teardown even when the body save rejects', async () => {
+		// Lesson opens with stored body content.
+		wrapper = await mountLoaded({
+			content: JSON.stringify(paragraph('Old body')),
+		})
+
+		// User edits the body; the @change captures the new content into the local
+		// lesson while the editor is still alive (no teardown race yet).
+		editorState.saveData.content = paragraph('New body')
+		await editEditor(wrapper, 'content')
+
+		// Now the editor is torn down and its save() rejects on the unmount flush.
+		// The freshly-captured "New body" must win — not the stale stored content,
+		// and not a silently-dropped edit behind a successful-looking save.
+		editorState.rejectBodySave = true
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		expect(editLesson.lastParams.fieldname.content).toContain('New body')
+		expect(editLesson.lastParams.fieldname.content).not.toContain('Old body')
+	})
+
+	it('persists the latest instructor-note edit captured before teardown even when its save rejects', async () => {
+		wrapper = await mountLoaded({
+			content: JSON.stringify(paragraph('Body text')),
+			instructor_content: JSON.stringify(paragraph('Old note')),
+		})
+
+		// Edit the instructor note; captured while the editor is alive.
+		editorState.saveData.content = paragraph('Body text')
+		editorState.saveData.instructor_content = paragraph('New note')
+		await editEditor(wrapper, 'instructor_content')
+
+		// The instructor editor's save() rejects on the unmount flush (its EditorJS
+		// instance is being destroyed). The captured note must still be persisted.
+		editorState.rejectNotesSave = true
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.submit).toHaveBeenCalledTimes(1)
+		expect(editLesson.lastParams.fieldname.instructor_content).toContain(
+			'New note'
+		)
+		expect(editLesson.lastParams.fieldname.instructor_content).not.toContain(
+			'Old note'
+		)
 	})
 
 	it('does not wipe stored instructor notes on a title-only flush before the notes finish loading', async () => {

--- a/frontend/src/utils/courseOutline.ts
+++ b/frontend/src/utils/courseOutline.ts
@@ -44,3 +44,19 @@ export function isSelectionStale(
 		? !lessonExistsByName(chapters, selected.name)
 		: !lessonExistsByNumber(chapters, selected.number ?? '')
 }
+
+/**
+ * Whether `lessonName` lives in the chapter `chapterName`. Used when a chapter is
+ * deleted to decide whether the open lesson went with it — resolved against the
+ * still-current outline (the delete's reload hasn't landed yet) so the editor can
+ * suppress that lesson's teardown flush before it writes to the deleted document.
+ */
+export function isLessonInChapter(
+	chapters: Chapters,
+	chapterName: string,
+	lessonName: string | null | undefined
+): boolean {
+	if (!lessonName) return false
+	const chapter = chapters?.find((c) => c.name === chapterName)
+	return !!chapter?.lessons?.some((l) => l.name === lessonName)
+}


### PR DESCRIPTION
- Fixes a few cases where the lesson editor didnt save in silence. If you renamed a lesson or edited its notes and then clicked away quickly, those edits could get dropped while the screen still looked like it saved fine.
- Also stops the editor from re-saving a lesson (or chapter) you just deleted, which could otherwise bring the deleted item back.