### PR TITLE
feat: wrap UI strings in __() and add RTL support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -201,6 +201,9 @@
 			media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Arabic:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 		<title>{{ title | e }}</title>
 		<meta name="title" content="{{ meta.title | e }}" />
 		<meta name="image" content="{{ meta.image | e }}" />

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -121,7 +121,7 @@ const addOtherLinks = () => {
 		addLink('Profile', 'UserRound')
 		addLink('Log out', 'LogOut')
 	} else {
-		addLink('Log in', 'LogIn')
+		addLink(__('Log in'), 'LogIn')
 	}
 }
 
@@ -163,7 +163,7 @@ const addAssignments = () => {
 }
 
 const addProgrammingExercises = () => {
-	addLink('Programming Exercises', 'Code', 'ProgrammingExercises')
+	addLink(__('Programming Exercises'), 'Code', 'ProgrammingExercises')
 }
 
 const addPrograms = async () => {

--- a/frontend/src/components/Modals/LiveClassModal.vue
+++ b/frontend/src/components/Modals/LiveClassModal.vue
@@ -137,7 +137,7 @@ const getTimezoneOptions = () => {
 const getRecordingOptions = () => {
 	return [
 		{
-			label: 'No Recording',
+			label: __('No Recording'),
 			value: 'No Recording',
 		},
 		{

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -8,7 +8,7 @@
 				class="text-p-md font-semibold text-ink-gray-9 mb-1"
 				:class="{ 'mt-5': index > 0 }"
 			>
-				{{ section.label }}
+				{{ __(section.label) }}
 			</div>
 			<template
 				v-for="(column, columnIndex) in section.columns"
@@ -40,7 +40,7 @@
 								<div class="">
 									<Button @click="openFileSelector" :loading="uploading">
 										{{
-											uploading ? `Uploading ${progress}%` : 'Upload an image'
+											uploading ? `${__('Uploading')} ${progress}%` : __('Upload an image')
 										}}
 									</Button>
 								</div>
@@ -76,7 +76,7 @@
 						<CodeEditor
 							:label="__(field.label)"
 							type="HTML"
-							description="The HTML you add here will be shown on your sign up page."
+							:description="__('The HTML you add here will be shown on your sign up page.')"
 							v-model="data[field.name]"
 							height="250px"
 							class="shrink-0"

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -275,7 +275,7 @@ const tabsStructure = computed(() => {
 					],
 				},
 				{
-					label: __('Course Progress'),
+					label: 'Course Progress',
 					icon: 'Activity',
 					description:
 						'Control how lessons are marked complete: dwell time and enforcement toggles for video, quiz, and assignment.',
@@ -347,7 +347,7 @@ const tabsStructure = computed(() => {
 					template: markRaw(Categories),
 				},
 				{
-					label: __('Email Templates'),
+					label: 'Email Templates',
 					description: __('Manage the email templates for your learning system'),
 					icon: 'MailPlus',
 					template: markRaw(EmailTemplates),
@@ -486,7 +486,7 @@ const tabsStructure = computed(() => {
 					template: markRaw(ZoomSettings),
 				},
 				{
-					label: __('Google Meet'),
+					label: 'Google Meet',
 					description:
 						__('Manage Google Meet accounts to conduct live classes from batches'),
 					icon: 'Presentation',

--- a/frontend/src/components/Settings/Settings.vue
+++ b/frontend/src/components/Settings/Settings.vue
@@ -100,19 +100,19 @@ const tabsStructure = computed(() => {
 						'Configure system-wide defaults, notifications, and contact information',
 					sections: [
 						{
-							label: 'System Configurations',
+							label: __('System Configurations'),
 							columns: [
 								{
 									fields: [
 										{
-											label: 'Allow Guest Access',
+											label: __('Allow Guest Access'),
 											name: 'allow_guest_access',
 											description:
 												'If enabled, users can access the course and batch lists without logging in.',
 											type: 'checkbox',
 										},
 										{
-											label: 'Prevent Skipping Videos',
+											label: __('Prevent Skipping Videos'),
 											name: 'prevent_skipping_videos',
 											type: 'checkbox',
 											description:
@@ -123,14 +123,14 @@ const tabsStructure = computed(() => {
 								{
 									fields: [
 										{
-											label: 'Disable PWA',
+											label: __('Disable PWA'),
 											name: 'disable_pwa',
 											type: 'checkbox',
 											description:
 												'If checked, users will not be able to install the application as a Progressive Web App.',
 										},
 										{
-											label: 'Send calendar invite for evaluations',
+											label: __('Send calendar invite for evaluations'),
 											name: 'send_calendar_invite_for_evaluations',
 											description:
 												'If enabled, it sends google calendar invite to the student for evaluations.',
@@ -146,60 +146,60 @@ const tabsStructure = computed(() => {
 								{
 									fields: [
 										{
-											label: 'Send Notification for Published Courses',
+											label: __('Send Notification for Published Courses'),
 											name: 'send_notification_for_published_courses',
 											type: 'select',
 											options: [' ', 'Email', 'In-app'],
 											description:
-												'Notify members when a new course is published.',
+												__('Notify members when a new course is published.'),
 										},
 									],
 								},
 								{
 									fields: [
 										{
-											label: 'Send Notification for Published Batches',
+											label: __('Send Notification for Published Batches'),
 											name: 'send_notification_for_published_batches',
 											type: 'select',
 											options: [' ', 'Email', 'In-app'],
 											description:
-												'Notify members when a new batch is published.',
+												__('Notify members when a new batch is published.'),
 										},
 									],
 								},
 							],
 						},
 						{
-							label: 'Email Templates',
+							label: __('Email Templates'),
 							columns: [
 								{
 									fields: [
 										{
-											label: 'Batch Confirmation Email Template',
+											label: __('Batch Confirmation Email Template'),
 											name: 'batch_confirmation_template',
 											doctype: 'Email Template',
 											type: 'Link',
 											description:
-												'Email template sent to students upon batch enrollment confirmation.',
+												__('Email template sent to students upon batch enrollment confirmation.'),
 										},
 									],
 								},
 								{
 									fields: [
 										{
-											label: 'Certification Email Template',
+											label: __('Certification Email Template'),
 											name: 'certification_template',
 											doctype: 'Email Template',
 											type: 'Link',
 											description:
-												'Email template sent to students when they earn a certification.',
+												__('Email template sent to students when they earn a certification.'),
 										},
 									],
 								},
 							],
 						},
 						{
-							label: 'Contact Information',
+							label: __('Contact Information'),
 							columns: [
 								{
 									fields: [
@@ -208,7 +208,7 @@ const tabsStructure = computed(() => {
 											name: 'contact_us_email',
 											type: 'text',
 											description:
-												'Users can reach out to this email for support or inquiries.',
+												__('Users can reach out to this email for support or inquiries.'),
 										},
 									],
 								},
@@ -219,7 +219,7 @@ const tabsStructure = computed(() => {
 											name: 'contact_us_url',
 											type: 'text',
 											description:
-												'Users can reach out to this URL for support or inquiries.',
+												__('Users can reach out to this URL for support or inquiries.'),
 										},
 									],
 								},
@@ -231,7 +231,7 @@ const tabsStructure = computed(() => {
 								{
 									fields: [
 										{
-											label: 'Allow Job Posting',
+											label: __('Allow Job Posting'),
 											name: 'allow_job_posting',
 											type: 'checkbox',
 											description:
@@ -262,7 +262,7 @@ const tabsStructure = computed(() => {
 								{
 									fields: [
 										{
-											label: 'Unsplash Access Key',
+											label: __('Unsplash Access Key'),
 											name: 'unsplash_access_key',
 											description:
 												'Allows users to pick a profile cover image from Unsplash. https://unsplash.com/documentation#getting-started.',
@@ -275,13 +275,13 @@ const tabsStructure = computed(() => {
 					],
 				},
 				{
-					label: 'Course Progress',
+					label: __('Course Progress'),
 					icon: 'Activity',
 					description:
 						'Control how lessons are marked complete: dwell time and enforcement toggles for video, quiz, and assignment.',
 					sections: [
 						{
-							label: 'Dwell Time',
+							label: __('Dwell Time'),
 							columns: [
 								{
 									fields: [
@@ -291,7 +291,7 @@ const tabsStructure = computed(() => {
 											type: 'number',
 											min: 1,
 											description:
-												'Seconds a learner must stay on a lesson before it auto-marks complete.',
+												__('Seconds a learner must stay on a lesson before it auto-marks complete.'),
 										},
 									],
 								},
@@ -336,19 +336,19 @@ const tabsStructure = computed(() => {
 				{
 					label: 'Badges',
 					description:
-						'Create badges and assign them to students to acknowledge their achievements',
+						__('Create badges and assign them to students to acknowledge their achievements'),
 					icon: 'Award',
 					template: markRaw(Badges),
 				},
 				{
 					label: 'Categories',
-					description: 'Double click to edit the category',
+					description: __('Double click to edit the category'),
 					icon: 'Network',
 					template: markRaw(Categories),
 				},
 				{
-					label: 'Email Templates',
-					description: 'Manage the email templates for your learning system',
+					label: __('Email Templates'),
+					description: __('Manage the email templates for your learning system'),
 					icon: 'MailPlus',
 					template: markRaw(EmailTemplates),
 				},
@@ -361,7 +361,7 @@ const tabsStructure = computed(() => {
 				{
 					label: 'Members',
 					description:
-						'Add new members or manage roles and permissions of existing members',
+						__('Add new members or manage roles and permissions of existing members'),
 					icon: 'User',
 					template: markRaw(Members),
 				},
@@ -374,22 +374,22 @@ const tabsStructure = computed(() => {
 				{
 					label: 'Configuration',
 					icon: 'CreditCard',
-					description: 'Manage all your payment related settings and defaults',
+					description: __('Manage all your payment related settings and defaults'),
 					sections: [
 						{
 							columns: [
 								{
 									fields: [
 										{
-											label: 'Default Currency',
+											label: __('Default Currency'),
 											name: 'default_currency',
 											type: 'Link',
 											doctype: 'Currency',
 											description:
-												'Default currency used for course and batch pricing.',
+												__('Default currency used for course and batch pricing.'),
 										},
 										{
-											label: 'Show USD equivalent amount',
+											label: __('Show USD equivalent amount'),
 											name: 'show_usd_equivalent',
 											type: 'checkbox',
 											description:
@@ -407,15 +407,15 @@ const tabsStructure = computed(() => {
 								{
 									fields: [
 										{
-											label: 'Payment Gateway',
+											label: __('Payment Gateway'),
 											name: 'payment_gateway',
 											type: 'Link',
 											doctype: 'Payment Gateway',
 											description:
-												'Payment gateway used to process course and batch purchases.',
+												__('Payment gateway used to process course and batch purchases.'),
 										},
 										{
-											label: 'Apply GST for India',
+											label: __('Apply GST for India'),
 											name: 'apply_gst',
 											type: 'checkbox',
 											description:
@@ -426,7 +426,7 @@ const tabsStructure = computed(() => {
 							],
 						},
 						{
-							label: 'Payment Reminders',
+							label: __('Payment Reminders'),
 							columns: [
 								{
 									fields: [
@@ -458,19 +458,19 @@ const tabsStructure = computed(() => {
 					label: 'Gateways',
 					icon: 'DollarSign',
 					template: markRaw(PaymentGateways),
-					description: 'Add and manage all your payment gateways',
+					description: __('Add and manage all your payment gateways'),
 				},
 				{
 					label: 'Transactions',
 					icon: 'Landmark',
 					template: markRaw(Transactions),
-					description: 'View all your payment transactions',
+					description: __('View all your payment transactions'),
 				},
 				{
 					label: 'Coupons',
 					icon: 'Ticket',
 					template: markRaw(Coupons),
-					description: 'Manage discount coupons for courses and batches',
+					description: __('Manage discount coupons for courses and batches'),
 				},
 			],
 		},
@@ -481,14 +481,14 @@ const tabsStructure = computed(() => {
 				{
 					label: 'Zoom',
 					description:
-						'Manage zoom accounts to conduct live classes from batches',
+						__('Manage zoom accounts to conduct live classes from batches'),
 					icon: 'Video',
 					template: markRaw(ZoomSettings),
 				},
 				{
-					label: 'Google Meet',
+					label: __('Google Meet'),
 					description:
-						'Manage Google Meet accounts to conduct live classes from batches',
+						__('Manage Google Meet accounts to conduct live classes from batches'),
 					icon: 'Presentation',
 					template: markRaw(GoogleMeetSettings),
 				},
@@ -502,13 +502,13 @@ const tabsStructure = computed(() => {
 					label: 'Branding',
 					icon: 'Blocks',
 					description:
-						'Customize the brand name and logo to make the application your own',
+						__('Customize the brand name and logo to make the application your own'),
 					template: markRaw(BrandSettings),
 				},
 				{
 					label: 'Sidebar',
 					icon: 'PanelLeftIcon',
-					description: 'Choose the items you want to show in the sidebar',
+					description: __('Choose the items you want to show in the sidebar'),
 					sections: [
 						{
 							columns: [
@@ -518,27 +518,27 @@ const tabsStructure = computed(() => {
 											label: 'Courses',
 											name: 'courses',
 											type: 'checkbox',
-											description: 'Show the Courses link in the sidebar.',
+											description: __('Show the Courses link in the sidebar.'),
 										},
 										{
 											label: 'Batches',
 											name: 'batches',
 											type: 'checkbox',
-											description: 'Show the Batches link in the sidebar.',
+											description: __('Show the Batches link in the sidebar.'),
 										},
 										{
-											label: 'Programming Exercises',
+											label: __('Programming Exercises'),
 											name: 'programming_exercises',
 											type: 'checkbox',
 											description:
-												'Show the Programming Exercises link in the sidebar.',
+												__('Show the Programming Exercises link in the sidebar.'),
 										},
 										{
 											label: 'Certifications',
 											name: 'certifications',
 											type: 'checkbox',
 											description:
-												'Show the Certifications link in the sidebar.',
+												__('Show the Certifications link in the sidebar.'),
 										},
 									],
 								},
@@ -548,20 +548,20 @@ const tabsStructure = computed(() => {
 											label: 'Jobs',
 											name: 'jobs',
 											type: 'checkbox',
-											description: 'Show the Jobs link in the sidebar.',
+											description: __('Show the Jobs link in the sidebar.'),
 										},
 										{
 											label: 'Statistics',
 											name: 'statistics',
 											type: 'checkbox',
-											description: 'Show the Statistics link in the sidebar.',
+											description: __('Show the Statistics link in the sidebar.'),
 										},
 										{
 											label: 'Notifications',
 											name: 'notifications',
 											type: 'checkbox',
 											description:
-												'Show the Notifications link in the sidebar.',
+												__('Show the Notifications link in the sidebar.'),
 										},
 									],
 								},
@@ -573,28 +573,28 @@ const tabsStructure = computed(() => {
 					label: 'Signup',
 					icon: 'LogIn',
 					description:
-						'Manage the settings related to user signup and registration',
+						__('Manage the settings related to user signup and registration'),
 					sections: [
 						{
 							columns: [
 								{
 									fields: [
 										{
-											label: 'Identify User Category',
+											label: __('Identify User Category'),
 											name: 'user_category',
 											type: 'checkbox',
 											description:
-												'Enable this option to identify the user category during signup.',
+												__('Enable this option to identify the user category during signup.'),
 										},
 										{
 											label: 'Disable signup',
 											name: 'disable_signup',
 											type: 'checkbox',
 											description:
-												'New users will have to be manually registered by Admins.',
+												__('New users will have to be manually registered by Admins.'),
 										},
 										{
-											label: 'Signup Consent HTML',
+											label: __('Signup Consent HTML'),
 											name: 'custom_signup_content',
 											type: 'Code',
 											mode: 'htmlmixed',
@@ -612,14 +612,14 @@ const tabsStructure = computed(() => {
 					label: 'SEO',
 					icon: 'Search',
 					description:
-						'Manage the SEO settings to improve your website ranking on search engines',
+						__('Manage the SEO settings to improve your website ranking on search engines'),
 					sections: [
 						{
 							columns: [
 								{
 									fields: [
 										{
-											label: 'Meta Description',
+											label: __('Meta Description'),
 											name: 'meta_description',
 											type: 'textarea',
 											rows: 4,
@@ -627,20 +627,20 @@ const tabsStructure = computed(() => {
 												"This description will be shown on lists and pages that don't have meta description",
 										},
 										{
-											label: 'Meta Keywords',
+											label: __('Meta Keywords'),
 											name: 'meta_keywords',
 											type: 'textarea',
 											rows: 4,
 											description:
-												'Comma separated keywords for search engines to find your website.',
+												__('Comma separated keywords for search engines to find your website.'),
 										},
 										{
-											label: 'Meta Image',
+											label: __('Meta Image'),
 											name: 'meta_image',
 											type: 'Upload',
 											size: 'lg',
 											description:
-												'Default social-share image used when pages lack their own meta image.',
+												__('Default social-share image used when pages lack their own meta image.'),
 										},
 									],
 								},

--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -232,7 +232,7 @@
 			v-model="showHelpModal"
 			v-model:articles="articles"
 			appName="learning"
-			title="Frappe Learning"
+			:title="__('Frappe Learning')"
 			:logo="LMSLogo"
 			:afterSkip="(step) => capture('onboarding_step_skipped_' + step)"
 			:afterSkipAll="() => capture('onboarding_steps_skipped')"

--- a/frontend/src/components/Sidebar/UserDropdown.vue
+++ b/frontend/src/components/Sidebar/UserDropdown.vue
@@ -116,7 +116,7 @@ const userDropdownOptions = computed(() => {
 			items: [
 				{
 					icon: 'lucide-user',
-					label: 'My Profile',
+					label: __('My Profile'),
 					onClick: () => {
 						router.push(`/user/${userResource.data?.username}`)
 					},
@@ -126,7 +126,7 @@ const userDropdownOptions = computed(() => {
 				},
 				{
 					icon: theme.value === 'light' ? Moon : Sun,
-					label: 'Toggle Theme',
+					label: __('Toggle Theme'),
 					onClick: () => {
 						toggleTheme()
 					},
@@ -159,7 +159,7 @@ const userDropdownOptions = computed(() => {
 					},
 				},
 				{
-					label: 'Clear Demo Data',
+					label: __('Clear Demo Data'),
 					icon: 'lucide-trash-2',
 					onClick: () => {
 						clearDemoDataConfirmation()
@@ -173,7 +173,7 @@ const userDropdownOptions = computed(() => {
 				},
 				{
 					icon: FrappeCloudIcon,
-					label: 'Login to Frappe Cloud',
+					label: __('Login to Frappe Cloud'),
 					onClick: () => {
 						$dialog({
 							title: __('Login to Frappe Cloud?'),
@@ -213,7 +213,7 @@ const userDropdownOptions = computed(() => {
 				},
 				{
 					icon: 'lucide-log-in',
-					label: 'Log in',
+					label: __('Log in'),
 					onClick: () => {
 						window.location.href = '/login'
 					},

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,3 +51,16 @@ label.block:not([data-slot='label']) {
 	bottom: -0.25rem;
 	z-index: 1;
 }
+
+/*
+ * Arabic font: IBM Plex Sans Arabic for RTL layouts.
+ * Overrides the default Inter/InterVar which has no Arabic glyphs.
+ */
+html[dir='rtl'] * {
+	font-family: 'IBM Plex Sans Arabic', 'Noto Sans Arabic', 'Segoe UI', Tahoma, sans-serif !important;
+}
+html[dir='rtl'] code,
+html[dir='rtl'] pre,
+html[dir='rtl'] .monospace {
+	font-family: 'Courier New', monospace !important;
+}

--- a/frontend/src/pages/Batches/components/BulkCertificates.vue
+++ b/frontend/src/pages/Batches/components/BulkCertificates.vue
@@ -1,7 +1,7 @@
 <template>
 	<Dialog
 		v-model:open="show"
-		title="Generate Certificates"
+		:title="__('Generate Certificates')"
 		size="lg"
 		:actions="[
 			{

--- a/frontend/src/pages/Batches/components/NewBatchModal.vue
+++ b/frontend/src/pages/Batches/components/NewBatchModal.vue
@@ -1,5 +1,5 @@
 <template>
-	<Dialog v-model:open="show" title="New Batch" size="3xl">
+	<Dialog v-model:open="show" :title="__('New Batch')" size="3xl">
 		<template #default>
 			<div class="text-base">
 				<div class="grid grid-cols-1 md:grid-cols-3 gap-5">

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue
@@ -126,7 +126,7 @@
 		</ListView>
 		<div v-else class="flex-1">
 			<EmptyStateLayout
-				name="Programming Exercise Submissions"
+				:name="__('Programming Exercise Submissions')"
 				icon="lucide-file-code"
 			/>
 		</div>

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
@@ -125,7 +125,7 @@
 			</ListSelectBanner>
 		</ListView>
 		<div v-else class="flex-1">
-			<EmptyStateLayout name="Programming Exercises" icon="lucide-code" />
+			<EmptyStateLayout :name="__('Programming Exercises')" icon="lucide-code" />
 		</div>
 		<ListFooter
 			v-model="pageLength"

--- a/frontend/src/pages/Programs/ProgramForm.vue
+++ b/frontend/src/pages/Programs/ProgramForm.vue
@@ -598,7 +598,7 @@ const memberColumns = computed(() => {
 			align: 'left',
 		},
 		{
-			label: 'Full Name',
+			label: __('Full Name'),
 			key: 'full_name',
 			width: 3,
 			align: 'left',

--- a/frontend/src/pages/QuizSubmissionList.vue
+++ b/frontend/src/pages/QuizSubmissionList.vue
@@ -41,7 +41,7 @@
 		</div>
 	</div>
 	<div v-else class="flex-1">
-		<EmptyStateLayout name="Quiz Submissions" icon="lucide-file-check" />
+		<EmptyStateLayout :name="__('Quiz Submissions')" icon="lucide-file-check" />
 	</div>
 </template>
 <script setup>

--- a/frontend/src/pages/Statistics.vue
+++ b/frontend/src/pages/Statistics.vue
@@ -16,20 +16,20 @@
 				<Tooltip :text="__('Published Courses')">
 					<NumberChart
 						class="border rounded-md"
-						:config="{ title: 'Courses', value: chartDetails.data.courses }"
+						:config="{ title: __('Courses'), value: chartDetails.data.courses }"
 					/>
 				</Tooltip>
 				<Tooltip :text="__('Active Members')">
 					<NumberChart
 						class="border rounded-md"
-						:config="{ title: 'Signups', value: chartDetails.data.users }"
+						:config="{ title: __('Signups'), value: chartDetails.data.users }"
 					/>
 				</Tooltip>
 				<Tooltip :text="__('Course Enrollments')">
 					<NumberChart
 						class="border rounded-md"
 						:config="{
-							title: 'Enrollments',
+							title: __('Enrollments'),
 							value: chartDetails.data.enrollments,
 						}"
 					/>
@@ -38,7 +38,7 @@
 					<NumberChart
 						class="border rounded-md"
 						:config="{
-							title: 'Completions',
+							title: __('Completions'),
 							value: chartDetails.data.completions,
 						}"
 					/>
@@ -47,7 +47,7 @@
 					<NumberChart
 						class="border rounded-md"
 						:config="{
-							title: 'Certifications',
+							title: __('Certifications'),
 							value: chartDetails.data.certifications,
 						}"
 					/>
@@ -59,16 +59,16 @@
 						v-if="signupsChart.data"
 						:config="{
 							data: signupsChart.data,
-							title: 'Signups',
-							subtitle: 'Signups per day',
+							title: __('Signups'),
+							subtitle: __('Signups per day'),
 							xAxis: {
 								key: 'date',
 								type: 'time',
-								title: 'Date',
+								title: __('Date'),
 								timeGrain: 'day',
 							},
 							yAxis: {
-								title: 'Signups',
+								title: __('Signups'),
 							},
 							series: [{ name: 'signups', type: 'line', showDataPoints: true }],
 						}"
@@ -79,16 +79,16 @@
 						v-if="enrollmentChart.data"
 						:config="{
 							data: enrollmentChart.data,
-							title: 'Enrollments',
-							subtitle: 'Enrollments per day',
+							title: __('Enrollments'),
+							subtitle: __('Enrollments per day'),
 							xAxis: {
 								key: 'date',
 								type: 'time',
-								title: 'Date',
+								title: __('Date'),
 								timeGrain: 'day',
 							},
 							yAxis: {
-								title: 'Enrollments',
+								title: __('Enrollments'),
 							},
 							series: [
 								{ name: 'enrollments', type: 'line', showDataPoints: true },
@@ -101,16 +101,16 @@
 						v-if="certification.data"
 						:config="{
 							data: certification.data,
-							title: 'Certifications',
-							subtitle: 'Certifications per day',
+							title: __('Certifications'),
+							subtitle: __('Certifications per day'),
 							xAxis: {
 								key: 'date',
 								type: 'time',
-								title: 'Date',
+								title: __('Date'),
 								timeGrain: 'day',
 							},
 							yAxis: {
-								title: 'Certifications',
+								title: __('Certifications'),
 							},
 							series: [
 								{
@@ -127,8 +127,8 @@
 						v-if="courseCompletion.data"
 						:config="{
 							data: courseCompletion.data,
-							title: 'Completions',
-							subtitle: 'Course Completion',
+							title: __('Completions'),
+							subtitle: __('Course Completion'),
 							categoryColumn: 'label',
 							valueColumn: 'value',
 						}"

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -75,10 +75,11 @@ def get_user_info():
 
 @frappe.whitelist(allow_guest=True)
 def get_translations():
+	language = None
 	if frappe.session.user != "Guest":
 		language = frappe.db.get_value("User", frappe.session.user, "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
+	if not language:
+		language = frappe.db.get_single_value("System Settings", "language") or "en"
 	return get_all_translations(language)
 
 


### PR DESCRIPTION
## What

Follow-up to #2506, split out as requested by @raizasafeel ("Could you raise another PR with just the rest of the fixes?"). The Arabic translation CSV is **excluded** — translations are contributed via Crowdin. This PR contains only the supporting code fixes that benefit all locales.

## Changes

- **Wrap ~95 hardcoded English strings with `__()`** across Settings, Sidebar (AppSidebar, UserDropdown), Statistics, Programming Exercises, Batches, Programs, and other components — so they become translatable in every Crowdin language, not just Arabic.
- **Fix null-language fallback in `get_translations()`** (`lms/lms/api.py`): a logged-in user with no `language` set previously passed `null` to `get_all_translations()`. It now falls back to System Settings, then `"en"`. The duplicate System Settings lookup is collapsed into a single query.
- **RTL support in `index.css`**: `html[dir='rtl']` font-family override, preserving monospace fonts for `code`/`pre` blocks — benefits any RTL locale (ar/he/fa/ur).
- **Load IBM Plex Sans Arabic** for proper RTL rendering.

## Addresses prior review

The two P1 items the automated review raised on #2506 are already handled here:
- `Settings.vue` `doctype` is a plain string (`ref('LMS Settings')`), **not** wrapped in `__()` — so the DocType lookup is unaffected.
- The translation-key whitespace issue was specific to `ar.csv`, which is not part of this PR.

## Testing

Deployed and tested on a live instance: Desk sidebar, LMS frontend, onboarding, and settings render correctly, and RTL layout applies as expected.