### PR TITLE
ci: build and upload prebuilt assets on push

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -1,0 +1,83 @@
+name: Build and Upload Assets
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - 'version-*'
+
+concurrency:
+  group: build-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-assets:
+    name: Build assets and upload to release
+    runs-on: ubuntu-latest
+    env:
+      # Vite/esbuild builds of large SPAs can exceed Node's default heap and
+      # abort with "JavaScript heap out of memory" (exit 134) even when the
+      # runner has free RAM. Raise the old-space limit to be safe.
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe
+          path: apps/frappe
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/checkout@v4
+        with:
+          path: apps/lms
+
+      - name: Create bench structure
+        run: |
+          mkdir -p sites
+          printf "frappe\nlms\n" > sites/apps.txt
+          # frontend/src/socket imports socketio_port from this file at build time
+          echo '{"socketio_port": 9000}' > sites/common_site_config.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: apps/frappe/yarn.lock
+
+      - name: Install frappe JS dependencies
+        working-directory: apps/frappe
+        run: yarn install --frozen-lockfile
+
+      - name: Install lms JS dependencies
+        working-directory: apps/lms
+        run: yarn install --frozen-lockfile
+
+      - name: Link node_modules into public/
+        working-directory: apps/frappe
+        run: ln -s "$PWD/node_modules" frappe/public/node_modules
+
+      - name: Build frappe bundles (production)
+        working-directory: apps/frappe
+        run: yarn run production
+
+      - name: Build lms SPA
+        working-directory: apps/lms
+        run: yarn build
+
+      - name: Package assets
+        run: |
+          tar czf lms-assets.tar.gz \
+            --exclude=node_modules --exclude=.gitkeep \
+            -C apps/lms/lms/public .
+
+      - name: Upload to rolling release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="assets-${GITHUB_REF_NAME//\//-}"
+          gh release create "$TAG" -R "$GITHUB_REPOSITORY" --prerelease --title "Assets: $GITHUB_REF_NAME" --notes "" 2>/dev/null || true
+          gh release upload "$TAG" -R "$GITHUB_REPOSITORY" lms-assets.tar.gz --clobber


### PR DESCRIPTION
Builds JS/CSS + the Vue SPA on push to develop/main/version-* and uploads them as a rolling `assets-<branch>` release, so benches can download prebuilt assets instead of building from source. Same setup as frappe/erpnext/hrms.