### PR TITLE
fix(reviews): show real review dates instead of "Today" everywhere

### DIFF
--- a/frontend/src/components/Modals/ReviewModal.vue
+++ b/frontend/src/components/Modals/ReviewModal.vue
@@ -49,14 +49,15 @@ const createReview = createResource({
 			doc: {
 				doctype: 'LMS Course Review',
 				course: props.courseName,
-				...review,
+				review: review.review,
+				// the Rating control is 0–5; the doctype stores a 0–1 fraction
+				rating: review.rating / 5,
 			},
 		}
 	},
 })
 
 function submitReview(close: () => void) {
-	review.rating = review.rating / 5
 	createReview.submit(review, {
 		validate() {
 			if (!review.rating) {
@@ -66,12 +67,12 @@ function submitReview(close: () => void) {
 		onSuccess() {
 			reviews.value?.reload()
 			hasReviewed.value?.reload()
+			close()
 		},
 		onError(err: { messages?: string[] } | string) {
 			const msg = typeof err === 'string' ? err : err.messages?.[0] ?? 'Error'
 			toast.error(msg)
 		},
 	})
-	close()
 }
 </script>

--- a/frontend/src/tests/CourseReviews.test.ts
+++ b/frontend/src/tests/CourseReviews.test.ts
@@ -1,0 +1,101 @@
+/**
+ * CourseReviews.vue — review date rendering.
+ *
+ * Regression guard for the "every review shows Today" bug: the backend used to
+ * overwrite `creation` with pretty_date() (e.g. "2 days ago"), and the frontend
+ * then fed that string into dayjs(), which produced an Invalid Date so every row
+ * collapsed to __('Today'). The backend now returns the raw datetime; this test
+ * asserts that real datetimes render their true relative age, so a regression to
+ * pre-formatted `creation` (which dayjs can't parse) fails here instead of in prod.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import dayjs from 'dayjs'
+import CourseReviews from '@/components/CourseReviews.vue'
+
+const fmt = (d: dayjs.Dayjs) => d.format('YYYY-MM-DD HH:mm:ss')
+
+const REVIEWS = [
+	{
+		name: 'r-today',
+		rating: 5,
+		owner: 'a@b.c',
+		creation: fmt(dayjs()),
+		owner_details: { username: 'a', full_name: 'A', user_image: '' },
+	},
+	{
+		name: 'r-1-day',
+		rating: 4,
+		owner: 'b@b.c',
+		creation: fmt(dayjs().subtract(1, 'day').subtract(1, 'hour')),
+		owner_details: { username: 'b', full_name: 'B', user_image: '' },
+	},
+	{
+		name: 'r-5-days',
+		rating: 3,
+		owner: 'c@b.c',
+		creation: fmt(dayjs().subtract(5, 'day')),
+		owner_details: { username: 'c', full_name: 'C', user_image: '' },
+	},
+	{
+		name: 'r-2-months',
+		rating: 2,
+		owner: 'd@b.c',
+		creation: fmt(dayjs().subtract(2, 'month').subtract(3, 'day')),
+		owner_details: { username: 'd', full_name: 'D', user_image: '' },
+	},
+]
+
+// frappe-ui's internal module resolution doesn't work under vitest; stub the
+// pieces CourseReviews uses. The reviews resource returns our fixture; the
+// has-reviewed count resource returns 0.
+vi.mock('frappe-ui', () => ({
+	Button: { template: '<button><slot /></button>' },
+	createResource: (opts: { url: string }) =>
+		opts.url === 'lms.lms.utils.get_reviews'
+			? { data: REVIEWS, reload: vi.fn(), refresh: vi.fn() }
+			: { data: 0, reload: vi.fn(), refresh: vi.fn() },
+}))
+vi.mock('@/components/UserAvatar.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/components/Modals/ReviewModal.vue', () => ({
+	default: { template: '<div />' },
+}))
+vi.mock('@/utils', () => ({ formatRating: (r: string) => String(r) }))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const mountReviews = () =>
+	mount(CourseReviews, {
+		props: { courseName: 'C1' },
+		global: {
+			provide: {
+				$user: { data: { name: 'a@b.c' } },
+				$dayjs: dayjs,
+			},
+			mocks: { __: (s: string) => s },
+			stubs: { LucideStar: true, RouterLink: true },
+		},
+	})
+
+const renderedDates = async () => {
+	const wrapper = mountReviews()
+	await flushPromises()
+	return wrapper.findAll('article span.text-ink-gray-5').map((n) => n.text())
+}
+
+describe('CourseReviews date rendering', () => {
+	it('renders the true relative age of each review', async () => {
+		expect(await renderedDates()).toEqual([
+			'Today',
+			'1 day ago',
+			'5 days ago',
+			'2 months ago',
+		])
+	})
+
+	it('does not collapse old reviews to "Today" (the pretty_date regression)', async () => {
+		const dates = await renderedDates()
+		// every row but the first is older than a day and must not read "Today"
+		expect(dates.slice(1).every((d) => d !== 'Today')).toBe(true)
+	})
+})

--- a/frontend/src/tests/CourseReviews.test.ts
+++ b/frontend/src/tests/CourseReviews.test.ts
@@ -1,59 +1,70 @@
 /**
- * CourseReviews.vue — review date rendering.
+ * CourseReviews.vue — review list rendering.
  *
- * Regression guard for the "every review shows Today" bug: the backend used to
- * overwrite `creation` with pretty_date() (e.g. "2 days ago"), and the frontend
- * then fed that string into dayjs(), which produced an Invalid Date so every row
- * collapsed to __('Today'). The backend now returns the raw datetime; this test
- * asserts that real datetimes render their true relative age, so a regression to
- * pre-formatted `creation` (which dayjs can't parse) fails here instead of in prod.
+ * Date guard: the "every review shows Today" bug came from the backend
+ * overwriting `creation` with pretty_date() ("2 days ago"), which the frontend
+ * fed into dayjs() → Invalid Date → diff NaN → every row collapsed to
+ * __('Today'). The backend now returns the raw datetime; these tests assert real
+ * datetimes render their true relative age, plus the list's other display rules
+ * (null-author drop, preview limit, star fill, header summary, clamp toggle).
  */
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import dayjs from 'dayjs'
 import CourseReviews from '@/components/CourseReviews.vue'
 
 const fmt = (d: dayjs.Dayjs) => d.format('YYYY-MM-DD HH:mm:ss')
 
-const REVIEWS = [
-	{
-		name: 'r-today',
-		rating: 5,
-		owner: 'a@b.c',
-		creation: fmt(dayjs()),
-		owner_details: { username: 'a', full_name: 'A', user_image: '' },
-	},
-	{
+type Review = {
+	name: string
+	rating: number
+	owner: string
+	creation: string
+	review?: string
+	owner_details: { username: string; full_name: string; user_image: string } | null
+}
+
+const review = (over: Partial<Review> & { name: string }): Review => ({
+	rating: 5,
+	owner: 'a@b.c',
+	creation: fmt(dayjs()),
+	owner_details: { username: 'a', full_name: 'A', user_image: '' },
+	...over,
+})
+
+const DEFAULT_REVIEWS: Review[] = [
+	review({ name: 'r-today', rating: 5, creation: fmt(dayjs()) }),
+	review({
 		name: 'r-1-day',
 		rating: 4,
-		owner: 'b@b.c',
 		creation: fmt(dayjs().subtract(1, 'day').subtract(1, 'hour')),
-		owner_details: { username: 'b', full_name: 'B', user_image: '' },
-	},
-	{
-		name: 'r-5-days',
-		rating: 3,
-		owner: 'c@b.c',
-		creation: fmt(dayjs().subtract(5, 'day')),
-		owner_details: { username: 'c', full_name: 'C', user_image: '' },
-	},
-	{
+	}),
+	review({ name: 'r-5-days', rating: 3, creation: fmt(dayjs().subtract(5, 'day')) }),
+	review({
 		name: 'r-2-months',
 		rating: 2,
-		owner: 'd@b.c',
 		creation: fmt(dayjs().subtract(2, 'month').subtract(3, 'day')),
-		owner_details: { username: 'd', full_name: 'D', user_image: '' },
-	},
+	}),
 ]
 
+// Mutable so each test can swap in its own fixture before mounting; the resource
+// exposes `data` via a getter so the component reads the current value.
+let currentReviews: Review[] = DEFAULT_REVIEWS
+
 // frappe-ui's internal module resolution doesn't work under vitest; stub the
-// pieces CourseReviews uses. The reviews resource returns our fixture; the
+// pieces CourseReviews uses. The reviews resource returns the fixture; the
 // has-reviewed count resource returns 0.
 vi.mock('frappe-ui', () => ({
 	Button: { template: '<button><slot /></button>' },
 	createResource: (opts: { url: string }) =>
 		opts.url === 'lms.lms.utils.get_reviews'
-			? { data: REVIEWS, reload: vi.fn(), refresh: vi.fn() }
+			? {
+					get data() {
+						return currentReviews
+					},
+					reload: vi.fn(),
+					refresh: vi.fn(),
+			  }
 			: { data: 0, reload: vi.fn(), refresh: vi.fn() },
 }))
 vi.mock('@/components/UserAvatar.vue', () => ({ default: { template: '<div />' } }))
@@ -64,9 +75,9 @@ vi.mock('@/utils', () => ({ formatRating: (r: string) => String(r) }))
 
 vi.stubGlobal('__', (s: string) => s)
 
-const mountReviews = () =>
+const mountReviews = (props: Record<string, unknown> = {}) =>
 	mount(CourseReviews, {
-		props: { courseName: 'C1' },
+		props: { courseName: 'C1', ...props },
 		global: {
 			provide: {
 				$user: { data: { name: 'a@b.c' } },
@@ -83,6 +94,10 @@ const renderedDates = async () => {
 	return wrapper.findAll('article span.text-ink-gray-5').map((n) => n.text())
 }
 
+beforeEach(() => {
+	currentReviews = DEFAULT_REVIEWS
+})
+
 describe('CourseReviews date rendering', () => {
 	it('renders the true relative age of each review', async () => {
 		expect(await renderedDates()).toEqual([
@@ -97,5 +112,63 @@ describe('CourseReviews date rendering', () => {
 		const dates = await renderedDates()
 		// every row but the first is older than a day and must not read "Today"
 		expect(dates.slice(1).every((d) => d !== 'Today')).toBe(true)
+	})
+})
+
+describe('CourseReviews list rendering', () => {
+	it('drops reviews whose author record is missing', async () => {
+		currentReviews = [
+			review({ name: 'ok' }),
+			review({ name: 'ghost', owner: 'x@y.z', owner_details: null }),
+		]
+		const wrapper = mountReviews()
+		await flushPromises()
+		// the null-author row would crash on the avatar/profile deref, so it's filtered
+		expect(wrapper.findAll('article')).toHaveLength(1)
+	})
+
+	it('shows only the first 4 reviews until "View all reviews" is clicked', async () => {
+		currentReviews = Array.from({ length: 6 }, (_, i) =>
+			review({ name: `r-${i}`, owner: `u${i}@b.c` })
+		)
+		const wrapper = mountReviews()
+		await flushPromises()
+		expect(wrapper.findAll('article')).toHaveLength(4)
+
+		const viewAll = wrapper
+			.findAll('button')
+			.find((b) => b.text() === 'View all reviews')!
+		await viewAll.trigger('click')
+		expect(wrapper.findAll('article')).toHaveLength(6)
+	})
+
+	it('fills one star per (rounded-up) rating point', async () => {
+		currentReviews = [review({ name: 'r3', rating: 3 })]
+		const wrapper = mountReviews()
+		await flushPromises()
+		const row = wrapper.get('article')
+		expect(row.findAll('.fill-yellow-500')).toHaveLength(3)
+		expect(row.findAll('.fill-surface-gray-3')).toHaveLength(2)
+	})
+
+	it('summarizes the rating and pluralizes the count', async () => {
+		currentReviews = [review({ name: 'only' })]
+		const wrapper = mountReviews({ avg_rating: '4.5' })
+		await flushPromises()
+		const header = wrapper.text()
+		expect(header).toContain('4.5')
+		expect(header).toContain('1 user rating')
+		expect(header).not.toContain('user ratings')
+	})
+
+	it('clamps long review text behind a "See more" toggle', async () => {
+		currentReviews = [review({ name: 'long', review: 'x'.repeat(300) })]
+		const wrapper = mountReviews()
+		await flushPromises()
+		const body = wrapper.get('article p')
+		expect(body.classes()).toContain('line-clamp-5')
+
+		await wrapper.get('article button').trigger('click')
+		expect(wrapper.get('article p').classes()).not.toContain('line-clamp-5')
 	})
 })

--- a/frontend/src/tests/ReviewModal.test.ts
+++ b/frontend/src/tests/ReviewModal.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ReviewModal.vue — submit behavior.
+ *
+ * Guards: (1) a missing rating must keep the dialog OPEN and surface the error
+ * (the old code called close() unconditionally, so the modal vanished on a
+ * validation failure and the user lost their input); (2) the 0–5 Rating is
+ * scaled to the stored 0–1 range; (3) a successful submit reloads the review
+ * list + has-reviewed count and then closes.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ReviewModal from '@/components/Modals/ReviewModal.vue'
+
+// hoisted so the vi.mock factory (which runs at import time) can reference it
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }))
+// captured from the createResource() call so the test can inspect makeParams()
+let resourceConfig: { makeParams: () => { doc: Record<string, unknown> } }
+
+// frappe-ui doesn't resolve under vitest; stub the pieces ReviewModal uses.
+// The Dialog stub renders each action as a button that invokes its onClick with
+// a { close } that emits update:open=false, mirroring the real Dialog contract.
+// createResource.submit runs validate() and routes to onError/onSuccess so the
+// component's real wiring is exercised without a network call.
+vi.mock('frappe-ui', () => ({
+	Dialog: {
+		props: ['open', 'title', 'size', 'actions'],
+		emits: ['update:open'],
+		methods: {
+			runAction(a: { onClick: (ctx: { close: () => void }) => void }) {
+				a.onClick({ close: () => (this as any).$emit('update:open', false) })
+			},
+		},
+		template: `<div><slot />
+			<button
+				v-for="a in actions"
+				:key="a.label"
+				data-testid="action"
+				@click="runAction(a)"
+			>{{ a.label }}</button>
+		</div>`,
+	},
+	Rating: {
+		props: ['modelValue', 'label'],
+		emits: ['update:modelValue'],
+		template: `<input data-testid="rating" :value="modelValue"
+			@input="$emit('update:modelValue', Number($event.target.value))" />`,
+	},
+	FormControl: {
+		props: ['modelValue', 'label', 'type', 'rows'],
+		emits: ['update:modelValue'],
+		template: `<textarea data-testid="review" :value="modelValue"
+			@input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+	toast: { error: toastError },
+	createResource: (cfg: typeof resourceConfig) => {
+		resourceConfig = cfg
+		return {
+			submit: (
+				_values: unknown,
+				opts: {
+					validate?: () => string | undefined
+					onError?: (e: unknown) => void
+					onSuccess?: () => void
+				}
+			) => {
+				const err = opts.validate?.()
+				if (err) opts.onError?.(err)
+				else opts.onSuccess?.()
+			},
+		}
+	},
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const reloadReviews = vi.fn()
+const reloadHasReviewed = vi.fn()
+
+const mountModal = () =>
+	mount(ReviewModal, {
+		props: {
+			modelValue: true,
+			reloadReviews: { reload: reloadReviews },
+			hasReviewed: { reload: reloadHasReviewed },
+			courseName: 'C1',
+		},
+		global: { mocks: { __: (s: string) => s } },
+	})
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('ReviewModal submit', () => {
+	it('keeps the dialog open and shows an error when the rating is missing', async () => {
+		const wrapper = mountModal()
+		await wrapper.get('[data-testid="action"]').trigger('click')
+
+		expect(toastError).toHaveBeenCalledWith('Please enter a rating.')
+		// close() must NOT have fired — the modal stays open so input isn't lost
+		expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+		expect(reloadReviews).not.toHaveBeenCalled()
+	})
+
+	it('scales the 0–5 rating to the stored 0–1 range', async () => {
+		const wrapper = mountModal()
+		await wrapper.get('[data-testid="rating"]').setValue('5')
+		await wrapper.get('[data-testid="review"]').setValue('Great course')
+		await wrapper.get('[data-testid="action"]').trigger('click')
+
+		const doc = resourceConfig.makeParams().doc
+		expect(doc.rating).toBe(1)
+		expect(doc.review).toBe('Great course')
+		expect(doc.course).toBe('C1')
+		expect(doc.doctype).toBe('LMS Course Review')
+	})
+
+	it('reloads reviews + has-reviewed and closes on a successful submit', async () => {
+		const wrapper = mountModal()
+		await wrapper.get('[data-testid="rating"]').setValue('4')
+		await wrapper.get('[data-testid="action"]').trigger('click')
+
+		expect(reloadReviews).toHaveBeenCalled()
+		expect(reloadHasReviewed).toHaveBeenCalled()
+		expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([false])
+	})
+})

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -22,7 +22,6 @@ from frappe.utils import (
 	get_fullname,
 	getdate,
 	nowtime,
-	pretty_date,
 	rounded,
 	validate_email_address,
 )
@@ -315,7 +314,6 @@ def get_reviews(course: str):
 		review.owner_details = frappe.db.get_value(
 			"User", review.owner, ["username", "full_name", "user_image"], as_dict=True
 		)
-		review.creation = pretty_date(review.creation)
 
 	return reviews
 

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
+from datetime import datetime
+
 import frappe
 from frappe.utils import getdate, to_timedelta
 
@@ -76,6 +78,47 @@ class TestLMSUtils(BaseTestUtils):
 	def test_get_reviews(self):
 		reviews = get_reviews(self.course.name)
 		self.assertEqual(len(reviews), 2)
+
+	def test_get_reviews_creation_is_datetime(self):
+		# Regression guard: get_reviews must return the raw `creation` datetime,
+		# not a pretty_date() string. The frontend computes the relative age from
+		# this value, so a prettified string made every review render as "Today".
+		reviews = get_reviews(self.course.name)
+		for review in reviews:
+			self.assertIsInstance(review.creation, datetime)
+
+	def test_get_reviews_scales_rating_to_display_range(self):
+		# stored 0–1 fractions are returned on the 0–5 display scale (× out_of_ratings)
+		ratings_by_owner = {review.owner: review.rating for review in get_reviews(self.course.name)}
+		self.assertEqual(ratings_by_owner[self.student1.email], 4.0)  # stored 0.8
+		self.assertEqual(ratings_by_owner[self.student2.email], 5.0)  # stored 1.0
+
+	def test_get_reviews_includes_owner_details(self):
+		review = next(r for r in get_reviews(self.course.name) if r.owner == self.student1.email)
+		self.assertIsNotNone(review.owner_details)
+		self.assertEqual(review.owner_details.full_name, self.student1.full_name)
+
+	def test_get_reviews_ordered_newest_first(self):
+		# student2's review is added after student1's; order_by creation desc
+		reviews = get_reviews(self.course.name)
+		self.assertEqual(reviews[0].owner, self.student2.email)
+		self.assertEqual(reviews[1].owner, self.student1.email)
+
+	def test_get_average_rating_none_without_reviews(self):
+		course = frappe.new_doc("LMS Course")
+		course.update(
+			{
+				"title": "Unrated Course",
+				"short_introduction": "No reviews yet",
+				"description": "A course with no reviews.",
+				"category": self.course.category,
+				"published": 1,
+				"instructors": [{"instructor": "frappe@example.com"}],
+			}
+		)
+		course.save()
+		self.cleanup_items.append(("LMS Course", course.name))
+		self.assertIsNone(get_average_rating(course.name))
 
 	def test_get_lesson_index(self):
 		lessons = get_lessons(self.course.name)


### PR DESCRIPTION
## Summary
- All dates showed 'today' in reviews due to parsing it twice. Once in backend with pretty_date and second time in frontend. Removed backend backend 'pretty_date()' parsing.
- Fixed the review modal closing (and losing input) when submitted with no rating; now it stays open and shows the error.
- Added tests for the following
   - The date bug above (frontend + a backend guard that creation stays a raw datetime)
  - Missing rating keeps the dialog open with an error
  - Other review rendering: rating scaling, null-author rows dropped, preview limit / "View all", star fill, header count, "See more" part