### PR TITLE
fix: contain SCORM extraction to the authorised course directory

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import xml.etree.ElementTree as ET
 import zipfile
 from datetime import timedelta
@@ -592,8 +593,7 @@ def delete_lesson(lesson: str, chapter: str):
 	frappe.db.delete("LMS Course Progress", {"lesson": lesson})
 	frappe.db.delete("LMS Video Watch Duration", {"lesson": lesson})
 
-	# Discussion topics link to the lesson, so delete_doc raises LinkExistsError
-	# unless they (and their replies) are removed first.
+	# Discussion topics link to the lesson, so remove them (and their replies) first, else delete_doc raises LinkExistsError.
 	topics = frappe.get_all(
 		"Discussion Topic",
 		{"reference_doctype": "Course Lesson", "reference_docname": lesson},
@@ -608,13 +608,7 @@ def delete_lesson(lesson: str, chapter: str):
 
 @frappe.whitelist()
 def create_lesson(chapter: str) -> str:
-	"""Create a draft "Untitled lesson" appended to the chapter, atomically.
-
-	Delegates to add_lesson(), which inserts the Course Lesson and its Lesson
-	Reference in this single request — if the reference insert fails the whole
-	request rolls back, so no lesson is orphaned without a chapter pointing at
-	it. Returns the new lesson's docname.
-	"""
+	"""Create a draft "Untitled lesson" appended to the chapter, atomically via add_lesson() (inserts the Course Lesson + its Lesson Reference in one request that rolls back together; returns the new docname)."""
 	course = frappe.db.get_value("Course Chapter", chapter, "course")
 	if not course:
 		frappe.throw(_("Invalid chapter."))
@@ -1126,11 +1120,7 @@ def upsert_chapter(
 		chapter.update(values)
 		chapter.save()
 
-		# Link the new chapter into the course outline. This was previously done
-		# client-side via frappe.client.insert (ChapterModal.vue), which did not
-		# reliably persist on CI — leaving get_outline_chapter() empty. Creating the
-		# Chapter Reference here keeps it atomic with the chapter and consistent
-		# across environments.
+		# Link the new chapter into the outline here (was client-side frappe.client.insert in ChapterModal.vue, which didn't reliably persist on CI); keeps the Chapter Reference atomic with the chapter.
 		course_doc = frappe.get_doc("LMS Course", course)
 		course_doc.append("chapters", {"chapter": chapter.name})
 		course_doc.save()
@@ -1142,32 +1132,44 @@ def upsert_chapter(
 
 
 def _scorm_url(abs_path: str) -> str:
-	"""Map an extracted SCORM disk path under <site>/private/scorm/... to the
-	location-independent "/scorm/<course>/<title>/..." URL stored on Course Chapter.
-	Keeps the same URL shape legacy (public) chapters already have, so no DB change."""
+	"""Map an extracted SCORM disk path (<site>/private/scorm/...) to the location-independent "/scorm/<course>/<title>/..." URL stored on Course Chapter — same shape legacy public chapters have, so no DB change."""
 	rel = os.path.relpath(abs_path, frappe.get_site_path("private"))
 	return "/" + rel.replace(os.sep, "/")
+
+
+def _scorm_extract_path(course: str, title: str) -> str:
+	"""Resolve the SCORM extraction dir, contained to this course's directory (an attacker-controlled chapter title must not traverse out → cross-course overwrite / same-origin stored XSS)."""
+	scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
+	course_root = os.path.realpath(frappe.get_site_path("private", "scorm", course))
+
+	# The course segment must resolve strictly inside the scorm root, never the root itself (empty/"." course).
+	if not course_root.startswith(scorm_root + os.sep):
+		frappe.throw(_("Invalid course or chapter name"))
+
+	# Must resolve strictly inside the course dir — a title of "."/""/"sub/.." collapses to course_root, whose rmtree would wipe every chapter.
+	extract_path = os.path.realpath(os.path.join(course_root, title))
+	if not extract_path.startswith(course_root + os.sep):
+		frappe.throw(_("Invalid course or chapter name"))
+
+	return extract_path
 
 
 def extract_package(course: str, title: str, scorm_package: dict):
 	package = frappe.get_doc("File", scorm_package.name)
 	zip_path = package.get_full_path()
-	scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
-	extract_path = frappe.get_site_path("private", "scorm", course, title)
+	extract_path = _scorm_extract_path(course, title)
 
-	if not os.path.realpath(extract_path).startswith(scorm_root + os.sep):
-		frappe.throw(_("Invalid course or chapter name"))
-
-	# Clear any previously extracted package so a re-uploaded package does not
-	# leave stale files behind (the old manifest/launch file would otherwise
-	# still be served). extract_path is confirmed to live under scorm_root above.
+	# Clear any previously extracted package so a re-upload doesn't leave stale files served (path confirmed under the course dir above).
 	if os.path.exists(extract_path):
 		shutil.rmtree(extract_path)
 
 	with zipfile.ZipFile(zip_path, "r") as zf:
 		dest = os.path.realpath(extract_path)
-		for name in zf.namelist():
-			target = os.path.realpath(os.path.join(extract_path, name))
+		for info in zf.infolist():
+			# Reject symlink entries outright: a symlink + a path through it could escape the course dir once materialised.
+			if stat.S_ISLNK(info.external_attr >> 16):
+				frappe.throw(_("Invalid file path in package"))
+			target = os.path.realpath(os.path.join(extract_path, info.filename))
 			if not target.startswith(dest + os.sep) and target != dest:
 				frappe.throw(_("Invalid file path in package"))
 		zf.extractall(extract_path)
@@ -1274,8 +1276,7 @@ def delete_chapter(chapter: str):
 
 	course = frappe.db.get_value("Chapter Reference", {"chapter": chapter}, "parent")
 
-	# Clean up per-lesson dependants before the raw lesson delete below, which
-	# would otherwise leave discussions/progress orphaned at the deleted lessons.
+	# Clean up per-lesson dependants before the raw lesson delete below, else discussions/progress orphan at the deleted lessons.
 	lessons = frappe.get_all("Course Lesson", {"chapter": chapter}, pluck="name")
 	for lesson in lessons:
 		topics = frappe.get_all(
@@ -1438,8 +1439,7 @@ def get_week_difference(start_date: str, current_date: str) -> int:
 @frappe.whitelist()
 def get_notifications(filters: dict = None):
 	filters = frappe._dict(filters or {})
-	# Always scoped to the session user — no IDOR surface. Only an optional
-	# read flag from the client is honoured.
+	# Always scoped to the session user — no IDOR surface; only an optional read flag from the client is honoured.
 	query_filters = {"for_user": frappe.session.user}
 	if "read" in filters:
 		query_filters["read"] = 1 if filters.read else 0
@@ -1604,9 +1604,7 @@ def save_evaluator_role(user: str, value: int):
 			try:
 				doc.save(ignore_permissions=True)
 			except frappe.DuplicateEntryError:
-				# A concurrent request already created this evaluator. The
-				# primary key (autoname field:evaluator) guarantees uniqueness,
-				# so the row we wanted exists — nothing more to do.
+				# A concurrent request already created this evaluator; the primary key (autoname field:evaluator) guarantees uniqueness, so the row exists — nothing more to do.
 				frappe.db.rollback(save_point="save_evaluator")
 	else:
 		frappe.db.delete("Has Role", {"parent": user, "role": "Batch Evaluator"})

--- a/lms/lms/test_scorm_security.py
+++ b/lms/lms/test_scorm_security.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2021, FOSS United and Contributors
+# See license.txt
+
+"""SCORM security regression tests: extraction/serving containment + hostile manifest parsing (XXE, amplification, traversal href). Excludes content execution (documented trust model, sandbox-origin mitigation)."""
+
+import os
+import shutil
+import stat
+import tempfile
+import time
+import unittest
+import zipfile
+from xml.parsers.expat import ExpatError
+
+import frappe
+
+from lms.lms.api import _scorm_extract_path, extract_package, get_launch_file
+from lms.page_renderers import SCORMRenderer
+
+
+class TestScormExtractPath(unittest.TestCase):
+	"""A traversal chapter title must not resolve outside the course's own dir."""
+
+	def test_normal_title_stays_in_course_dir(self):
+		course_root = os.path.realpath(frappe.get_site_path("private", "scorm", "my-course"))
+		path = _scorm_extract_path("my-course", "chapter-1")
+		self.assertEqual(path, os.path.join(course_root, "chapter-1"))
+
+	def test_parent_traversal_in_title_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", "../victim-course/victim-chapter")
+
+	def test_nested_traversal_in_title_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", "sub/../../victim-course/x")
+
+	def test_absolute_title_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", "/srv/other/x")
+
+	def test_empty_course_is_rejected(self):
+		# An empty course collapses course_root to the scorm root, so a title could reach a sibling course.
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("", "victim-course/chapter-1")
+
+	def test_dot_course_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path(".", "victim-course/chapter-1")
+
+	def test_dot_title_is_rejected(self):
+		# "." collapses extract_path to course_root, whose rmtree would wipe every chapter.
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", ".")
+
+	def test_empty_title_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", "")
+
+	def test_sub_parent_title_collapsing_to_course_root_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_scorm_extract_path("my-course", "sub/..")
+
+
+class TestScormExtractContainment(unittest.TestCase):
+	"""extract_package() must never write outside the package's own course dir."""
+
+	COURSE_A = "ct-scorm-course-a"
+	COURSE_B = "ct-scorm-course-b"
+
+	def setUp(self):
+		self.scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
+		self._tmp = tempfile.mkdtemp()
+		self.zip_path = os.path.join(self._tmp, "pkg.zip")
+		self._make_zip([("index.html", "<html>ok</html>")])
+
+		# Stub the File lookup so extract_package reads our temp zip (no real File doc).
+		self._orig_get_doc = frappe.get_doc
+
+		def fake_get_doc(doctype, *args, **kwargs):
+			if doctype == "File":
+				return frappe._dict(get_full_path=lambda: self.zip_path)
+			return self._orig_get_doc(doctype, *args, **kwargs)
+
+		frappe.get_doc = fake_get_doc
+		self._stray_paths = []
+
+	def tearDown(self):
+		frappe.get_doc = self._orig_get_doc
+		shutil.rmtree(self._tmp, ignore_errors=True)
+		for course in (self.COURSE_A, self.COURSE_B):
+			shutil.rmtree(os.path.join(self.scorm_root, course), ignore_errors=True)
+		for p in self._stray_paths:
+			if os.path.lexists(p):
+				os.remove(p)
+
+	def _make_zip(self, entries):
+		with zipfile.ZipFile(self.zip_path, "w") as zf:
+			for name, content in entries:
+				zf.writestr(name, content)
+
+	def _extract(self, course, title):
+		return extract_package(course, title, frappe._dict(name="dummy"))
+
+	def test_benign_title_extracts_inside_course_dir(self):
+		path = self._extract(self.COURSE_A, "chapter-1")
+		course_root = os.path.join(self.scorm_root, self.COURSE_A)
+		self.assertTrue(os.path.realpath(path).startswith(course_root + os.sep))
+		self.assertTrue(os.path.isfile(os.path.join(path, "index.html")))
+
+	def test_traversal_title_cannot_overwrite_another_course(self):
+		victim_dir = os.path.join(self.scorm_root, self.COURSE_B, "victim-chapter")
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			self._extract(self.COURSE_A, f"../{self.COURSE_B}/victim-chapter")
+		self.assertFalse(os.path.exists(victim_dir), "traversal title wrote into another course")
+
+	def test_absolute_title_is_rejected(self):
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			self._extract(self.COURSE_A, "/srv/elsewhere/chapter")
+
+	def test_dot_title_cannot_wipe_the_course_dir(self):
+		# A "." title collapses to course_root; extract_package must refuse it before rmtree deletes sibling chapters.
+		sibling = os.path.join(self.scorm_root, self.COURSE_A, "existing-chapter")
+		os.makedirs(sibling, exist_ok=True)
+		with open(os.path.join(sibling, "keep.html"), "w") as f:
+			f.write("keep")
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			self._extract(self.COURSE_A, ".")
+		self.assertTrue(
+			os.path.isfile(os.path.join(sibling, "keep.html")), "'.' title wiped a sibling chapter"
+		)
+
+	def test_zip_slip_entry_is_rejected(self):
+		stray = os.path.join(self._tmp, "zipslip_evil.html")
+		rel_to_stray = os.path.relpath(stray, os.path.join(self.scorm_root, self.COURSE_A, "ch"))
+		self._stray_paths.append(stray)
+		self._make_zip([("index.html", "ok"), (rel_to_stray, "<script>pwn</script>")])
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			self._extract(self.COURSE_A, "ch")
+		self.assertFalse(os.path.exists(stray), "zip-slip entry escaped the extraction dir")
+
+	def test_zip_symlink_entry_is_rejected(self):
+		# Symlink entries are refused before extraction, so a symlink-then-traverse chain can't form.
+		zi = zipfile.ZipInfo("link")
+		zi.external_attr = (stat.S_IFLNK | 0o777) << 16
+		with zipfile.ZipFile(self.zip_path, "w") as zf:
+			zf.writestr("index.html", "ok")
+			zf.writestr(zi, "/etc/passwd")
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			self._extract(self.COURSE_A, "chapter-1")
+		self.assertFalse(os.path.exists(os.path.join(self.scorm_root, self.COURSE_A, "chapter-1", "link")))
+
+
+class TestScormServingContainment(unittest.TestCase):
+	"""_is_safe_path must contain served paths to the scorm root, resolving symlinks."""
+
+	def setUp(self):
+		self.scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
+		os.makedirs(self.scorm_root, exist_ok=True)
+		self._made = []
+
+	def tearDown(self):
+		for p in self._made:
+			if os.path.islink(p) or os.path.isfile(p):
+				os.remove(p)
+			elif os.path.isdir(p):
+				shutil.rmtree(p, ignore_errors=True)
+
+	def _renderer(self, path="/scorm/c/t/index.html"):
+		r = SCORMRenderer.__new__(SCORMRenderer)
+		r.path = path
+		return r
+
+	def test_path_inside_scorm_root_is_allowed(self):
+		inside = os.path.join(self.scorm_root, "c", "t", "index.html")
+		self.assertTrue(self._renderer()._is_safe_path(inside))
+
+	def test_parent_traversal_is_rejected(self):
+		escape = os.path.join(self.scorm_root, "c", "t", "..", "..", "..", "..", "etc", "passwd")
+		self.assertFalse(self._renderer()._is_safe_path(escape))
+
+	def test_symlink_escaping_scorm_root_is_rejected(self):
+		link = os.path.join(self.scorm_root, "ct-evil-link")
+		self._made.append(link)
+		if os.path.lexists(link):
+			os.remove(link)
+		os.symlink("/etc", link)
+		# The symlink lives under scorm_root, but realpath resolves it to /etc.
+		self.assertFalse(self._renderer()._is_safe_path(os.path.join(link, "passwd")))
+
+
+class TestScormManifestParsing(unittest.TestCase):
+	"""A hostile imsmanifest.xml must not read files, amplify, or yield a servable href."""
+
+	# adlcp namespace must be declared on the root, else expat raises "unbound prefix" first.
+	NS = 'xmlns:adlcp="http://www.adlnet.org/xsd/adlcp_rootv1p2"'
+
+	def setUp(self):
+		self._tmp = tempfile.mkdtemp()
+		self.scorm_root = os.path.realpath(frappe.get_site_path("private", "scorm"))
+
+	def tearDown(self):
+		shutil.rmtree(self._tmp, ignore_errors=True)
+
+	def _write_manifest(self, xml):
+		with open(os.path.join(self._tmp, "imsmanifest.xml"), "w") as f:
+			f.write(xml)
+		return self._tmp
+
+	def test_external_entity_does_not_leak_file_contents(self):
+		# Modern expat refuses external entities (raises), so the file is never read.
+		path = self._write_manifest(
+			'<?xml version="1.0"?>\n'
+			'<!DOCTYPE manifest [ <!ENTITY xxe SYSTEM "file:///etc/hostname"> ]>\n'
+			f'<manifest {self.NS}><resource adlcp:scormtype="sco" href="&xxe;"/></manifest>'
+		)
+		with self.assertRaises(ExpatError):
+			get_launch_file(path)
+
+	def test_entity_amplification_is_bounded(self):
+		# Billion-laughs: libexpat's amplification guard raises quickly instead of OOMing.
+		entities = '<!ENTITY a "AAAAAAAAAA">\n'
+		prev = "a"
+		for i in range(1, 8):
+			cur = chr(ord("a") + i)
+			entities += f'<!ENTITY {cur} "{("&" + prev + ";") * 10}">\n'
+			prev = cur
+		path = self._write_manifest(
+			f'<?xml version="1.0"?>\n<!DOCTYPE manifest [\n{entities}]>\n'
+			f'<manifest {self.NS}><resource adlcp:scormtype="sco" href="&{prev};"/></manifest>'
+		)
+		start = time.time()
+		with self.assertRaises(ExpatError):
+			get_launch_file(path)
+		self.assertLess(time.time() - start, 5, "entity expansion was not bounded")
+
+	def test_traversal_launch_href_is_not_servable(self):
+		# A traversal href resolves outside the scorm root, which _is_safe_path refuses.
+		path = self._write_manifest(
+			'<?xml version="1.0"?>\n'
+			f'<manifest {self.NS}><resource adlcp:scormtype="sco" '
+			'href="../../../../../../../etc/passwd"/></manifest>'
+		)
+		launch = get_launch_file(path)
+		self.assertTrue(launch)
+		renderer = SCORMRenderer.__new__(SCORMRenderer)
+		renderer.path = "/scorm/c/t/launch"
+		self.assertFalse(renderer._is_safe_path(launch), "traversal launch href resolved to a servable path")


### PR DESCRIPTION
## Summary
- A malicious chapter title/course name (e.g. "../../") could escape the SCORM extraction dir, allowing cross-course file overwrite 
- Fix: new _scorm_extract_path() helper resolves the extraction path with realpath and rejects anything that traverses outside the course's own directory (both the course segment and the title are now validated).
- Also added tests covering SCORM extraction containment, serving, and manifest parsing.
