### PR TITLE
fix(evaluator): make "Add Slot" work on the availability profile

### DIFF
--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -42,19 +42,19 @@
 						type="select"
 						:options="days"
 						v-model="slot.day"
-						@focusout.stop="update(slot.name, 'day', slot.day)"
+						@update:modelValue="update(slot.name, 'day', $event)"
 						:disabled="!isSessionUser()"
 					/>
 					<FormControl
 						type="time"
 						v-model="slot.start_time"
-						@focusout.stop="update(slot.name, 'start_time', slot.start_time)"
+						@update:modelValue="update(slot.name, 'start_time', $event)"
 						:disabled="!isSessionUser()"
 					/>
 					<FormControl
 						type="time"
 						v-model="slot.end_time"
-						@focusout.stop="update(slot.name, 'end_time', slot.end_time)"
+						@update:modelValue="update(slot.name, 'end_time', $event)"
 						:disabled="!isSessionUser()"
 					/>
 					<span
@@ -72,19 +72,19 @@
 						type="select"
 						:options="days"
 						v-model="newSlot.day"
-						@focusout.stop="add()"
+						@update:modelValue="add()"
 						:disabled="!isSessionUser()"
 					/>
 					<FormControl
 						type="time"
 						v-model="newSlot.start_time"
-						@focusout.stop="add()"
+						@update:modelValue="add()"
 						:disabled="!isSessionUser()"
 					/>
 					<FormControl
 						type="time"
 						v-model="newSlot.end_time"
-						@focusout.stop="add()"
+						@update:modelValue="add()"
 						:disabled="!isSessionUser()"
 					/>
 				</div>
@@ -221,7 +221,6 @@ const formatTime = (time) => {
 const createSlot = createResource({
 	url: 'frappe.client.insert',
 	makeParams(values) {
-		console.log(evaluator.data)
 		return {
 			doc: {
 				doctype: 'Evaluator Schedule',
@@ -317,6 +316,9 @@ const update = (name, field, value) => {
 
 const add = () => {
 	if (!newSlot.day || !newSlot.start_time || !newSlot.end_time) {
+		return
+	}
+	if (createSlot.loading) {
 		return
 	}
 	createSlot.submit()

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -376,27 +376,39 @@ def get_unsplash_photos(keyword: str = None):
 def get_evaluator_details(evaluator: str):
 	frappe.only_for("Batch Evaluator")
 
-	if not frappe.db.exists("Google Calendar", {"user": evaluator}):
-		calendar = frappe.new_doc("Google Calendar")
-		calendar.update({"user": evaluator, "calendar_name": evaluator})
-		calendar.insert()
-	else:
+	if frappe.db.exists("Google Calendar", {"user": evaluator}):
 		calendar = frappe.db.get_value(
 			"Google Calendar", {"user": evaluator}, ["name", "authorization_code"], as_dict=1
 		)
+	else:
+		# Batch Evaluators are portal users without create permission on Google
+		# Calendar (only System Manager / Desk User have it), so provision the
+		# evaluator's own calendar on their behalf via ignore_permissions. This is
+		# best-effort: creation requires Google OAuth configured in Google Settings,
+		# so a missing config (ValidationError) or permission gap must not block the
+		# availability (slots) UI, the primary purpose. Any other error is
+		# unexpected and left to propagate.
+		try:
+			calendar = frappe.new_doc("Google Calendar")
+			calendar.update({"user": evaluator, "calendar_name": evaluator})
+			calendar.insert(ignore_permissions=True)
+		except (frappe.ValidationError, frappe.PermissionError):
+			frappe.clear_last_message()
+			calendar = None
 
 	if frappe.db.exists("Course Evaluator", {"evaluator": evaluator}):
 		doc = frappe.get_doc("Course Evaluator", evaluator)
 	else:
+		# Batch Evaluator already has create permission on Course Evaluator, so use
+		# a normal permission-checked insert here (no ignore_permissions).
 		doc = frappe.new_doc("Course Evaluator")
 		doc.evaluator = evaluator
 		doc.insert()
-	for slot in doc.schedule:
-		print(slot.start_time, slot.end_time)
+
 	return {
 		"slots": doc.as_dict(),
-		"calendar": calendar.name,
-		"is_authorised": calendar.authorization_code,
+		"calendar": calendar.name if calendar else None,
+		"is_authorised": calendar.authorization_code if calendar else None,
 	}
 
 


### PR DESCRIPTION
## Summary
- In frontend, slot fields auto-submitted via @focusout, silently dropped on beta.7 popover fragments; switch to @update:modelValue so add()/update() fire.
- get_evaluator_details always created a Google Calendar, which errored the whole call (no perm / unconfigured) leaving slot parent null; fixed with ignore_permissions.
