### PR TITLE
fix: guard Attach fields in settings against non-string values

### DIFF
--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -53,14 +53,14 @@
 									:class="field.size == 'lg' ? 'px-5 py-5' : 'px-20 py-8'"
 								>
 									<img
-										:src="data[field.name]"
+										:src="fileUrl(data[field.name])"
 										class="rounded"
 										:class="field.size == 'lg' ? 'w-36' : 'size-6'"
 									/>
 								</div>
 								<div class="flex flex-col flex-wrap">
 									<span class="break-all text-ink-gray-9">
-										{{ data[field.name].split('/').pop() }}
+										{{ fileName(data[field.name]) }}
 									</span>
 								</div>
 								<span
@@ -170,6 +170,18 @@ const props = defineProps({
 		required: true,
 	},
 })
+
+// Attach fields arrive from the backend as a {file_name, file_url} object, but
+// become a plain file_url string after a fresh upload. Handle both shapes.
+const fileUrl = (value) =>
+	value && typeof value === 'object' ? value.file_url : value
+
+const fileName = (value) => {
+	const url = fileUrl(value)
+	return value && typeof value === 'object' && value.file_name
+		? value.file_name
+		: (url || '').split('/').pop()
+}
 
 const resolveInitialValue = (field, dataValue) => {
 	if (dataValue !== null && dataValue !== undefined && dataValue !== '') {

--- a/frontend/src/tests/SettingFields.test.ts
+++ b/frontend/src/tests/SettingFields.test.ts
@@ -146,6 +146,66 @@ describe('SettingFields — number input persists to data', () => {
 	})
 })
 
+describe('SettingFields — Upload field renders both object and string values', () => {
+	const uploadSections = () =>
+		reactive([
+			{
+				columns: [
+					{
+						fields: [
+							{
+								label: 'Brand image',
+								name: 'brand_image',
+								type: 'Upload',
+							},
+						],
+					},
+				],
+			},
+		])
+
+	// Regression: the backend (get_payment_gateway_details -> get_file_info)
+	// hands back an Attach value as a {file_name, file_url} object, but the
+	// template used to call data[field.name].split('/') on it, throwing
+	// "split is not a function" and blanking the whole settings dialog.
+	it('does not throw when the value is a {file_name, file_url} object', async () => {
+		const data = reactive({
+			brand_image: {
+				file_name: 'logo.png',
+				file_url: '/files/logo.png',
+				file_size: 1234,
+			},
+		})
+		const wrapper = mountFields(uploadSections(), data)
+		await flushPromises()
+
+		// Shows the file name from the object...
+		expect(wrapper.text()).toContain('logo.png')
+		// ...and the <img> src is the object's file_url, not [object Object].
+		expect(wrapper.get('img').attributes('src')).toBe('/files/logo.png')
+	})
+
+	it('falls back to the URL basename when the value is a plain string', async () => {
+		// A fresh upload sets data[field.name] = file.file_url (a string).
+		const data = reactive({ brand_image: '/files/fresh-upload.png' })
+		const wrapper = mountFields(uploadSections(), data)
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('fresh-upload.png')
+		expect(wrapper.get('img').attributes('src')).toBe(
+			'/files/fresh-upload.png'
+		)
+	})
+
+	it('renders the uploader (no image) when the value is empty', async () => {
+		const data = reactive<Record<string, unknown>>({ brand_image: '' })
+		const wrapper = mountFields(uploadSections(), data)
+		await flushPromises()
+
+		expect(wrapper.find('img').exists()).toBe(false)
+	})
+})
+
 describe('SettingFields — defaults surface in the input when data is empty', () => {
 	it('uses field.default when data[field.name] is undefined', async () => {
 		const sections = reactive([


### PR DESCRIPTION
## Summary
- `get_file_info` returns an Attach as a {file_name, file_url} object, but SettingFields.vue called .split('/') on it as a string → "split is not a function", blanking the whole dialog. Fresh uploads set a plain file_url string, so both shapes occur. Now fixed by adding fileUrl()/fileName() helpers that handle object, string, and empty cases, used for the <img> src and displayed name.
- Added tests to prevent regression
