### PR TITLE
fix(lesson): serve private media without the recent send_private_file

### DIFF
--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, FOSS United and contributors
 # For license information, please see license.txt
 
+import inspect
 import json
 from urllib.parse import unquote
 
@@ -184,7 +185,21 @@ def serve_resource(file_url: str):
 
 	# send_private_file expects a path relative to the site's private/ dir.
 	relative_path = file_url.split("/private", 1)[1] if "/private" in file_url else file_url
-	return send_private_file(relative_path, filename=file_row.file_name)
+	return _serve_private_file(relative_path, file_row.file_name)
+
+
+def _serve_private_file(relative_path: str, filename: str):
+	"""Version-safe call into Frappe's send_private_file.
+
+	The `filename` kwarg (nicer download name + content-type) was added only in recent
+	Frappe; LMS supports frappe>=14 where it may be absent. Passing it there raises
+	`TypeError: unexpected keyword argument 'filename'`. Fall back to the path-only form
+	(send_private_file derives the name from the path basename, which keeps the .pdf
+	extension so inline viewing still works).
+	"""
+	if "filename" in inspect.signature(send_private_file).parameters:
+		return send_private_file(relative_path, filename=filename)
+	return send_private_file(relative_path)
 
 
 def _deny(file_url, reason):

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -3,6 +3,7 @@
 
 import inspect
 import json
+from functools import cache
 from urllib.parse import unquote
 
 import frappe
@@ -188,6 +189,13 @@ def serve_resource(file_url: str):
 	return _serve_private_file(relative_path, file_row.file_name)
 
 
+@cache
+def _accepts_filename(func) -> bool:
+	"""Whether `func` takes a `filename` kwarg. Memoized per function object, so the
+	signature is introspected once per Frappe build (and again for a test's stub)."""
+	return "filename" in inspect.signature(func).parameters
+
+
 def _serve_private_file(relative_path: str, filename: str):
 	"""Version-safe call into Frappe's send_private_file.
 
@@ -197,7 +205,7 @@ def _serve_private_file(relative_path: str, filename: str):
 	(send_private_file derives the name from the path basename, which keeps the .pdf
 	extension so inline viewing still works).
 	"""
-	if "filename" in inspect.signature(send_private_file).parameters:
+	if _accepts_filename(send_private_file):
 		return send_private_file(relative_path, filename=filename)
 	return send_private_file(relative_path)
 

--- a/lms/lms/doctype/course_lesson/test_course_lesson.py
+++ b/lms/lms/doctype/course_lesson/test_course_lesson.py
@@ -135,3 +135,39 @@ class TestApplyEnforcementFlagsEdgeCases(unittest.TestCase):
 			self.fn(assignment_done=False, quiz_done=True, settings=settings),
 			(True, False),
 		)
+
+
+class TestServePrivateFileVersionSafe(unittest.TestCase):
+	"""serve_resource must not pass `filename=` to a Frappe whose send_private_file
+	predates that kwarg (LMS supports frappe>=14). Regression for the student-view 500:
+	TypeError: send_private_file() got an unexpected keyword argument 'filename'."""
+
+	def _run(self, stub):
+		from lms.lms.doctype.course_lesson import course_lesson
+
+		original = course_lesson.send_private_file
+		course_lesson.send_private_file = stub
+		try:
+			return course_lesson._serve_private_file("/files/x.pdf", "nice.pdf")
+		finally:
+			course_lesson.send_private_file = original
+
+	def test_old_frappe_without_filename_kwarg(self):
+		calls = []
+
+		def old_stub(path):  # pre-filename Frappe: only accepts the path
+			calls.append((path,))
+			return "sent"
+
+		self.assertEqual(self._run(old_stub), "sent")
+		self.assertEqual(calls, [("/files/x.pdf",)])
+
+	def test_new_frappe_passes_filename(self):
+		calls = []
+
+		def new_stub(path, filename=None):
+			calls.append((path, filename))
+			return "sent"
+
+		self.assertEqual(self._run(new_stub), "sent")
+		self.assertEqual(calls, [("/files/x.pdf", "nice.pdf")])


### PR DESCRIPTION
## Summary
- Student/guest requests for private lesson PDFs were returned 500 because the code passed a filename= argument that only exists in very new Frappe versions (LMS still supports older ones). 
- Fixed it with a wrapper that only passes filename when the installed Frappe supports it, otherwise falls back to the old path-only call. Added a test covering both the old and new Frappe signatures.