### PR TITLE
fix(lesson): preserve rich formatting when pasting HTML into the editor

### DIFF
--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -58,6 +58,15 @@ describe('_parsePastedHTMLToBlocks — inline formatting', () => {
 		expect(bad[0].data.text).not.toContain('javascript')
 	})
 
+	it('drops protocol-relative links but keeps a same-site path', () => {
+		const evil = parse('<p><a href="//evil.com/x">x</a></p>')
+		expect(evil[0].data.text).toBe('x')
+		expect(evil[0].data.text).not.toContain('evil.com')
+
+		const local = parse('<p><a href="/courses/1">c</a></p>')
+		expect(local[0].data.text).toBe('<a href="/courses/1">c</a>')
+	})
+
 	it('strips presentational wrappers (span/font/color) but keeps their text', () => {
 		const blocks = parse(
 			'<p><span style="color:red">red</span> <font color="blue">blue</font></p>'
@@ -119,9 +128,34 @@ describe('_parsePastedHTMLToBlocks — block structure', () => {
 		expect(data[0].data.url).toBe('data:image/png;base64,AAAA')
 	})
 
-	it('drops images with unsafe src schemes', () => {
-		const blocks = parse('<p><img src="javascript:alert(1)"></p>')
-		expect(blocks.filter((b) => b.type === 'image')).toHaveLength(0)
+	it('drops images with unsafe or protocol-relative src', () => {
+		expect(
+			parse('<p><img src="javascript:alert(1)"></p>').filter(
+				(b) => b.type === 'image'
+			)
+		).toHaveLength(0)
+		expect(
+			parse('<p><img src="//evil.com/x.png"></p>').filter(
+				(b) => b.type === 'image'
+			)
+		).toHaveLength(0)
+	})
+
+	it('does not duplicate rows or text from a nested table', () => {
+		const blocks = parse(
+			'<table><tr><td>outer<table><tr><td>inner</td></tr></table></td><td>B</td></tr></table>'
+		)
+		const tables = blocks.filter((b) => b.type === 'table')
+		expect(tables).toHaveLength(1)
+		// Only the outer table's single row, with its two direct cells.
+		expect(tables[0].data.content).toHaveLength(1)
+		expect(tables[0].data.content[0]).toHaveLength(2)
+		expect(tables[0].data.content[0][1]).toBe('B')
+		// The inner text appears once (folded into the parent cell), not as an
+		// extra row.
+		const innerCount = (tables[0].data.content[0][0].match(/inner/g) || [])
+			.length
+		expect(innerCount).toBe(1)
 	})
 
 	it('recurses through wrapper divs/sections and preserves order', () => {

--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Markdown } from '@/utils/markdownParser'
+
+// The Markdown block's constructor calls the Frappe `__` translation global.
+declare global {
+	// eslint-disable-next-line no-var
+	var __: (text: string) => string
+}
+globalThis.__ = (text: string) => text
+
+type Block = { type: string; data: any }
+
+function newBlock() {
+	// api is only touched by paste *insertion*, not by the pure HTML->blocks
+	// parser, so a bare stub is enough for parser-level unit tests.
+	return new Markdown({
+		data: {},
+		api: {
+			blocks: {
+				getCurrentBlockIndex: () => 0,
+				insert: vi.fn(),
+				delete: vi.fn(),
+			},
+			caret: { setToBlock: vi.fn() },
+		},
+		readOnly: false,
+		config: {},
+	}) as any
+}
+
+function parse(html: string): Block[] {
+	return newBlock()._parsePastedHTMLToBlocks(html)
+}
+
+describe('_parsePastedHTMLToBlocks — inline formatting', () => {
+	it('preserves bold, italic and inline code inside a paragraph', () => {
+		const blocks = parse(
+			'<p>Plain <b>bold</b> and <i>italic</i> and <code>code()</code>.</p>'
+		)
+		expect(blocks).toHaveLength(1)
+		expect(blocks[0].type).toBe('paragraph')
+		expect(blocks[0].data.text).toContain('<b>bold</b>')
+		expect(blocks[0].data.text).toContain('<i>italic</i>')
+		expect(blocks[0].data.text).toContain('code()')
+	})
+
+	it('normalizes strong/em/del to the editor’s inline tags', () => {
+		const blocks = parse('<p><strong>a</strong><em>b</em><del>c</del></p>')
+		expect(blocks[0].data.text).toBe('<b>a</b><i>b</i><s>c</s>')
+	})
+
+	it('keeps safe links and drops the tag (keeping text) for unsafe hrefs', () => {
+		const ok = parse('<p><a href="https://x.io/y">link</a></p>')
+		expect(ok[0].data.text).toBe('<a href="https://x.io/y">link</a>')
+
+		const bad = parse('<p><a href="javascript:alert(1)">x</a></p>')
+		expect(bad[0].data.text).toBe('x')
+		expect(bad[0].data.text).not.toContain('javascript')
+	})
+
+	it('strips presentational wrappers (span/font/color) but keeps their text', () => {
+		const blocks = parse(
+			'<p><span style="color:red">red</span> <font color="blue">blue</font></p>'
+		)
+		expect(blocks[0].data.text).toBe('red blue')
+		expect(blocks[0].data.text).not.toContain('style')
+		expect(blocks[0].data.text).not.toContain('color')
+	})
+
+	it('escapes raw angle brackets in text content', () => {
+		const blocks = parse('<p>1 &lt; 2 &amp; 3 &gt; 0</p>')
+		expect(blocks[0].data.text).toBe('1 &lt; 2 &amp; 3 &gt; 0')
+	})
+})
+
+describe('_parsePastedHTMLToBlocks — block structure', () => {
+	it('maps h1..h6 to header blocks with the right level and inline text', () => {
+		const blocks = parse('<h2>Title <b>here</b></h2>')
+		expect(blocks[0]).toMatchObject({ type: 'header' })
+		expect(blocks[0].data.level).toBe(2)
+		expect(blocks[0].data.text).toBe('Title <b>here</b>')
+	})
+
+	it('preserves nested lists with inline formatting', () => {
+		const blocks = parse(
+			'<ul><li>one <b>bold</b><ul><li>nested</li></ul></li><li>two</li></ul>'
+		)
+		expect(blocks[0].type).toBe('list')
+		expect(blocks[0].data.style).toBe('unordered')
+		const [first, second] = blocks[0].data.items
+		expect(first.content).toBe('one <b>bold</b>')
+		expect(first.items).toHaveLength(1)
+		expect(first.items[0].content).toBe('nested')
+		expect(second.content).toBe('two')
+	})
+
+	it('converts a table (with th header row) to a table block', () => {
+		const blocks = parse(
+			'<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'
+		)
+		expect(blocks[0].type).toBe('table')
+		expect(blocks[0].data.withHeadings).toBe(true)
+		expect(blocks[0].data.content).toEqual([
+			['A', 'B'],
+			['1', '2'],
+		])
+	})
+
+	it('extracts https and base64 images into image blocks', () => {
+		const https = parse('<p><img src="https://cdn.x/i.png" alt="cat"></p>')
+		expect(https[0]).toMatchObject({ type: 'image' })
+		expect(https[0].data.url).toBe('https://cdn.x/i.png')
+		expect(https[0].data.caption).toBe('cat')
+
+		const data = parse(
+			'<figure><img src="data:image/png;base64,AAAA"></figure>'
+		)
+		expect(data[0].type).toBe('image')
+		expect(data[0].data.url).toBe('data:image/png;base64,AAAA')
+	})
+
+	it('drops images with unsafe src schemes', () => {
+		const blocks = parse('<p><img src="javascript:alert(1)"></p>')
+		expect(blocks.filter((b) => b.type === 'image')).toHaveLength(0)
+	})
+
+	it('recurses through wrapper divs/sections and preserves order', () => {
+		const blocks = parse(
+			'<div><h3>Head</h3><div><p>para</p></div><ul><li>item</li></ul></div>'
+		)
+		expect(blocks.map((b) => b.type)).toEqual(['header', 'paragraph', 'list'])
+	})
+
+	it('keeps a PRE block as code (angle brackets escaped)', () => {
+		const blocks = parse('<pre>let x = 1 &lt; 2</pre>')
+		expect(blocks[0].type).toBe('codeBox')
+		expect(blocks[0].data.code).toContain('let x')
+		expect(blocks[0].data.code).toContain('&lt;')
+	})
+
+	it('ignores blank/whitespace-only paragraphs', () => {
+		const blocks = parse('<p>real</p><p></p><p>&nbsp;</p>')
+		expect(blocks).toHaveLength(1)
+		expect(blocks[0].data.text).toBe('real')
+	})
+})
+
+describe('_onNativePaste — routing', () => {
+	function fakeEvent(data: Record<string, string>) {
+		return {
+			clipboardData: { getData: (t: string) => data[t] || '' },
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+			stopImmediatePropagation: vi.fn(),
+		} as any
+	}
+
+	let block: any
+	beforeEach(() => {
+		block = newBlock()
+		block._insertBlocks = vi.fn()
+		block._insertMarkdownAsBlocks = vi.fn()
+	})
+
+	it('takes over rich HTML pastes and inserts parsed blocks', () => {
+		const e = fakeEvent({
+			'text/html':
+				'<h1>T</h1><p><b>x</b></p><table><tr><td>c</td></tr></table>',
+			'text/plain': 'T x c',
+		})
+		block._onNativePaste(e)
+		expect(e.preventDefault).toHaveBeenCalled()
+		expect(block._insertBlocks).toHaveBeenCalledTimes(1)
+		const inserted = block._insertBlocks.mock.calls[0][0]
+		expect(inserted.map((b: Block) => b.type)).toEqual([
+			'header',
+			'paragraph',
+			'table',
+		])
+	})
+
+	it('defers to EditorJS for internal block paste (x-editor-js clipboard)', () => {
+		const e = fakeEvent({
+			'application/x-editor-js': '[{"type":"paragraph"}]',
+			'text/html': '<p>hi</p>',
+		})
+		block._onNativePaste(e)
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(block._insertBlocks).not.toHaveBeenCalled()
+	})
+
+	it('leaves plain non-markdown text to the default handler', () => {
+		const e = fakeEvent({ 'text/plain': 'just a sentence' })
+		block._onNativePaste(e)
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(block._insertBlocks).not.toHaveBeenCalled()
+		expect(block._insertMarkdownAsBlocks).not.toHaveBeenCalled()
+	})
+})

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -618,11 +618,17 @@ export class Markdown {
 	}
 
 	_parseTable(tableNode) {
-		const rows = [...tableNode.querySelectorAll('tr')]
+		// Scope to this table's own rows/cells; querySelectorAll would descend
+		// into nested tables and duplicate their rows/text into the parent.
+		const rows = [
+			...tableNode.querySelectorAll(
+				':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr'
+			),
+		]
 		if (!rows.length) return null
 
 		const content = rows.map((tr) =>
-			[...tr.querySelectorAll('th, td')].map((cell) =>
+			[...tr.querySelectorAll(':scope > th, :scope > td')].map((cell) =>
 				this._inline(cell.childNodes)
 			)
 		)
@@ -631,7 +637,7 @@ export class Markdown {
 		return {
 			type: 'table',
 			data: {
-				withHeadings: rows[0].querySelector('th') != null,
+				withHeadings: rows[0].querySelector(':scope > th') != null,
 				content,
 			},
 		}
@@ -660,7 +666,8 @@ export class Markdown {
 		if (!href) return ''
 		const h = href.trim()
 		if (/^(https?:|mailto:|tel:)/i.test(h)) return h
-		if (/^(\/|#|\.)/.test(h)) return h // relative / anchor
+		if (/^\/\//.test(h)) return '' // protocol-relative → cross-origin
+		if (/^(\/|#|\.)/.test(h)) return h // same-site path / anchor
 		return ''
 	}
 
@@ -669,6 +676,7 @@ export class Markdown {
 		const s = src.trim()
 		if (/^https?:\/\//i.test(s)) return s
 		if (/^data:image\//i.test(s)) return s // embedded base64 images
+		if (/^\/\//.test(s)) return '' // protocol-relative → cross-origin
 		if (/^\//.test(s)) return s // site-relative
 		return ''
 	}

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -2,6 +2,39 @@ import { CodeXml } from 'lucide-vue-next'
 import { createApp, h } from 'vue'
 import { escapeHTML } from '@/utils/format'
 
+// Inline tags we keep when pasting rich HTML, normalized to the same tags the
+// editor's own inline tools emit. Everything else (span/font/div wrappers,
+// colors, styles) is dropped while its text is preserved. The stored content is
+// still run through DOMPurify (render) and Frappe sanitize_html (save), so this
+// map is a whitelist, not the only line of defense.
+const INLINE_TAG_MAP = {
+	B: 'b',
+	STRONG: 'b',
+	I: 'i',
+	EM: 'i',
+	U: 'u',
+	S: 's',
+	STRIKE: 's',
+	DEL: 's',
+	MARK: 'mark',
+	CODE: 'code',
+	SUP: 'sup',
+	SUB: 'sub',
+	A: 'a',
+}
+
+// Inline elements that, when they appear at the top level, should become a
+// single paragraph rather than being recursed into as a container.
+const INLINE_TAGS = new Set([
+	...Object.keys(INLINE_TAG_MAP),
+	'SPAN',
+	'FONT',
+	'SMALL',
+	'ABBR',
+	'LABEL',
+	'BR',
+])
+
 export class Markdown {
 	constructor({ data, api, readOnly, config }) {
 		this.api = api
@@ -69,9 +102,16 @@ export class Markdown {
 		const clipboardData = event.clipboardData || window.clipboardData
 		if (!clipboardData) return
 
+		// Internal EditorJS block copy/paste carries its own payload — let
+		// EditorJS handle it so cross-block moves keep working.
+		if (clipboardData.getData('application/x-editor-js')) return
+
 		const pastedText = clipboardData.getData('text/plain')
 		const pastedHTML = clipboardData.getData('text/html')
-		const hasHTMLTags = (s) => /<(pre|h[1-6]|ul|ol)[\s>]/i.test(s)
+		const hasHTMLTags = (s) =>
+			/<(pre|h[1-6]|ul|ol|table|img|blockquote|figure|p|div|section|article)[\s>]/i.test(
+				s
+			)
 
 		const html =
 			(pastedText && hasHTMLTags(pastedText) && pastedText) ||
@@ -445,12 +485,13 @@ export class Markdown {
 	_parsePastedHTMLToBlocks(html) {
 		const doc = new DOMParser().parseFromString(html, 'text/html')
 		const blocks = []
+		const push = (block) => block && blocks.push(block)
 
-		const walk = (node) => {
+		const handle = (node) => {
 			if (node.nodeType === Node.TEXT_NODE) {
-				const text = node.textContent.trim()
+				const text = node.textContent.replace(/�\u00a0/g, ' ').trim()
 				if (text)
-					blocks.push({
+					push({
 						type: 'paragraph',
 						data: { text: escapeHTML(text) },
 					})
@@ -462,7 +503,7 @@ export class Markdown {
 			const tag = node.tagName
 
 			if (tag === 'PRE') {
-				blocks.push({
+				push({
 					type: 'codeBox',
 					data: {
 						code: escapeHTML(node.textContent),
@@ -470,41 +511,166 @@ export class Markdown {
 					},
 				})
 			} else if (/^H[1-6]$/.test(tag)) {
-				blocks.push({
-					type: 'header',
-					data: {
-						text: escapeHTML(node.textContent.trim()),
-						level: +tag[1],
-					},
-				})
-			} else if (tag === 'UL' || tag === 'OL') {
-				const items = [...node.querySelectorAll(':scope > li')].map(
-					(li) => ({
-						content: escapeHTML(li.textContent.trim()),
-						items: [],
+				if (this._hasText(node))
+					push({
+						type: 'header',
+						data: {
+							text: this._inline(node.childNodes),
+							level: +tag[1],
+						},
 					})
-				)
-				blocks.push({
+			} else if (tag === 'UL' || tag === 'OL') {
+				push({
 					type: 'list',
 					data: {
 						style: tag === 'UL' ? 'unordered' : 'ordered',
-						items,
+						items: this._parseListItems(node),
 					},
 				})
+			} else if (tag === 'TABLE') {
+				push(this._parseTable(node))
+			} else if (tag === 'IMG') {
+				push(this._imageBlock(node))
+			} else if (tag === 'P' || tag === 'BLOCKQUOTE') {
+				if (this._hasText(node))
+					push({
+						type: 'paragraph',
+						data: { text: this._inline(node.childNodes) },
+					})
+				this._emitImages(node, push)
+			} else if (INLINE_TAGS.has(tag)) {
+				if (this._hasText(node))
+					push({
+						type: 'paragraph',
+						data: { text: this._inline([node]) },
+					})
 			} else if (node.childNodes.length) {
-				for (const child of node.childNodes) walk(child)
+				// FIGURE / DIV / SECTION / ARTICLE and other containers.
+				for (const child of node.childNodes) handle(child)
 			} else {
 				const text = node.textContent.trim()
 				if (text)
-					blocks.push({
+					push({
 						type: 'paragraph',
 						data: { text: escapeHTML(text) },
 					})
 			}
 		}
 
-		for (const child of doc.body.childNodes) walk(child)
+		for (const child of doc.body.childNodes) handle(child)
 		return blocks
+	}
+
+	// True when a node carries visible text (nbsp-aware).
+	_hasText(node) {
+		return node.textContent.replace(/�\u00a0/g, ' ').trim().length > 0
+	}
+
+	// Serialize a set of nodes to a whitelisted inline-HTML string. Unknown
+	// wrappers keep their text but lose the tag; unsafe links/text are escaped.
+	_inline(nodes) {
+		let out = ''
+		for (const child of nodes) {
+			if (child.nodeType === Node.TEXT_NODE) {
+				out += escapeHTML(child.textContent)
+				continue
+			}
+			if (child.nodeType !== Node.ELEMENT_NODE) continue
+
+			const tag = child.tagName
+			if (tag === 'BR') {
+				out += '<br>'
+				continue
+			}
+			if (tag === 'IMG') continue // images become their own blocks
+
+			const mapped = INLINE_TAG_MAP[tag]
+			const inner = this._inline(child.childNodes)
+
+			if (mapped === 'a') {
+				const href = this._safeHref(child.getAttribute('href'))
+				out += href
+					? `<a href="${escapeHTML(href)}">${inner}</a>`
+					: inner
+			} else if (mapped) {
+				const cls = mapped === 'code' ? ' class="inline-code"' : ''
+				out += `<${mapped}${cls}>${inner}</${mapped}>`
+			} else {
+				out += inner
+			}
+		}
+		return out
+	}
+
+	_parseListItems(listNode) {
+		return [...listNode.querySelectorAll(':scope > li')].map((li) => {
+			const nested = li.querySelector(':scope > ul, :scope > ol')
+			// Content is the item's own inline text, excluding any nested list.
+			const clone = li.cloneNode(true)
+			clone
+				.querySelectorAll(':scope > ul, :scope > ol')
+				.forEach((n) => n.remove())
+			return {
+				content: this._inline(clone.childNodes),
+				items: nested ? this._parseListItems(nested) : [],
+			}
+		})
+	}
+
+	_parseTable(tableNode) {
+		const rows = [...tableNode.querySelectorAll('tr')]
+		if (!rows.length) return null
+
+		const content = rows.map((tr) =>
+			[...tr.querySelectorAll('th, td')].map((cell) =>
+				this._inline(cell.childNodes)
+			)
+		)
+		if (!content.length || !content[0].length) return null
+
+		return {
+			type: 'table',
+			data: {
+				withHeadings: rows[0].querySelector('th') != null,
+				content,
+			},
+		}
+	}
+
+	_imageBlock(imgNode) {
+		const url = this._safeSrc(imgNode.getAttribute('src'))
+		if (!url) return null
+		return {
+			type: 'image',
+			data: {
+				url,
+				caption: escapeHTML(imgNode.getAttribute('alt') || ''),
+			},
+		}
+	}
+
+	// Pull standalone images out of a text container into their own blocks.
+	_emitImages(node, push) {
+		node.querySelectorAll('img').forEach((img) =>
+			push(this._imageBlock(img))
+		)
+	}
+
+	_safeHref(href) {
+		if (!href) return ''
+		const h = href.trim()
+		if (/^(https?:|mailto:|tel:)/i.test(h)) return h
+		if (/^(\/|#|\.)/.test(h)) return h // relative / anchor
+		return ''
+	}
+
+	_safeSrc(src) {
+		if (!src) return ''
+		const s = src.trim()
+		if (/^https?:\/\//i.test(s)) return s
+		if (/^data:image\//i.test(s)) return s // embedded base64 images
+		if (/^\//.test(s)) return s // site-relative
+		return ''
 	}
 }
 


### PR DESCRIPTION
- The lesson editor's paste handler only understood a few tags (pre/headings/lists) and escaped everything else, so pasting bold, italic, links, images, or tables just dumped plain text.
- Rewrote it to properly convert pasted HTML into editor blocks: keeping inline formatting, headings, nested lists, tables, and images (https + base64). Junk wrappers like span/font are stripped but their text kept, unsafe link/image URLs are rejected, and copy/paste within the editor is left to EditorJS. Content is still sanitized on render and save. 
- Added tests