### PR TITLE
fix(delete): clean up all lesson/course back-references on deletion

### DIFF
--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -209,6 +209,11 @@ const deleteLesson = createResource({
 		outline.reload()
 		toast.success(__('Lesson deleted successfully'))
 	},
+	onError(err: { messages?: string[] } | string) {
+		toast.error(
+			typeof err === 'string' ? err : err.messages?.[0] ?? __('Error')
+		)
+	},
 })
 
 const updateLessonIndex = createResource({
@@ -246,6 +251,11 @@ const deleteChapter = createResource({
 	onSuccess() {
 		outline.reload()
 		toast.success(__('Chapter deleted successfully'))
+	},
+	onError(err: { messages?: string[] } | string) {
+		toast.error(
+			typeof err === 'string' ? err : err.messages?.[0] ?? __('Error')
+		)
 	},
 })
 

--- a/frontend/src/pages/Courses/CourseForm.vue
+++ b/frontend/src/pages/Courses/CourseForm.vue
@@ -249,6 +249,11 @@ const deleteCourse = createResource({
 		// Land on the creator's "Created" courses — pick another course to edit.
 		router.push({ name: 'Courses', query: { tab: 'created' } })
 	},
+	onError(err: { messages?: string[] } | string) {
+		toast.error(
+			typeof err === 'string' ? err : err.messages?.[0] ?? __('Error')
+		)
+	},
 }) as Resource<unknown>
 
 const trashCourse = (): void => {

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -31,7 +31,10 @@ from frappe.utils.response import Response
 from pypika import functions as fn
 
 from lms.lms.course_import_export import export_course_zip, import_course_zip
-from lms.lms.doctype.course_lesson.course_lesson import save_progress
+from lms.lms.doctype.course_lesson.course_lesson import (
+	cleanup_lesson_backreferences,
+	save_progress,
+)
 from lms.lms.utils import (
 	LMS_ROLES,
 	can_modify_batch,
@@ -1013,11 +1016,23 @@ def delete_course(course: str):
 
 	frappe.db.delete("LMS Enrollment", {"course": course})
 	frappe.db.delete("LMS Course Progress", {"course": course})
+	frappe.db.delete("LMS Video Watch Duration", {"course": course})
 	frappe.db.delete("LMS Certificate", {"course": course})
+	frappe.db.delete("LMS Certificate Request", {"course": course})
+	frappe.db.delete("LMS Certificate Evaluation", {"course": course})
+	frappe.db.delete("LMS Course Interest", {"course": course})
+	frappe.db.delete("LMS Course Mentor Mapping", {"course": course})
 	frappe.db.delete("Batch Course", {"course": course})
 	frappe.db.delete("LMS Course Review", {"course": course})
+	# This course may appear in another parent's child table (another course's related
+	# list, a program's course list); remove those rows so the delete isn't blocked.
+	frappe.db.delete("Related Courses", {"course": course})
+	frappe.db.delete("LMS Program Course", {"course": course})
+	# Preserve authored assessments and graded work — unlink from the course/lesson rather than delete.
 	frappe.db.set_value("LMS Quiz", {"course": course}, {"course": None, "lesson": None})
 	frappe.db.set_value("LMS Quiz Submission", {"course": course}, "course", None)
+	frappe.db.set_value("LMS Assignment Submission", {"course": course}, {"course": None, "lesson": None})
+	frappe.db.set_value("LMS Assignment", {"course": course}, "course", None)
 
 	chapters = frappe.get_all("Course Chapter", {"course": course}, pluck="name")
 	frappe.db.delete("Chapter Reference", {"parent": course})
@@ -1301,6 +1316,8 @@ def delete_chapter(chapter: str):
 			frappe.db.delete("Discussion Topic", topic)
 		frappe.db.delete("LMS Course Progress", {"lesson": lesson})
 		frappe.db.delete("LMS Video Watch Duration", {"lesson": lesson})
+		# Raw db.delete below skips the controller's on_trash, so unlink back-references here.
+		cleanup_lesson_backreferences(lesson)
 
 	frappe.db.delete("Chapter Reference", {"chapter": chapter})
 	frappe.db.delete("Lesson Reference", {"parent": chapter})

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -29,15 +29,10 @@ class CourseLesson(Document):
 		self.validate_progress_recalculation()
 
 	def on_trash(self):
-		self.delete_linked_notes()
+		cleanup_lesson_backreferences(self.name)
 
 	def after_delete(self):
 		self.validate_progress_recalculation()
-
-	def delete_linked_notes(self):
-		notes = frappe.get_all("LMS Lesson Note", filters={"lesson": self.name}, pluck="name")
-		for note in notes:
-			frappe.delete_doc("LMS Lesson Note", note, ignore_permissions=True)
 
 	def validate(self):
 		self.content = sanitize_editorjs(self.content)
@@ -89,6 +84,20 @@ class CourseLesson(Document):
 						"lesson": self.name,
 					},
 				)
+
+
+def cleanup_lesson_backreferences(lesson: str):
+	"""Clear other docs' references to `lesson` so its deletion isn't blocked by
+	LinkExistsError (delete_doc paths: delete_lesson, delete_course, desk) or silently
+	orphaned (delete_chapter's raw db.delete). Notes are meaningless without the lesson
+	and are deleted; data-bearing docs (quiz + its submissions, enrollment progress,
+	graded work) are only unlinked."""
+	for note in frappe.get_all("LMS Lesson Note", {"lesson": lesson}, pluck="name"):
+		frappe.delete_doc("LMS Lesson Note", note, ignore_permissions=True)
+
+	frappe.db.set_value("LMS Quiz", {"lesson": lesson}, "lesson", None)
+	frappe.db.set_value("LMS Enrollment", {"current_lesson": lesson}, "current_lesson", None)
+	frappe.db.set_value("LMS Assignment Submission", {"lesson": lesson}, "lesson", None)
 
 
 def has_permission(doc, ptype="read", user=None):

--- a/lms/tests/api/test_delete.py
+++ b/lms/tests/api/test_delete.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_days, nowdate
 
 from lms.lms.api import delete_chapter, delete_course, delete_lesson
 from lms.lms.test_helpers import BaseTestUtils
@@ -76,6 +77,70 @@ class DeletionTestBase(BaseTestUtils):
 		self.cleanup_items.append(("Discussion Reply", reply.name))
 		return topic, reply
 
+	def _create_quiz_for_lesson(self, lesson, title="Deletion Quiz"):
+		question = frappe.get_doc(
+			{
+				"doctype": "LMS Question",
+				"question": "Deletion question?",
+				"type": "Choices",
+				"option_1": "A",
+				"is_correct_1": 1,
+				"option_2": "B",
+				"is_correct_2": 0,
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Question", question.name))
+
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": title,
+				"passing_percentage": 70,
+				"questions": [{"question": question.name, "marks": 5}],
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Quiz", quiz.name))
+
+		# Mirror save_lesson_details_in_quiz: an embedded quiz back-references its lesson.
+		frappe.db.set_value("LMS Quiz", quiz.name, {"lesson": lesson, "course": self.course.name})
+		return quiz
+
+	def _create_assignment_submission_for_lesson(self, lesson, member):
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": f"Deletion Assignment {frappe.generate_hash()}",
+				"question": "Do the thing.",
+				"type": "Text",
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Assignment", assignment.name))
+
+		submission = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment Submission",
+				"assignment": assignment.name,
+				"member": member,
+				"lesson": lesson,
+				"answer": "My answer.",
+				"status": "Pass",
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Assignment Submission", submission.name))
+		return submission
+
+	def _create_lesson_note(self, lesson, member):
+		note = frappe.get_doc(
+			{
+				"doctype": "LMS Lesson Note",
+				"lesson": lesson,
+				"member": member,
+				"note": "My note",
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Lesson Note", note.name))
+		return note
+
 
 class TestLessonDeletion(DeletionTestBase):
 	def setUp(self):
@@ -130,6 +195,43 @@ class TestLessonDeletion(DeletionTestBase):
 		self.assertFalse(frappe.db.exists("Discussion Topic", topic.name))
 		self.assertFalse(frappe.db.exists("Discussion Reply", reply.name))
 
+	def test_unlinks_quiz_instead_of_blocking_deletion(self):
+		lesson = self._add_lesson(self.chapter, "Lesson 1", 1)
+		quiz = self._create_quiz_for_lesson(lesson.name)
+
+		delete_lesson(lesson.name, self.chapter.name)
+
+		self.assertFalse(frappe.db.exists("Course Lesson", lesson.name))
+		self.assertTrue(frappe.db.exists("LMS Quiz", quiz.name))
+		self.assertIsNone(frappe.db.get_value("LMS Quiz", quiz.name, "lesson"))
+
+	def test_unlinks_enrollment_current_lesson(self):
+		lesson = self._add_lesson(self.chapter, "Lesson 1", 1)
+		enrollment = self._create_enrollment(self.student.email, self.course.name)
+		frappe.db.set_value("LMS Enrollment", enrollment.name, "current_lesson", lesson.name)
+
+		delete_lesson(lesson.name, self.chapter.name)
+
+		self.assertTrue(frappe.db.exists("LMS Enrollment", enrollment.name))
+		self.assertIsNone(frappe.db.get_value("LMS Enrollment", enrollment.name, "current_lesson"))
+
+	def test_unlinks_assignment_submission(self):
+		lesson = self._add_lesson(self.chapter, "Lesson 1", 1)
+		submission = self._create_assignment_submission_for_lesson(lesson.name, self.student.email)
+
+		delete_lesson(lesson.name, self.chapter.name)
+
+		self.assertTrue(frappe.db.exists("LMS Assignment Submission", submission.name))
+		self.assertIsNone(frappe.db.get_value("LMS Assignment Submission", submission.name, "lesson"))
+
+	def test_deletes_linked_notes(self):
+		lesson = self._add_lesson(self.chapter, "Lesson 1", 1)
+		note = self._create_lesson_note(lesson.name, self.student.email)
+
+		delete_lesson(lesson.name, self.chapter.name)
+
+		self.assertFalse(frappe.db.exists("LMS Lesson Note", note.name))
+
 	def test_student_cannot_delete_lesson(self):
 		lesson = self._add_lesson(self.chapter, "Lesson 1", 1)
 		frappe.set_user(self.student.email)
@@ -178,6 +280,25 @@ class TestChapterDeletion(DeletionTestBase):
 		self.assertFalse(frappe.db.exists("Discussion Reply", reply.name))
 		self.assertFalse(frappe.db.exists("LMS Course Progress", {"lesson": lesson.name}))
 
+	def test_cleans_up_lesson_backreferences(self):
+		# delete_chapter deletes lessons via a raw db.delete that bypasses on_trash,
+		# so it must clean up back-references itself or leave them dangling.
+		chapter = self._add_chapter("Chapter 1", 1)
+		lesson = self._add_lesson(chapter, "Lesson 1", 1)
+		quiz = self._create_quiz_for_lesson(lesson.name)
+		note = self._create_lesson_note(lesson.name, self.student.email)
+		submission = self._create_assignment_submission_for_lesson(lesson.name, self.student.email)
+		enrollment = self._create_enrollment(self.student.email, self.course.name)
+		frappe.db.set_value("LMS Enrollment", enrollment.name, "current_lesson", lesson.name)
+
+		delete_chapter(chapter.name)
+
+		self.assertFalse(frappe.db.exists("Course Lesson", lesson.name))
+		self.assertFalse(frappe.db.exists("LMS Lesson Note", note.name))
+		self.assertIsNone(frappe.db.get_value("LMS Quiz", quiz.name, "lesson"))
+		self.assertIsNone(frappe.db.get_value("LMS Assignment Submission", submission.name, "lesson"))
+		self.assertIsNone(frappe.db.get_value("LMS Enrollment", enrollment.name, "current_lesson"))
+
 	def test_student_cannot_delete_chapter(self):
 		chapter = self._add_chapter("Chapter 1", 1)
 		frappe.set_user(self.student.email)
@@ -225,6 +346,103 @@ class TestCourseDeletion(DeletionTestBase):
 		self.assertFalse(frappe.db.exists("LMS Certificate", {"course": self.course.name}))
 		self.assertFalse(frappe.db.exists("Discussion Topic", topic.name))
 		self.assertFalse(frappe.db.exists("Discussion Reply", reply.name))
+
+	def test_unlinks_lesson_backreferences(self):
+		quiz = self._create_quiz_for_lesson(self.lesson.name)
+		note = self._create_lesson_note(self.lesson.name, self.student.email)
+		submission = self._create_assignment_submission_for_lesson(self.lesson.name, self.student.email)
+
+		delete_course(self.course.name)
+
+		self.assertFalse(frappe.db.exists("Course Lesson", self.lesson.name))
+		self.assertFalse(frappe.db.exists("LMS Lesson Note", note.name))
+		self.assertTrue(frappe.db.exists("LMS Quiz", quiz.name))
+		self.assertIsNone(frappe.db.get_value("LMS Quiz", quiz.name, "lesson"))
+		self.assertIsNone(frappe.db.get_value("LMS Assignment Submission", submission.name, "lesson"))
+
+	def test_deletes_course_with_all_course_referrers(self):
+		# Every doc that references the course via a Link must be cleaned up, else the
+		# final course delete is blocked by LinkExistsError.
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": f"Ref Assignment {frappe.generate_hash()}",
+				"question": "Q",
+				"type": "Text",
+				"course": self.course.name,
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Assignment", assignment.name))
+
+		cert_request = frappe.get_doc(
+			{
+				"doctype": "LMS Certificate Request",
+				"course": self.course.name,
+				"member": self.student.email,
+				"date": add_days(nowdate(), 5),
+				"start_time": "10:00:00",
+				"end_time": "11:00:00",
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Certificate Request", cert_request.name))
+
+		cert_eval = frappe.get_doc(
+			{
+				"doctype": "LMS Certificate Evaluation",
+				"course": self.course.name,
+				"member": self.student.email,
+				"date": add_days(nowdate(), 5),
+				"start_time": "10:00:00",
+				"status": "Pending",
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Certificate Evaluation", cert_eval.name))
+
+		interest = frappe.get_doc(
+			{
+				"doctype": "LMS Course Interest",
+				"course": self.course.name,
+				"user": self.student.email,
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Course Interest", interest.name))
+
+		mentor = frappe.get_doc(
+			{
+				"doctype": "LMS Course Mentor Mapping",
+				"course": self.course.name,
+				"mentor": self.student.email,
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Course Mentor Mapping", mentor.name))
+
+		# This course listed as "related" inside another course.
+		other = self._create_course(title="Other Referrer Course")
+		other.append("related_courses", {"course": self.course.name})
+		other.save(ignore_permissions=True)
+
+		# This course included in a program.
+		program = frappe.get_doc(
+			{
+				"doctype": "LMS Program",
+				"title": f"Ref Program {frappe.generate_hash()}",
+				"program_courses": [{"course": self.course.name}],
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Program", program.name))
+
+		delete_course(self.course.name)
+
+		self.assertFalse(frappe.db.exists("LMS Course", self.course.name))
+		self.assertFalse(frappe.db.exists("LMS Certificate Request", cert_request.name))
+		self.assertFalse(frappe.db.exists("LMS Certificate Evaluation", cert_eval.name))
+		self.assertFalse(frappe.db.exists("LMS Course Interest", interest.name))
+		self.assertFalse(frappe.db.exists("LMS Course Mentor Mapping", mentor.name))
+		self.assertFalse(frappe.db.exists("Related Courses", {"course": self.course.name}))
+		self.assertFalse(frappe.db.exists("LMS Program Course", {"course": self.course.name}))
+		# The reusable assignment definition is preserved, just unlinked from the course.
+		self.assertTrue(frappe.db.exists("LMS Assignment", assignment.name))
+		self.assertIsNone(frappe.db.get_value("LMS Assignment", assignment.name, "course"))
 
 	def test_get_course_details_on_deleted_course_returns_empty(self):
 		course_name = self.course.name


### PR DESCRIPTION
## Summary
- Deleting a Course Lesson threw LinkExistsError when a quiz, enrollment, or assignment submission still referenced it; delete_chapter's raw delete orphaned them instead.
- delete_course also choked on several referrers it never cleaned up.
- Added cleanup_lesson_backreferences() (called from on_trash) to unlink/delete back-references while preserving graded work; extended delete_course to clean the rest.
- Frontend: added onError toasts to the delete calls so failures surface.
- Added regression tests for every pathway × referrer.