### PR TITLE
fix(course editor): commit chapter rename on Enter

### DIFF
--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -16,14 +16,14 @@
 				:class="inlineSelect ? '' : 'flex items-baseline justify-between gap-3'"
 				@click="redirectToChapter"
 			>
-				<Input
+				<TextInput
 					v-if="isRenaming"
 					ref="renameInput"
 					v-model="renameValue"
 					class="w-full"
 					@click.stop.prevent
-					@keydown.enter="commitRename"
-					@keydown.esc="cancelRename"
+					@keydown.enter.stop.prevent="commitRename"
+					@keydown.esc.stop.prevent="cancelRename"
 					@blur="commitRename"
 				/>
 				<div
@@ -144,7 +144,7 @@
 </template>
 
 <script setup lang="ts">
-import { Button, Input, Tooltip, toast } from 'frappe-ui'
+import { Button, TextInput, Tooltip, toast } from 'frappe-ui'
 import { computed, inject, nextTick, ref, watch } from 'vue'
 import Draggable from 'vuedraggable'
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'

--- a/frontend/src/tests/ChapterRow.test.ts
+++ b/frontend/src/tests/ChapterRow.test.ts
@@ -1,0 +1,93 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ChapterRow from '@/components/ChapterRow.vue'
+
+const pushMock = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-router', () => ({
+	useRoute: () => ({ params: {}, query: {} }),
+	useRouter: () => ({ push: pushMock }),
+}))
+
+vi.mock('frappe-ui', () => ({
+	Button: {
+		template: `<button><slot name="prefix" /><slot /></button>`,
+	},
+	TextInput: {
+		props: ['modelValue'],
+		emits: ['update:modelValue'],
+		template: `
+			<div>
+				<input
+					:value="modelValue"
+					@input="$emit('update:modelValue', $event.target.value)"
+				/>
+			</div>
+		`,
+	},
+	Tooltip: {
+		template: `<span><slot /></span>`,
+	},
+	toast: {
+		success: vi.fn(),
+	},
+}))
+
+vi.mock('vuedraggable', () => ({
+	default: {
+		props: ['list'],
+		template: `
+			<div>
+				<div v-for="item in list" :key="item.name">
+					<slot name="item" :element="item" />
+				</div>
+			</div>
+		`,
+	},
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const chapter = {
+	name: 'CH-2',
+	title: 'Old Chapter',
+	idx: 2,
+	is_scorm_package: 0 as const,
+	lessons: [{ name: 'LESSON-1', title: 'Lesson 1', number: '2-1' }],
+}
+
+const mountRow = () =>
+	mount(ChapterRow, {
+		props: {
+			chapter,
+			index: 1,
+			courseName: 'course-1',
+			allowEdit: true,
+		},
+		global: {
+			mocks: { __: (s: string) => s },
+			provide: { $user: { data: { name: 'admin@example.com' } } },
+		},
+	})
+
+beforeEach(() => {
+	pushMock.mockReset()
+})
+
+describe('ChapterRow inline rename', () => {
+	it('commits on Enter without toggling the chapter disclosure', async () => {
+		const wrapper = mountRow()
+
+		expect(wrapper.text()).not.toContain('Lesson 1')
+		await wrapper.get('[title="Old Chapter"]').trigger('dblclick')
+
+		const input = wrapper.get('input')
+		await input.setValue('Renamed Chapter')
+		await input.trigger('keydown.enter')
+
+		expect(wrapper.emitted('rename-chapter')?.[0]).toMatchObject([
+			{ chapter, title: 'Renamed Chapter' },
+		])
+		expect(wrapper.text()).not.toContain('Lesson 1')
+	})
+})


### PR DESCRIPTION
## Problem

In the course editor, double-clicking a chapter to rename it inline and pressing Enter does not save the new title. Instead, the chapter disclosure toggles open/closed, the input loses focus, and the title stays unchanged.

Two causes:

1. The rename input sits inside a headlessui `DisclosureButton`, so the Enter keydown bubbles up and toggles the panel.
2. The component used the deprecated frappe-ui `Input`, which only emits `update:modelValue` on the native `change` event (i.e. on blur). When the Enter keydown handler ran, the v-model still held the old title, so `commitRename` saw an unchanged value and bailed out silently.

## How this PR solves it

- Adds `.stop.prevent` to the Enter/Escape keydown handlers on the rename input so the keypress never reaches the `DisclosureButton`.
- Replaces the deprecated `Input` with `TextInput`, which emits `update:modelValue` on every `input` event, so the v-model is up to date when Enter is pressed.
- Adds a component test covering the flow: double-click to rename, type a new title, press Enter — asserts the rename event is emitted with the new title and the disclosure does not toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)