### PR TITLE
fix: duplicate courses shown to moderators in created courses list

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -2101,6 +2101,7 @@ def get_created_courses():
 		.join(Course)
 		.on(CourseInstructor.parent == Course.name)
 		.select(Course.name)
+		.distinct()
 		.orderby(Course.published_on, order=frappe.qb.desc)
 		.limit(3)
 	)


### PR DESCRIPTION
The moderator fallback in `get_created_courses()` runs the base query without the instructor filter. Since the query joins `Course Instructor` with `LMS Course`, a course with multiple instructors returns duplicate rows. With `limit(3)`, a single course can occupy all slots in the "Created Courses" section.

Add `.distinct()` to ensure each course is returned only once.

Fixes #2476