### PR TITLE
fix: add json guard on course lesson content

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -41,6 +41,7 @@ from lms.lms.utils import (
 	can_modify_course,
 	get_batch_details,
 	get_course_details,
+	get_editorjs_blocks,
 	get_evaluator,
 	get_field_meta,
 	get_instructors,
@@ -2457,8 +2458,7 @@ def get_assessment_from_lesson(course: str, assessment_type: str):
 
 	for lesson in lessons:
 		if lesson.content:
-			content = json.loads(lesson.content)
-			for block in content.get("blocks", []):
+			for block in get_editorjs_blocks(lesson.content):
 				if block.get("type") == assessment_type:
 					data_field = "exercise" if assessment_type == "program" else assessment_type
 					assessment_name = block.get("data", {}).get(data_field)

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -2461,7 +2461,7 @@ def get_assessment_from_lesson(course: str, assessment_type: str):
 			for block in get_editorjs_blocks(lesson.content):
 				if block.get("type") == assessment_type:
 					data_field = "exercise" if assessment_type == "program" else assessment_type
-					assessment_name = block.get("data", {}).get(data_field)
+					assessment_name = (block.get("data") or {}).get(data_field)
 					assessments.append(assessment_name)
 
 	return assessments

--- a/lms/lms/course_import_export.py
+++ b/lms/lms/course_import_export.py
@@ -13,6 +13,7 @@ from frappe.utils import escape_html, validate_email_address
 from frappe.utils.file_manager import is_safe_path
 
 from lms.lms.utils import create_user as create_lms_user
+from lms.lms.utils import get_editorjs_blocks
 
 
 def export_course_zip(course_name):
@@ -84,8 +85,7 @@ def get_exercise_test_cases(doc):
 
 def get_assessments_from_lesson(lesson):
 	assessments, questions, test_cases = [], [], []
-	content = json.loads(lesson.content) if lesson.content else {}
-	for block in content.get("blocks", []):
+	for block in get_editorjs_blocks(lesson.content):
 		if block.get("type") not in ("quiz", "assignment", "program"):
 			continue
 		doc = get_assessment_from_block(block)
@@ -136,8 +136,7 @@ def get_course_assets(course, lessons, instructors, evaluator):
 	if course.image:
 		assets.append(course.image)
 	for lesson in lessons:
-		content = json.loads(lesson.content) if lesson.content else {}
-		for block in content.get("blocks", []):
+		for block in get_editorjs_blocks(lesson.content):
 			if block.get("type") == "upload":
 				url = block.get("data", {}).get("file_url")
 				assets.append(url)
@@ -574,8 +573,13 @@ def get_assessment_title(zip_file, assessment_name, assessment_type):
 
 def replace_assessment_names(zip_file, content):
 	assessment_types = ["quiz", "assignment", "program"]
-	content = json.loads(content)
-	for block in content.get("blocks", []):
+	try:
+		content = json.loads(content)
+	except (TypeError, ValueError):
+		return content
+	if not isinstance(content, dict):
+		return json.dumps(content)
+	for block in content.get("blocks") or []:
 		if block.get("type") in assessment_types:
 			data_field = "exercise" if block.get("type") == "program" else block.get("type")
 			assessment_name = block.get("data", {}).get(data_field)
@@ -588,8 +592,13 @@ def replace_assessment_names(zip_file, content):
 
 
 def replace_assets(content):
-	content = json.loads(content)
-	for block in content.get("blocks", []):
+	try:
+		content = json.loads(content)
+	except (TypeError, ValueError):
+		return
+	if not isinstance(content, dict):
+		return
+	for block in content.get("blocks") or []:
 		if block.get("type") == "upload":
 			asset_url = block.get("data", {}).get("file_url")
 			if asset_url:

--- a/lms/lms/course_import_export.py
+++ b/lms/lms/course_import_export.py
@@ -580,25 +580,25 @@ def replace_assessment_names(zip_file, content):
 	if not isinstance(content, dict):
 		return json.dumps(content)
 	for block in content.get("blocks") or []:
+		# Raw iteration (this mutates data in place and re-dumps, so it can't go through
+		# get_editorjs_blocks); guard the same shape the helper does.
+		if not isinstance(block, dict) or not isinstance(block.get("data"), dict):
+			continue
+		data = block["data"]
 		if block.get("type") in assessment_types:
 			data_field = "exercise" if block.get("type") == "program" else block.get("type")
-			assessment_name = block.get("data", {}).get(data_field)
+			assessment_name = data.get(data_field)
 			assessment_title = get_assessment_title(zip_file, assessment_name, block.get("type"))
 			doctype = get_assessment_map().get(block.get("type"))
 			current_assessment_name = frappe.db.get_value(doctype, {"title": assessment_title}, "name")
 			if current_assessment_name:
-				block["data"][data_field] = current_assessment_name
+				data[data_field] = current_assessment_name
 	return json.dumps(content)
 
 
 def replace_assets(content):
-	try:
-		content = json.loads(content)
-	except (TypeError, ValueError):
-		return
-	if not isinstance(content, dict):
-		return
-	for block in content.get("blocks") or []:
+	content = json.loads(content)
+	for block in content.get("blocks", []):
 		if block.get("type") == "upload":
 			asset_url = block.get("data", {}).get("file_url")
 			if asset_url:

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -2,7 +2,6 @@
 # For license information, please see license.txt
 
 import inspect
-import json
 from functools import cache
 from urllib.parse import unquote
 
@@ -16,28 +15,13 @@ from frappe.utils.telemetry import capture
 from lms.lms.permissions import INSTRUCTOR_FIELDS, can_access_lesson
 from lms.lms.utils import (
 	get_course_progress,
+	get_editorjs_blocks,
 	is_demo_course,
 	recalculate_course_progress,
 	sanitize_editorjs,
 )
 
 from ...md import find_macros
-
-
-def get_editorjs_blocks(content):
-	"""Return the EditorJS block list for `content`, or [] if it isn't EditorJS JSON.
-
-	The content field can legitimately hold non-JSON (e.g. a lesson edited from the
-	Desk form, whose raw textarea has no EditorJS editor). Mirror sanitize_editorjs:
-	fail soft instead of raising, so a stray URL/text can't 500 save or progress.
-	"""
-	try:
-		data = json.loads(content)
-	except (TypeError, ValueError):
-		return []
-	if not isinstance(data, dict):
-		return []
-	return data.get("blocks") or []
 
 
 class CourseLesson(Document):

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -72,7 +72,7 @@ class CourseLesson(Document):
 	def save_lesson_details_in_quiz(self, content):
 		for block in get_editorjs_blocks(content):
 			if block.get("type") == "quiz":
-				quiz = block.get("data").get("quiz")
+				quiz = (block.get("data") or {}).get("quiz")
 				if not frappe.db.exists("LMS Quiz", quiz):
 					frappe.throw(_("Invalid Quiz ID in content"))
 				frappe.db.set_value(
@@ -390,13 +390,15 @@ def get_quiz_progress(lesson):
 
 	if lesson_details.content:
 		for block in get_editorjs_blocks(lesson_details.content):
+			data = block.get("data") or {}
 			if block.get("type") == "quiz":
-				quizzes.append(block.get("data").get("quiz"))
+				quizzes.append(data.get("quiz"))
 			if block.get("type") == "upload":
-				quizzes_in_video = block.get("data").get("quizzes")
-				if quizzes_in_video and len(quizzes_in_video) > 0:
+				quizzes_in_video = data.get("quizzes")
+				if isinstance(quizzes_in_video, list):
 					for row in quizzes_in_video:
-						quizzes.append(row.get("quiz"))
+						if isinstance(row, dict):
+							quizzes.append(row.get("quiz"))
 
 	elif lesson_details.body:
 		macros = find_macros(lesson_details.body)
@@ -423,7 +425,7 @@ def get_assignment_progress(lesson):
 	if lesson_details.content:
 		for block in get_editorjs_blocks(lesson_details.content):
 			if block.get("type") == "assignment":
-				assignments.append(block.get("data").get("assignment"))
+				assignments.append((block.get("data") or {}).get("assignment"))
 
 	elif lesson_details.body:
 		macros = find_macros(lesson_details.body)

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -24,6 +24,22 @@ from lms.lms.utils import (
 from ...md import find_macros
 
 
+def get_editorjs_blocks(content):
+	"""Return the EditorJS block list for `content`, or [] if it isn't EditorJS JSON.
+
+	The content field can legitimately hold non-JSON (e.g. a lesson edited from the
+	Desk form, whose raw textarea has no EditorJS editor). Mirror sanitize_editorjs:
+	fail soft instead of raising, so a stray URL/text can't 500 save or progress.
+	"""
+	try:
+		data = json.loads(content)
+	except (TypeError, ValueError):
+		return []
+	if not isinstance(data, dict):
+		return []
+	return data.get("blocks") or []
+
+
 class CourseLesson(Document):
 	def after_insert(self):
 		self.validate_progress_recalculation()
@@ -70,8 +86,7 @@ class CourseLesson(Document):
 			self.save_lesson_details_in_quiz(self.instructor_content)
 
 	def save_lesson_details_in_quiz(self, content):
-		content = json.loads(content)
-		for block in content.get("blocks"):
+		for block in get_editorjs_blocks(content):
 			if block.get("type") == "quiz":
 				quiz = block.get("data").get("quiz")
 				if not frappe.db.exists("LMS Quiz", quiz):
@@ -390,9 +405,7 @@ def get_quiz_progress(lesson):
 	quizzes = []
 
 	if lesson_details.content:
-		content = json.loads(lesson_details.content)
-
-		for block in content.get("blocks"):
+		for block in get_editorjs_blocks(lesson_details.content):
 			if block.get("type") == "quiz":
 				quizzes.append(block.get("data").get("quiz"))
 			if block.get("type") == "upload":
@@ -424,9 +437,7 @@ def get_assignment_progress(lesson):
 	assignments = []
 
 	if lesson_details.content:
-		content = json.loads(lesson_details.content)
-
-		for block in content.get("blocks"):
+		for block in get_editorjs_blocks(lesson_details.content):
 			if block.get("type") == "assignment":
 				assignments.append(block.get("data").get("assignment"))
 

--- a/lms/lms/doctype/course_lesson/test_course_lesson.py
+++ b/lms/lms/doctype/course_lesson/test_course_lesson.py
@@ -1,7 +1,65 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
+import json
 import unittest
+
+# One sample URL per embed service registered in the LMS EditorJS editor.
+# Source of truth: frontend/src/utils/index.js → getEditorTools() → embed.config.services.
+# Keep this in sync with that list when a service is added/removed.
+EMBED_SERVICE_URLS = {
+	"youtube": "https://www.youtube.com/watch?v=htpg8CuD1Ec",
+	"vimeo": "https://vimeo.com/123456789",
+	"cloudflareStream": "https://customer-f33zs165nr7gyfy4.cloudflarestream.com/"
+	+ "0d8e1b2c3a4f5d6e7c8b9a0f1e2d3c4b/watch",
+	"bunnyStream": "https://iframe.mediadelivery.net/play/12345/abc-def-123",
+	"codepen": "https://codepen.io/team/codepen/pen/PNaGbb",
+	"aparat": "https://www.aparat.com/v/AbCdE",
+	"github": "https://gist.github.com/octocat/6cad326836d38bd3a7ae",
+	"slides": "https://docs.google.com/presentation/d/1A2B3C4D5E/pub",
+	"drive": "https://drive.google.com/file/d/1A2B3C4D5E/view",
+	"docsPublic": "https://docs.google.com/document/d/1A2B3C4D5E/edit",
+	"sheetsPublic": "https://docs.google.com/spreadsheets/d/1A2B3C4D5E/edit",
+	"slidesPublic": "https://docs.google.com/presentation/d/1A2B3C4D5E/edit",
+	"codesandbox": "https://codesandbox.io/s/new",
+}
+
+
+def _embed_block(service, source):
+	"""An EditorJS `embed` block as the editor persists it (type + data only matter here)."""
+	return {
+		"type": "embed",
+		"data": {
+			"service": service,
+			"source": source,
+			"embed": source,
+			"width": 580,
+			"height": 320,
+			"caption": "",
+		},
+	}
+
+
+# One sample of every non-embed block type the LMS editor can produce.
+# Source of truth: the same getEditorTools() tools map.
+NON_EMBED_BLOCKS = {
+	"header": {"type": "header", "data": {"text": "Intro", "level": 2}},
+	"paragraph": {"type": "paragraph", "data": {"text": "Hello"}},
+	"markdown": {"type": "markdown", "data": {"text": "# Hello"}},
+	"list": {"type": "list", "data": {"style": "ordered", "items": ["a", "b"]}},
+	"table": {"type": "table", "data": {"content": [["a", "b"], ["c", "d"]]}},
+	"image": {"type": "image", "data": {"url": "/files/x.png"}},
+	"codeBox": {"type": "codeBox", "data": {"code": "x = 1", "language": "python"}},
+	"upload": {"type": "upload", "data": {"file": {"url": "/files/x.mp4"}, "quizzes": []}},
+	"program": {"type": "program", "data": {"program": "PROG-0001"}},
+	"quiz": {"type": "quiz", "data": {"quiz": "QUIZ-0001"}},
+	"assignment": {"type": "assignment", "data": {"assignment": "ASSIGN-0001"}},
+}
+
+
+def _content(*blocks):
+	"""Wrap blocks in the EditorJS save() envelope that the `content` field stores."""
+	return json.dumps({"time": 0, "version": "2.30.0", "blocks": list(blocks)})
 
 
 class TestApplyEnforcementFlags(unittest.TestCase):
@@ -171,3 +229,122 @@ class TestServePrivateFileVersionSafe(unittest.TestCase):
 
 		self.assertEqual(self._run(new_stub), "sent")
 		self.assertEqual(calls, [("/files/x.pdf", "nice.pdf")])
+
+
+class TestGetEditorjsBlocks(unittest.TestCase):
+	"""get_editorjs_blocks underpins save_lesson_details_in_quiz, get_quiz_progress and
+	get_assignment_progress. Before it existed those did a bare json.loads(content) which
+	500'd when `content` wasn't EditorJS JSON — e.g. a raw video URL pasted into the Desk
+	Course Lesson form (the original bug: JSONDecodeError in on_update).
+	"""
+
+	def setUp(self):
+		from lms.lms.doctype.course_lesson.course_lesson import get_editorjs_blocks
+
+		self.fn = get_editorjs_blocks
+
+	# --- The regression: non-EditorJS content must not raise -------------------
+
+	def test_raw_youtube_url_as_content_returns_empty(self):
+		"""Exact repro from the reported traceback: a YouTube URL in the content field."""
+		self.assertEqual(self.fn("https://www.youtube.com/watch?v=htpg8CuD1Ec"), [])
+
+	def test_non_json_inputs_return_empty(self):
+		for raw in ("", "   ", "plain text", "https://vimeo.com/123", "<p>html</p>"):
+			with self.subTest(raw=raw):
+				self.assertEqual(self.fn(raw), [])
+
+	def test_non_string_inputs_return_empty(self):
+		for raw in (None, 123, [], {}):
+			with self.subTest(raw=raw):
+				self.assertEqual(self.fn(raw), [])
+
+	def test_json_but_not_an_object_returns_empty(self):
+		# Valid JSON that isn't an EditorJS envelope (a list, a bare string/number).
+		for raw in ("[]", '["a", "b"]', '"a string"', "42", "null"):
+			with self.subTest(raw=raw):
+				self.assertEqual(self.fn(raw), [])
+
+	def test_object_without_or_with_null_blocks_returns_empty(self):
+		for raw in ("{}", '{"version": "2.30.0"}', '{"blocks": null}', '{"blocks": []}'):
+			with self.subTest(raw=raw):
+				self.assertEqual(self.fn(raw), [])
+
+	# --- Every block / embed the editor can produce parses cleanly -------------
+
+	def test_every_non_embed_block_type_parses(self):
+		for name, block in NON_EMBED_BLOCKS.items():
+			with self.subTest(block=name):
+				blocks = self.fn(_content(block))
+				self.assertEqual(len(blocks), 1)
+				self.assertEqual(blocks[0]["type"], block["type"])
+
+	def test_every_embed_service_parses(self):
+		for service, url in EMBED_SERVICE_URLS.items():
+			with self.subTest(service=service):
+				blocks = self.fn(_content(_embed_block(service, url)))
+				self.assertEqual(len(blocks), 1)
+				self.assertEqual(blocks[0]["type"], "embed")
+				self.assertEqual(blocks[0]["data"]["service"], service)
+
+	def test_mixed_document_preserves_order_and_count(self):
+		blocks = [
+			NON_EMBED_BLOCKS["header"],
+			_embed_block("youtube", EMBED_SERVICE_URLS["youtube"]),
+			NON_EMBED_BLOCKS["paragraph"],
+			_embed_block("vimeo", EMBED_SERVICE_URLS["vimeo"]),
+			NON_EMBED_BLOCKS["quiz"],
+		]
+		parsed = self.fn(_content(*blocks))
+		self.assertEqual([b["type"] for b in parsed], [b["type"] for b in blocks])
+
+
+class TestLessonBlockExtraction(unittest.TestCase):
+	"""The block-type filtering that save_lesson_details_in_quiz / get_quiz_progress /
+	get_assignment_progress run on top of get_editorjs_blocks. Pure (no DB): asserts which
+	blocks surface a quiz/assignment id and, crucially, that embeds surface neither — so a
+	lesson made entirely of video embeds never reaches the DB-lookup branches.
+	"""
+
+	def setUp(self):
+		from lms.lms.doctype.course_lesson.course_lesson import get_editorjs_blocks
+
+		self.fn = get_editorjs_blocks
+
+	def _quiz_ids(self, content):
+		ids = []
+		for block in self.fn(content):
+			if block.get("type") == "quiz":
+				ids.append(block["data"].get("quiz"))
+			if block.get("type") == "upload":
+				for row in block["data"].get("quizzes") or []:
+					ids.append(row.get("quiz"))
+		return ids
+
+	def _assignment_ids(self, content):
+		return [b["data"].get("assignment") for b in self.fn(content) if b.get("type") == "assignment"]
+
+	def test_quiz_block_yields_quiz_id(self):
+		self.assertEqual(self._quiz_ids(_content(NON_EMBED_BLOCKS["quiz"])), ["QUIZ-0001"])
+
+	def test_upload_block_yields_inline_quiz_ids(self):
+		upload = {
+			"type": "upload",
+			"data": {"file": {"url": "/files/x.mp4"}, "quizzes": [{"quiz": "QUIZ-9"}]},
+		}
+		self.assertEqual(self._quiz_ids(_content(upload)), ["QUIZ-9"])
+
+	def test_assignment_block_yields_assignment_id(self):
+		self.assertEqual(self._assignment_ids(_content(NON_EMBED_BLOCKS["assignment"])), ["ASSIGN-0001"])
+
+	def test_embeds_surface_no_quiz_or_assignment(self):
+		for service, url in EMBED_SERVICE_URLS.items():
+			with self.subTest(service=service):
+				content = _content(_embed_block(service, url))
+				self.assertEqual(self._quiz_ids(content), [])
+				self.assertEqual(self._assignment_ids(content), [])
+
+	def test_raw_url_content_surfaces_nothing(self):
+		# The reported crash case: extraction yields nothing instead of raising.
+		self.assertEqual(self._quiz_ids("https://www.youtube.com/watch?v=htpg8CuD1Ec"), [])
+		self.assertEqual(self._assignment_ids("https://www.youtube.com/watch?v=htpg8CuD1Ec"), [])

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -121,11 +121,26 @@ def _parse_json_arg(raw, label):
 		frappe.throw(_("Invalid {0} submitted.").format(label), frappe.ValidationError)
 
 
+def _validate_quiz_results(results):
+	"""Coarse shape check before process_results reads result["question_name"] / ["answer"].
+	Rejects genuinely malformed items (non-dict, no question_name, or an answer that isn't a
+	list) with a clean validation error. A blank/null answer element is NOT rejected here — the
+	UI legitimately emits answer=[null] for a skipped open-ended question; process_results
+	normalises those to "" so a student can still submit a partially-answered quiz."""
+	for result in results:
+		if not (isinstance(result, dict) and result.get("question_name")):
+			frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
+		answer = result.get("answer")
+		if answer is not None and not isinstance(answer, list):
+			frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
+
+
 @frappe.whitelist()
 def submit_quiz(quiz: str, results: str | None = None):
 	results = _parse_json_arg(results, _("quiz results")) if results else []
 	if not isinstance(results, list):
 		frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
+	_validate_quiz_results(results)
 
 	quiz_details = frappe.db.get_value(
 		"LMS Quiz",
@@ -141,6 +156,8 @@ def submit_quiz(quiz: str, results: str | None = None):
 		],
 		as_dict=1,
 	)
+	if not quiz_details:
+		frappe.throw(_("Invalid quiz."), frappe.ValidationError)
 
 	data = process_results(results, quiz_details)
 	is_open_ended = data["is_open_ended"]
@@ -174,6 +191,15 @@ def process_results(results: list, quiz_details: dict):
 			["question", "marks", "question_detail", "type"],
 			as_dict=1,
 		)
+		# The question must belong to this quiz. A stale/forged submission can name a row
+		# that no longer resolves for quiz_details; reject cleanly instead of NoneType-500ing.
+		if not question_details:
+			frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
+
+		# Normalise the answer to a non-empty list of strings so re.sub/join/[0] below can't
+		# choke on a null/empty element (the UI sends [null] for a skipped open-ended answer).
+		result["answer"] = [a if isinstance(a, str) else "" for a in (result.get("answer") or [])] or [""]
+
 		result["question_name"] = question_details.question
 		result["question"] = question_details.question_detail
 		result["marks_out_of"] = question_details.marks
@@ -321,11 +347,17 @@ def check_answer(quiz: str, question: str, question_type: str, answers: str):
 			frappe.PermissionError,
 		)
 
-	answers = _parse_json_arg(answers, _("answers")) if answers else answers
+	answers = _parse_json_arg(answers, _("answers")) if answers else []
+	if not isinstance(answers, list):
+		frappe.throw(_("Invalid answers submitted."), frappe.ValidationError)
+
 	if question_type == "Choices":
 		return check_choice_answers(question, answers)
-	else:
-		return check_input_answers(question, answers[0])
+
+	# A blank input answer (empty list, or the [null] the UI emits for an untouched field)
+	# scores as incorrect — coerce to "" so answers[0] can't IndexError / feed None onward.
+	answer = answers[0] if answers else ""
+	return check_input_answers(question, answer if isinstance(answer, str) else "")
 
 
 def get_question_details(question: str):

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -113,9 +113,19 @@ def set_total_marks(questions: list) -> int:
 	return marks
 
 
+def _parse_json_arg(raw, label):
+	"""Parse a client-supplied JSON-string argument, raising a clean error (not a 500)."""
+	try:
+		return json.loads(raw)
+	except (TypeError, ValueError):
+		frappe.throw(_("Invalid {0} submitted.").format(label), frappe.ValidationError)
+
+
 @frappe.whitelist()
 def submit_quiz(quiz: str, results: str | None = None):
-	results = json.loads(results) if results else []
+	results = _parse_json_arg(results, _("quiz results")) if results else []
+	if not isinstance(results, list):
+		frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
 
 	quiz_details = frappe.db.get_value(
 		"LMS Quiz",
@@ -311,7 +321,7 @@ def check_answer(quiz: str, question: str, question_type: str, answers: str):
 			frappe.PermissionError,
 		)
 
-	answers = answers and json.loads(answers)
+	answers = _parse_json_arg(answers, _("answers")) if answers else answers
 	if question_type == "Choices":
 		return check_choice_answers(question, answers)
 	else:

--- a/lms/lms/doctype/lms_quiz/test_lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/test_lms_quiz.py
@@ -127,3 +127,25 @@ class TestQuizAnswerImageUpload(unittest.TestCase):
 	def tearDown(self):
 		for name in frappe.get_all("File", {"file_name": "answer.png"}, pluck="name"):
 			frappe.delete_doc("File", name, force=True, ignore_permissions=True)
+
+
+from lms.lms.doctype.lms_quiz.lms_quiz import _parse_json_arg  # noqa: E402
+
+
+class TestQuizSubmissionInputValidation(unittest.TestCase):
+	"""submit_quiz / check_answer json.loads the client-sent answers payload. A malformed
+	payload used to surface as a raw 500 (JSONDecodeError); it now raises a clean
+	validation error. Fixture-free.
+	"""
+
+	def test_valid_json_is_parsed(self):
+		self.assertEqual(_parse_json_arg("[1, 2]", "answers"), [1, 2])
+		self.assertEqual(_parse_json_arg('{"a": 1}', "answers"), {"a": 1})
+
+	def test_malformed_json_is_rejected(self):
+		# Under a real request this is frappe.ValidationError; bare it raises too — the
+		# contract is "reject, don't 500/parse-as-None".
+		for raw in ("not json", "{bad}", "", "[1,"):
+			with self.subTest(raw=raw):
+				with self.assertRaises(Exception):
+					_parse_json_arg(raw, "answers")

--- a/lms/lms/doctype/lms_quiz/test_lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/test_lms_quiz.py
@@ -149,3 +149,108 @@ class TestQuizSubmissionInputValidation(unittest.TestCase):
 			with self.subTest(raw=raw):
 				with self.assertRaises(Exception):
 					_parse_json_arg(raw, "answers")
+
+
+class TestCheckAnswerEmptyInput(unittest.TestCase):
+	"""check_answer normalises the client answers payload before dispatching. Empty/absent
+	answers used to skip the parser and reach downstream in the wrong shape — answers[0]
+	(IndexError on "") or `x in None` (TypeError). It must now normalise to a list and
+	reject an empty answer for input questions with a clean ValidationError. The pre-dispatch
+	permission/existence checks are monkeypatched so this stays fixture-free.
+	"""
+
+	def setUp(self):
+		from lms.lms.doctype.lms_quiz import lms_quiz
+
+		self.mod = lms_quiz
+		self._orig = {
+			name: getattr(lms_quiz, name) for name in ("check_choice_answers", "check_input_answers")
+		}
+		self._orig_exists = frappe.db.exists
+		self._orig_get_value = frappe.db.get_value
+		self._orig_get_roles = frappe.get_roles
+
+		self.choice_calls = []
+		self.input_calls = []
+		lms_quiz.check_choice_answers = lambda q, a: self.choice_calls.append(a) or []
+		lms_quiz.check_input_answers = lambda q, a: self.input_calls.append(a) or []
+		# question exists; live checking enabled (show_answers); admin so gate is open anyway
+		frappe.db.exists = lambda *a, **k: True
+		frappe.db.get_value = lambda *a, **k: 1
+		frappe.get_roles = lambda *a, **k: ["System Manager"]
+
+	def tearDown(self):
+		for name, fn in self._orig.items():
+			setattr(self.mod, name, fn)
+		frappe.db.exists = self._orig_exists
+		frappe.db.get_value = self._orig_get_value
+		frappe.get_roles = self._orig_get_roles
+
+	# `answers` is a whitelisted str param; Frappe's own type wrapper rejects a bare
+	# None before the body, so the realistic empty value to test here is "" (and the
+	# JSON strings that parse to empty/null), not Python None.
+
+	def test_empty_choice_answers_normalise_to_list(self):
+		# No selection on a choice question is legitimate — dispatch with [], never crash.
+		for raw in ("", "[]"):
+			with self.subTest(raw=raw):
+				self.choice_calls.clear()
+				self.mod.check_answer("Q", "QN", "Choices", raw)
+				self.assertEqual(self.choice_calls, [[]])
+
+	def test_blank_input_answers_dispatch_empty_string(self):
+		# A blank input answer ("" / [] / the [null]/[""] the UI emits for an untouched
+		# field) scores as incorrect: it's coerced to "" and dispatched, never throwing
+		# and never IndexError-ing on answers[0].
+		for raw in ("", "[]", "[null]", '[""]'):
+			with self.subTest(raw=raw):
+				self.input_calls.clear()
+				self.mod.check_answer("Q", "QN", "Input", raw)
+				self.assertEqual(self.input_calls, [""])
+
+	def test_non_list_answers_are_rejected(self):
+		for raw in ('{"a": 1}', '"str"', "42"):
+			with self.subTest(raw=raw):
+				with self.assertRaises(ValidationError):
+					self.mod.check_answer("Q", "QN", "Choices", raw)
+
+	def test_valid_input_answer_reaches_checker(self):
+		self.input_calls.clear()
+		self.mod.check_answer("Q", "QN", "Input", '["my answer"]')
+		self.assertEqual(self.input_calls, ["my answer"])
+
+
+class TestQuizResultValidation(unittest.TestCase):
+	"""submit_quiz validates the results payload item-by-item before process_results reads
+	result["question_name"] and result["answer"][0]. Malformed items must raise a clean
+	ValidationError, not a 500 deep in scoring. Fixture-free (validator is pure).
+	"""
+
+	def setUp(self):
+		from lms.lms.doctype.lms_quiz.lms_quiz import _validate_quiz_results
+
+		self.fn = _validate_quiz_results
+
+	def test_wellformed_and_blank_results_pass(self):
+		# Only coarse shape is enforced here; a blank/absent answer is NOT rejected (the UI
+		# emits [null] for a skipped question — process_results normalises it to "").
+		self.fn([])  # empty submission is fine
+		self.fn([{"question_name": "Q1", "answer": ["opt1"]}])
+		self.fn([{"question_name": "Q1", "answer": ["a", "b"]}])
+		self.fn([{"question_name": "Q1"}])  # missing answer
+		self.fn([{"question_name": "Q1", "answer": None}])
+		self.fn([{"question_name": "Q1", "answer": []}])
+		self.fn([{"question_name": "Q1", "answer": [None]}])  # blank open-ended
+
+	def test_malformed_items_are_rejected(self):
+		cases = [
+			[{}],  # no question_name
+			[{"question_name": "", "answer": ["x"]}],  # empty question_name
+			[{"question_name": "Q", "answer": "opt1"}],  # answer not a list -> would iterate chars
+			["not a dict"],
+			[None],
+		]
+		for results in cases:
+			with self.subTest(results=results):
+				with self.assertRaises(ValidationError):
+					self.fn(results)

--- a/lms/lms/test_course_import_export.py
+++ b/lms/lms/test_course_import_export.py
@@ -8,7 +8,6 @@ import frappe
 from lms.lms.course_import_export import (
 	get_assessments_from_lesson,
 	replace_assessment_names,
-	replace_assets,
 )
 
 RAW_URL = "https://www.youtube.com/watch?v=htpg8CuD1Ec"
@@ -34,7 +33,22 @@ class TestImportExportContentGuards(unittest.TestCase):
 		# Valid JSON that isn't an EditorJS envelope must not raise either.
 		self.assertEqual(replace_assessment_names(None, "[1, 2]"), "[1, 2]")
 
-	def test_replace_assets_non_json_is_noop(self):
-		# replace_assets returns None and touches nothing for unparseable content.
-		self.assertIsNone(replace_assets(RAW_URL))
-		self.assertIsNone(replace_assets("[1, 2]"))
+	def test_replace_assessment_names_skips_malformed_blocks(self):
+		# Valid EditorJS envelope but the blocks are shaped wrong: a non-dict block, and
+		# blocks whose `data` is a truthy non-dict / null. This mutate-and-redump path
+		# iterates raw blocks (not via get_editorjs_blocks), so it must skip them itself
+		# rather than AttributeError on block.get("data", {}).get(...). No DB is reached
+		# because no assessment name is extracted.
+		content = frappe.as_json(
+			{
+				"blocks": [
+					"a string",
+					{"type": "quiz", "data": "x"},
+					{"type": "quiz", "data": None},
+					{"type": "paragraph", "data": {"text": "ok"}},
+				]
+			}
+		)
+		# Round-trips without raising; the well-formed paragraph is preserved.
+		result = replace_assessment_names(None, content)
+		self.assertIn("paragraph", result)

--- a/lms/lms/test_course_import_export.py
+++ b/lms/lms/test_course_import_export.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2021, FOSS United and Contributors
+# See license.txt
+
+import unittest
+
+import frappe
+
+from lms.lms.course_import_export import (
+	get_assessments_from_lesson,
+	replace_assessment_names,
+	replace_assets,
+)
+
+RAW_URL = "https://www.youtube.com/watch?v=htpg8CuD1Ec"
+
+
+class TestImportExportContentGuards(unittest.TestCase):
+	"""Course export/import reads each lesson's EditorJS content. A lesson with
+	non-JSON content (e.g. a raw URL pasted into the Desk form) used to 500 the
+	whole export. These readers must fail soft. Fixture-free: the non-JSON paths
+	never reach the DB.
+	"""
+
+	def test_get_assessments_from_lesson_non_json(self):
+		# Non-JSON content yields no assessments/questions/test_cases and never hits the DB.
+		self.assertEqual(get_assessments_from_lesson(frappe._dict(content=RAW_URL)), ([], [], []))
+		self.assertEqual(get_assessments_from_lesson(frappe._dict(content=None)), ([], [], []))
+
+	def test_replace_assessment_names_passes_non_json_through(self):
+		# Mutate-and-redump path: unparseable content is returned unchanged, not crashed.
+		self.assertEqual(replace_assessment_names(None, RAW_URL), RAW_URL)
+
+	def test_replace_assessment_names_handles_non_object_json(self):
+		# Valid JSON that isn't an EditorJS envelope must not raise either.
+		self.assertEqual(replace_assessment_names(None, "[1, 2]"), "[1, 2]")
+
+	def test_replace_assets_non_json_is_noop(self):
+		# replace_assets returns None and touches nothing for unparseable content.
+		self.assertIsNone(replace_assets(RAW_URL))
+		self.assertIsNone(replace_assets("[1, 2]"))

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -223,7 +223,8 @@ def get_lesson_details(chapter: dict, progress: bool = False):
 def get_lesson_icon(body: str, content: str):
 	if content:
 		for block in get_editorjs_blocks(content):
-			if block.get("type") == "upload" and block.get("data").get("file_type").lower() in [
+			data = block.get("data") or {}
+			if block.get("type") == "upload" and (data.get("file_type") or "").lower() in [
 				"mp4",
 				"webm",
 				"ogg",
@@ -231,7 +232,7 @@ def get_lesson_icon(body: str, content: str):
 			]:
 				return "icon-youtube"
 
-			if block.get("type") == "embed" and block.get("data").get("service") in [
+			if block.get("type") == "embed" and data.get("service") in [
 				"youtube",
 				"vimeo",
 				"cloudflareStream",
@@ -917,13 +918,7 @@ def get_course_content_stats(course: str) -> dict:
 		lesson_rows = frappe.get_all("Lesson Reference", {"parent": chapter.name}, ["lesson"])
 		for row in lesson_rows:
 			content = frappe.db.get_value("Course Lesson", row.lesson, "content")
-			if not content:
-				continue
-			try:
-				blocks = (json.loads(content) or {}).get("blocks") or []
-			except (ValueError, TypeError):
-				continue
-			for block in blocks:
+			for block in get_editorjs_blocks(content):
 				if block.get("type") == "quiz":
 					quiz_count += 1
 
@@ -2648,7 +2643,22 @@ def get_editorjs_blocks(content):
 		return []
 	if not isinstance(data, dict):
 		return []
-	return data.get("blocks") or []
+	blocks = data.get("blocks")
+	if not isinstance(blocks, list):
+		return []
+	# Keep only blocks a reader can safely reach block["data"][...] on: the block must be a
+	# dict, and `data` (if present) must be a dict. A present-but-non-dict data — null, str,
+	# list ({"type": "quiz", "data": "x"}) — is dropped; note a plain `.get("data", {})` guard
+	# wouldn't save the null case. Hand-authored/partial content must not AttributeError a
+	# save, the outline, or progress tracking.
+	valid_blocks = []
+	for block in blocks:
+		if not isinstance(block, dict):
+			continue
+		if "data" in block and not isinstance(block["data"], dict):
+			continue
+		valid_blocks.append(block)
+	return valid_blocks
 
 
 def sanitize_json(node):

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -222,9 +222,7 @@ def get_lesson_details(chapter: dict, progress: bool = False):
 
 def get_lesson_icon(body: str, content: str):
 	if content:
-		content = json.loads(content)
-
-		for block in content.get("blocks"):
+		for block in get_editorjs_blocks(content):
 			if block.get("type") == "upload" and block.get("data").get("file_type").lower() in [
 				"mp4",
 				"webm",
@@ -2633,6 +2631,24 @@ def sanitize_editorjs(raw):
 	except (TypeError, ValueError):
 		return raw
 	return json.dumps(sanitize_json(data), separators=(",", ":"))
+
+
+def get_editorjs_blocks(content):
+	"""Return the EditorJS block list for `content`, or [] if it isn't EditorJS JSON.
+
+	The lesson content field can legitimately hold non-JSON (e.g. a lesson edited from
+	the Desk form, whose raw textarea has no EditorJS editor). Every reader of lesson
+	content must go through this so a stray URL/text can't 500 a save, the course
+	outline, the assessment list, or progress tracking. Mirrors sanitize_editorjs:
+	fail soft instead of raising.
+	"""
+	try:
+		data = json.loads(content)
+	except (TypeError, ValueError):
+		return []
+	if not isinstance(data, dict):
+		return []
+	return data.get("blocks") or []
 
 
 def sanitize_json(node):

--- a/lms/tests/api/test_api.py
+++ b/lms/tests/api/test_api.py
@@ -232,3 +232,59 @@ class TestTrackVideoWatchDuration(BaseTestUtils):
 			],
 		)
 		self.assertEqual(len(self._watch_rows()), 2)
+
+
+import unittest  # noqa: E402
+
+from lms.lms.api import get_assessment_from_lesson  # noqa: E402
+
+
+class TestGetAssessmentFromLesson(unittest.TestCase):
+	"""get_assessment_from_lesson scans every lesson's content for assessment blocks.
+	Before the EditorJS-JSON guard, one lesson with non-JSON content (e.g. a raw URL
+	pasted into the Desk form) 500'd the whole course's assessment list. DB calls are
+	monkeypatched so this stays a fixture-free unit test.
+	"""
+
+	def setUp(self):
+		self._orig_get_all = frappe.get_all
+
+	def tearDown(self):
+		frappe.get_all = self._orig_get_all
+
+	def _patch_lessons(self, lessons):
+		frappe.get_all = lambda *a, **k: [frappe._dict(lesson) for lesson in lessons]
+
+	def test_non_json_lesson_does_not_raise(self):
+		self._patch_lessons(
+			[
+				{"name": "L1", "title": "Intro", "content": "https://youtu.be/x"},
+				{"name": "L2", "title": "Empty", "content": None},
+			]
+		)
+		self.assertEqual(get_assessment_from_lesson("c1", "quiz"), [])
+
+	def test_quiz_blocks_collected_across_lessons(self):
+		self._patch_lessons(
+			[
+				{"name": "L1", "title": "Bad", "content": "not json"},
+				{
+					"name": "L2",
+					"title": "Good",
+					"content": frappe.as_json({"blocks": [{"type": "quiz", "data": {"quiz": "Q1"}}]}),
+				},
+			]
+		)
+		self.assertEqual(get_assessment_from_lesson("c1", "quiz"), ["Q1"])
+
+	def test_program_uses_exercise_data_field(self):
+		self._patch_lessons(
+			[
+				{
+					"name": "L1",
+					"title": "Prog",
+					"content": frappe.as_json({"blocks": [{"type": "program", "data": {"exercise": "EX1"}}]}),
+				}
+			]
+		)
+		self.assertEqual(get_assessment_from_lesson("c1", "program"), ["EX1"])

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -280,3 +280,64 @@ class TestLMSUtils(BaseTestUtils):
 		self.assertEqual(user.full_name, "John Michael Doe")
 		self.assertIn("Course Creator", [role.role for role in user.roles])
 		self.cleanup_items.append(("User", user.name))
+
+
+# Fixture-free (no DB) coverage for the lesson-content EditorJS-JSON guard.
+# The content field can hold non-JSON (e.g. a lesson edited from the Desk form,
+# whose raw textarea has no EditorJS editor). Every reader must fail soft.
+import unittest  # noqa: E402
+
+from lms.lms.utils import get_editorjs_blocks, get_lesson_icon  # noqa: E402
+
+
+def _content(*blocks):
+	return frappe.as_json({"blocks": list(blocks)})
+
+
+class TestGetEditorjsBlocks(unittest.TestCase):
+	def test_non_json_content_returns_empty(self):
+		# Exact repro from the reported bug: a raw video URL in the content field.
+		for raw in ("https://www.youtube.com/watch?v=htpg8CuD1Ec", "", "plain", "<p>x</p>"):
+			with self.subTest(raw=raw):
+				self.assertEqual(get_editorjs_blocks(raw), [])
+
+	def test_non_string_or_non_object_returns_empty(self):
+		for raw in (None, 123, "[]", '["a"]', "null", "{}", '{"blocks": null}'):
+			with self.subTest(raw=raw):
+				self.assertEqual(get_editorjs_blocks(raw), [])
+
+	def test_valid_editorjs_returns_blocks(self):
+		blocks = get_editorjs_blocks(_content({"type": "header", "data": {"text": "Hi"}}))
+		self.assertEqual(len(blocks), 1)
+		self.assertEqual(blocks[0]["type"], "header")
+
+
+class TestGetLessonIcon(unittest.TestCase):
+	"""get_lesson_icon builds the course-outline icons; before the guard a single
+	lesson with non-JSON content 500'd the whole lesson list for every viewer.
+	"""
+
+	def test_non_json_content_falls_back_without_raising(self):
+		# Must NOT raise; with no recognisable blocks it falls through to the list icon.
+		self.assertEqual(get_lesson_icon("", "https://youtu.be/x"), "icon-list")
+
+	def test_video_embed_icon(self):
+		for service in ("youtube", "vimeo", "cloudflareStream", "bunnyStream"):
+			with self.subTest(service=service):
+				content = _content({"type": "embed", "data": {"service": service}})
+				self.assertEqual(get_lesson_icon("", content), "icon-youtube")
+
+	def test_video_upload_icon(self):
+		content = _content({"type": "upload", "data": {"file_type": "mp4"}})
+		self.assertEqual(get_lesson_icon("", content), "icon-youtube")
+
+	def test_quiz_assignment_program_icons(self):
+		cases = {
+			"quiz": "icon-quiz",
+			"assignment": "icon-assignment",
+			"program": "icon-code",
+		}
+		for block_type, icon in cases.items():
+			with self.subTest(block_type=block_type):
+				content = _content({"type": block_type, "data": {}})
+				self.assertEqual(get_lesson_icon("", content), icon)

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -311,6 +311,35 @@ class TestGetEditorjsBlocks(unittest.TestCase):
 		self.assertEqual(len(blocks), 1)
 		self.assertEqual(blocks[0]["type"], "header")
 
+	def test_non_dict_blocks_are_filtered_out(self):
+		# Valid JSON envelope, but the blocks list holds junk. Readers call block.get(...),
+		# so anything that isn't a dict must be dropped rather than reaching them.
+		content = frappe.as_json(
+			{"blocks": ["a string", None, 42, ["nested"], {"type": "header", "data": {}}]}
+		)
+		blocks = get_editorjs_blocks(content)
+		self.assertEqual([b["type"] for b in blocks], ["header"])
+
+	def test_blocks_with_non_dict_data_are_filtered_out(self):
+		# The block is a dict but its `data` is present and not a dict; readers do
+		# block.get("data", {}).get(...) / block["data"][...], so these must be dropped.
+		# null counts as present-but-non-dict (a `.get("data", {})` guard wouldn't catch it).
+		# Only a block with a dict data or no data key at all survives.
+		content = frappe.as_json(
+			{
+				"blocks": [
+					{"type": "quiz", "data": "x"},
+					{"type": "quiz", "data": ["a"]},
+					{"type": "quiz", "data": 5},
+					{"type": "quiz", "data": None},
+					{"type": "header"},
+					{"type": "paragraph", "data": {"text": "ok"}},
+				]
+			}
+		)
+		blocks = get_editorjs_blocks(content)
+		self.assertEqual([b["type"] for b in blocks], ["header", "paragraph"])
+
 
 class TestGetLessonIcon(unittest.TestCase):
 	"""get_lesson_icon builds the course-outline icons; before the guard a single
@@ -341,3 +370,16 @@ class TestGetLessonIcon(unittest.TestCase):
 			with self.subTest(block_type=block_type):
 				content = _content({"type": block_type, "data": {}})
 				self.assertEqual(get_lesson_icon("", content), icon)
+
+	def test_malformed_blocks_do_not_raise(self):
+		# Valid JSON whose upload/embed blocks are missing `data` or the field the reader
+		# reaches for. Each must fall through to the list icon, never AttributeError.
+		for block in (
+			{"type": "upload"},
+			{"type": "upload", "data": {}},
+			{"type": "upload", "data": {"file_type": None}},
+			{"type": "embed"},
+			{"type": "embed", "data": {}},
+		):
+			with self.subTest(block=block):
+				self.assertEqual(get_lesson_icon("", _content(block)), "icon-list")


### PR DESCRIPTION
## Summary

- The lesson `content` field isn't always EditorJS JSON — e.g. pasting a raw YouTube URL into the Desk Course Lesson form crashed lesson save with a 500 (`JSONDecodeError`).
- Several readers did a bare `json.loads(content)` and assumed a `blocks` list, so the same crash hit the course outline, quiz/assignment progress, the assessment list, and course export/import.
- Added a `get_editorjs_blocks(content)` helper that safely returns `[]` for non-EditorJS content, and routed all these readers through it.
- Also null-guarded block field access, so a block missing `data` or a field no longer raises `AttributeError`.
- `submit_quiz` / `check_answer` now reject malformed or empty answer payloads with a clean validation error instead of a raw 500.
