### PR TITLE
feat(search): opt-in RediSearch backend for search

### DIFF
--- a/lms/command_palette.py
+++ b/lms/command_palette.py
@@ -4,9 +4,17 @@ from frappe.utils import nowdate
 
 @frappe.whitelist()
 def search_sqlite(query: str):
-	from lms.sqlite import LearningSearch, LearningSearchIndexMissingError
+	# Method name kept for frontend compatibility; the backend is selectable.
+	from lms.sqlite import LearningSearchIndexMissingError
 
-	search = LearningSearch()
+	if frappe.db.get_single_value("LMS Settings", "search_backend") == "RediSearch":
+		from lms.redisearch import LearningRediSearch
+
+		search = LearningRediSearch()
+	else:
+		from lms.sqlite import LearningSearch
+
+		search = LearningSearch()
 
 	try:
 		result = search.search(query)

--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -76,7 +76,10 @@ after_sync = "lms.install.after_sync"
 before_uninstall = "lms.install.before_uninstall"
 setup_wizard_complete = "lms.demo.demo_data.create_demo_data"
 after_migrate = [
-	"lms.sqlite.build_index_in_background",
+	# The SQLite index is (re)built by frappe core's global orchestration
+	# (get_search_classes); we no longer enqueue it here to avoid a double build.
+	# This entry only (re)builds the RediSearch index when that backend is on.
+	"lms.redisearch.build_index_in_background",
 ]
 
 # Desk Notifications
@@ -129,13 +132,30 @@ doc_events = {
 		"validate": "lms.lms.user.validate_username_duplicates",
 		"before_insert": "lms.lms.user.add_lms_student_role",
 	},
+	# RediSearch index (inert unless LMS Settings.search_backend = RediSearch)
+	"LMS Course": {
+		"on_update": "lms.redisearch.update_index",
+		"on_trash": "lms.redisearch.delete_index",
+	},
+	"LMS Batch": {
+		"on_update": "lms.redisearch.update_index",
+		"on_trash": "lms.redisearch.delete_index",
+	},
+	"Job Opportunity": {
+		"on_update": "lms.redisearch.update_index",
+		"on_trash": "lms.redisearch.delete_index",
+	},
+	"Course Instructor": {
+		"on_update": "lms.redisearch.update_index",
+		"on_trash": "lms.redisearch.delete_index",
+	},
 }
 
 # Scheduled Tasks
 # ---------------
 scheduler_events = {
 	"all": [
-		"lms.sqlite.build_index_in_background",
+		"lms.redisearch.build_index_if_enabled",
 	],
 	"hourly": [
 		"lms.lms.doctype.lms_certificate_request.lms_certificate_request.schedule_evals",

--- a/lms/lms/doctype/lms_settings/lms_settings.json
+++ b/lms/lms/doctype/lms_settings/lms_settings.json
@@ -6,6 +6,7 @@
 	"engine": "InnoDB",
 	"field_order": [
 		"general_tab",
+		"search_backend",
 		"allow_guest_access",
 		"prevent_skipping_videos",
 		"send_calendar_invite_for_evaluations",
@@ -355,6 +356,14 @@
 			"fieldname": "general_tab",
 			"fieldtype": "Tab Break",
 			"label": "General"
+		},
+		{
+			"default": "SQLite",
+			"description": "Storage backend for search. RediSearch requires the RediSearch module loaded in the cache Redis; use it for high-availability / NFS deployments where the SQLite FTS index cannot run.",
+			"fieldname": "search_backend",
+			"fieldtype": "Select",
+			"label": "Search Backend",
+			"options": "SQLite\nRediSearch"
 		},
 		{
 			"default": "1",

--- a/lms/redisearch.py
+++ b/lms/redisearch.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+"""RediSearch backend for LMS search.
+
+A drop-in alternative to :class:`lms.sqlite.LearningSearch` for deployments
+where the SQLite FTS index cannot run — notably high-availability topologies
+with ``sites/`` on a network filesystem, where SQLite's WAL mode requires shared
+memory between all processes on one host and therefore breaks
+(https://www.sqlite.org/wal.html).
+
+Selected by ``LMS Settings.search_backend`` (default SQLite). It returns the same
+result shape ``lms.command_palette`` consumes, so permission filtering and
+grouping there are unaffected — only the storage engine changes.
+
+The document preparation (including the Course Instructor -> parent
+denormalisation and modified-date handling) is reused verbatim from
+``LearningSearch`` so the indexed content is identical to the SQLite backend;
+only storage/query is RediSearch-specific.
+
+The redis-search client APIs are imported lazily inside the methods that use
+them (as ``wiki`` does), so importing this module on a SQLite-only site — which
+happens because ``hooks.py`` wires migration/scheduler/doc events here — never
+requires ``redis.commands.search`` to be present.
+"""
+
+import re
+
+import frappe
+from frappe.utils.redis_wrapper import RedisWrapper
+
+from lms.sqlite import LearningSearch, LearningSearchIndexMissingError
+
+INDEX_NAME = "lms_learning_idx"
+KEY_PREFIX = "lms_search:"
+
+TEXT_FIELDS = ("title", "content")
+TAG_FIELDS = (
+	"doctype",
+	"name",
+	"published",
+	"status",
+	"company_name",
+	"parent",
+	"parenttype",
+	"owner",
+)
+# stored (retrievable) but not queried as tags
+DATE_FIELDS = ("start_date", "published_on", "creation")
+
+# Doctypes whose child Course Instructor rows are denormalised onto them.
+PARENT_DOCTYPES = ("LMS Course", "LMS Batch")
+
+# RediSearch splits a TAG value on this character; use one that cannot occur in
+# the indexed values so each value stays a single exact tag (see helpdesk).
+TAG_SEPARATOR = "\n"
+
+_UNSAFE_QUERY_CHARS = re.compile(r"[^a-zA-Z0-9\s]")
+_TAG_SPECIAL = re.compile(r"([\s,.<>{}\[\]\"'\:;!@#$%^&*()\-+=~|/\\])")
+_MIN_PREFIX_LEN = 3
+
+
+def _response_error():
+	from redis import ResponseError
+
+	return ResponseError
+
+
+def _index_definition_cls():
+	try:
+		from redis.commands.search.index_definition import IndexDefinition
+	except ImportError:  # older redis-py
+		from redis.commands.search.indexDefinition import IndexDefinition
+	return IndexDefinition
+
+
+def is_search_module_loaded() -> bool:
+	"""True only if the RediSearch module is loaded in the cache Redis."""
+	try:
+		for module in frappe.cache().module_list():
+			if module.get(b"name") == b"search":
+				return True
+	except Exception:
+		return False
+	return False
+
+
+class LearningRediSearch:
+	"""RediSearch-backed LMS search with the LearningSearch public surface."""
+
+	def __init__(self):
+		self.cache = frappe.cache()
+		# Reuse LearningSearch purely for its ORM-based document preparation
+		# (get_documents / prepare_document); no SQLite I/O happens here.
+		self._domain = LearningSearch()
+
+	def _index(self):
+		return self.cache.ft(INDEX_NAME)
+
+	def index_exists(self) -> bool:
+		try:
+			self._index().info()
+			return True
+		except Exception:
+			return False
+
+	def raise_if_not_indexed(self):
+		if not self.index_exists():
+			raise LearningSearchIndexMissingError(
+				"Search index does not exist. Please build the index first."
+			)
+
+	def drop_index(self, delete_documents: bool = True):
+		try:
+			self._index().dropindex(delete_documents=delete_documents)
+		except _response_error():
+			pass
+
+	def create_index(self):
+		from redis.commands.search.field import NumericField, TagField, TextField
+
+		schema = (
+			[TextField(f) for f in TEXT_FIELDS]
+			+ [TagField(f, separator=TAG_SEPARATOR) for f in TAG_FIELDS]
+			+ [NumericField("modified", sortable=True)]
+		)
+		definition = _index_definition_cls()(prefix=[self.cache.make_key(KEY_PREFIX).decode()])
+		self._index().create_index(schema, definition=definition)
+
+	def build_index(self):
+		if not is_search_module_loaded():
+			frappe.log_error(
+				title="LMS RediSearch",
+				message="RediSearch module not loaded in cache Redis; index not built.",
+			)
+			return
+		self.drop_index()
+		self.create_index()
+		for doc in self._domain.get_documents():
+			self._store(doc)
+
+	# --------------------------------------------------------------- document
+
+	def _doc_key(self, doctype: str, name: str) -> str:
+		return self.cache.make_key(f"{KEY_PREFIX}{doctype}:{name}").decode()
+
+	def _to_hash(self, document: dict) -> dict:
+		"""Flatten a LearningSearch document dict into a Redis hash mapping."""
+		mapping = {f: "" for f in (*TEXT_FIELDS, *TAG_FIELDS, *DATE_FIELDS)}
+		for field in (
+			*TEXT_FIELDS,
+			"doctype",
+			"name",
+			"status",
+			"company_name",
+			"parent",
+			"parenttype",
+			"owner",
+		):
+			mapping[field] = str(document.get(field) or "")
+		mapping["published"] = "1" if document.get("published") else ""
+		for field in DATE_FIELDS:
+			value = document.get(field)
+			mapping[field] = (
+				value.isoformat() if hasattr(value, "isoformat") else (str(value) if value else "")
+			)
+		modified = document.get("modified")
+		mapping["modified"] = str(modified) if modified else "0"
+		return mapping
+
+	def _store(self, doc):
+		document = self._domain.prepare_document(doc)
+		if not document:
+			return
+		# Key by the SOURCE doc's own identity, not the (possibly remapped) one in
+		# the prepared document. A Course Instructor is denormalised onto its
+		# parent course/batch (doctype/name fields point at the parent), but each
+		# instructor keeps its own hash — so several instructors of one course all
+		# stay searchable, and deleting one removes only its entry. command_palette
+		# dedupes the shared parent name across these entries.
+		key = self._doc_key(doc.doctype, doc.name)
+		super(RedisWrapper, self.cache).hset(key, mapping=self._to_hash(document))
+
+	def index_doc(self, doctype: str, name: str, ensure: bool = True):
+		if ensure:
+			self.raise_if_not_indexed()
+		self._store(frappe.get_doc(doctype, name))
+
+	def remove_doc(self, doctype: str, name: str):
+		# delete_value applies make_key (the site prefix) to match the stored
+		# hash key; the plain cache.delete() would target an unprefixed key.
+		self.cache.delete_value(f"{KEY_PREFIX}{doctype}:{name}")
+
+	@staticmethod
+	def _escape_tag(value: str) -> str:
+		return _TAG_SPECIAL.sub(r"\\\1", value)
+
+	def drop_parent_entries(self, doctype: str, name: str):
+		"""Delete every index entry denormalised onto (doctype, name) — the
+		parent's own hash and any Course Instructor hashes pointing at it — by
+		querying the search index itself rather than SQL, so it works even after
+		the child rows have already been removed from the database.
+		"""
+		from redis.commands.search.query import Query
+
+		clause = f"@doctype:{{{self._escape_tag(doctype)}}} @name:{{{self._escape_tag(name)}}}"
+		try:
+			raw = self._index().search(Query(clause).paging(0, 1000))
+		except _response_error():
+			return
+		for entry in raw.docs:
+			# entry.id is the full (already prefixed) Redis key.
+			super(RedisWrapper, self.cache).delete(entry.id)
+
+	# ----------------------------------------------------------------- search
+
+	def _build_query_string(self, query: str) -> str:
+		cleaned = _UNSAFE_QUERY_CHARS.sub(" ", query or "").strip().lower()
+		cleaned = re.sub(r"\s+", " ", cleaned)
+		terms = [f"{t}*" if len(t) >= _MIN_PREFIX_LEN else t for t in cleaned.split()]
+		return f"({' '.join(terms)})" if terms else "*"
+
+	def search(self, query: str):
+		self.raise_if_not_indexed()
+		query_string = self._build_query_string(query)
+		# An empty / punctuation-only query yields "*" (match-all); return nothing
+		# instead so the command palette never shows unrelated indexed documents.
+		if query_string == "*":
+			return {"results": []}
+
+		from redis.commands.search.query import Query
+
+		try:
+			raw = self._index().search(Query(query_string).paging(0, 50))
+		except _response_error() as e:
+			frappe.log_error(title="LMS RediSearch query failed", message=str(e))
+			return {"results": []}
+		return {"results": [self._to_result(doc) for doc in raw.docs]}
+
+	def _to_result(self, doc) -> dict:
+		def get(f):
+			return getattr(doc, f, "") or ""
+
+		modified = get("modified")
+		return {
+			"doctype": get("doctype"),
+			"name": get("name"),
+			"title": get("title"),
+			"content": get("content"),
+			"author": get("owner"),
+			"published": 1 if get("published") else 0,
+			"start_date": get("start_date"),
+			"status": get("status"),
+			"company_name": get("company_name"),
+			"modified": float(modified) if modified else 0,
+		}
+
+
+def build_index():
+	"""Build the RediSearch LMS index — callable from console/scheduler."""
+	LearningRediSearch().build_index()
+
+
+# ------------------------------------------------------------------ lifecycle
+# doc_event + scheduler handlers, gated on the toggle so they are inert unless
+# the operator has switched LMS search to RediSearch.
+
+_INDEXED_DOCTYPES = ("LMS Course", "LMS Batch", "Job Opportunity", "Course Instructor")
+
+
+def _redisearch_selected() -> bool:
+	return frappe.db.get_single_value("LMS Settings", "search_backend") == "RediSearch"
+
+
+def _resync_parent(search, doctype, name):
+	"""Rebuild a course/batch's entries from current state: drop every entry
+	denormalised onto it (including instructor rows just removed from the child
+	table, which leave no trash event), then re-index it and its current
+	instructors."""
+	search.drop_parent_entries(doctype, name)
+	if not frappe.db.exists(doctype, name):
+		return
+	search.index_doc(doctype, name, ensure=False)
+	for row in frappe.get_all(
+		"Course Instructor",
+		filters={"parenttype": doctype, "parent": name},
+		pluck="name",
+	):
+		search.index_doc("Course Instructor", row, ensure=False)
+
+
+def update_index(doc, method=None):
+	if not _redisearch_selected():
+		return
+	search = LearningRediSearch()
+	if not search.index_exists():
+		return
+	try:
+		if doc.doctype in PARENT_DOCTYPES:
+			# Editing a course/batch can add or remove instructors (child rows,
+			# no per-row events), so rebuild all of its entries from current state.
+			_resync_parent(search, doc.doctype, doc.name)
+		else:
+			# Standalone doc (Job Opportunity, or an instructor row changed on its
+			# own) — refresh just its own entry.
+			search.index_doc(doc.doctype, doc.name)
+	except Exception:
+		frappe.log_error(
+			title="LMS RediSearch index update",
+			message=f"Failed to index {doc.doctype}:{doc.name}",
+		)
+
+
+def delete_index(doc, method=None):
+	if not _redisearch_selected():
+		return
+	search = LearningRediSearch()
+	try:
+		if doc.doctype in PARENT_DOCTYPES:
+			# Drop the parent's own hash and all its denormalised instructor
+			# hashes by querying the index (not SQL), so it holds even when the
+			# child rows are already gone by the time this trash event runs.
+			search.drop_parent_entries(doc.doctype, doc.name)
+		else:
+			# Every other source doc — including a standalone Course Instructor —
+			# has its own hash keyed by its own identity.
+			search.remove_doc(doc.doctype, doc.name)
+	except Exception:
+		frappe.log_error(
+			title="LMS RediSearch index delete",
+			message=f"Failed to remove {doc.doctype}:{doc.name}",
+		)
+
+
+def build_index_if_enabled():
+	"""Scheduler entry: build the index if RediSearch is on and it is missing."""
+	if not _redisearch_selected():
+		return
+	search = LearningRediSearch()
+	if not search.index_exists():
+		search.build_index()
+
+
+def build_index_in_background():
+	"""after_migrate entry: (re)build the index in the background if RediSearch is on."""
+	if not _redisearch_selected():
+		return
+	if not frappe.cache().get_value("lms_redisearch_indexing_in_progress"):
+		frappe.enqueue("lms.redisearch.build_index", queue="long")

--- a/lms/sqlite.py
+++ b/lms/sqlite.py
@@ -130,6 +130,17 @@ class LearningSearch(SQLiteSearch):
 		except Exception as e:
 			frappe.throw(e)
 
+	def is_search_enabled(self):
+		"""Disable the SQLite index while the RediSearch backend is selected.
+
+		Returning False makes the core's global doc_events and schedulers skip
+		this class, so no SQLite index is built or updated when the operator has
+		switched LMS search to RediSearch.
+		"""
+		return (
+			frappe.db.get_single_value("LMS Settings", "search_backend") != "RediSearch"
+		)
+
 	def get_search_filters(self):
 		return {}
 

--- a/lms/test_search_redisearch.py
+++ b/lms/test_search_redisearch.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+"""Integration tests for the RediSearch LMS backend.
+
+Mock-free: exercises the real RediSearch module in the cache Redis and the real
+command-palette permission/grouping. Skips itself when the module is absent.
+"""
+
+import frappe
+
+from lms.lms.test_helpers import BaseTestUtils
+from lms.redisearch import LearningRediSearch, delete_index, is_search_module_loaded
+
+
+class TestLearningRediSearch(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		if not is_search_module_loaded():
+			self.skipTest("RediSearch module not loaded in cache Redis")
+
+		self._prev_backend = frappe.db.get_single_value("LMS Settings", "search_backend")
+		frappe.db.set_single_value("LMS Settings", "search_backend", "RediSearch")
+
+		# _create_course links an instructor User that must exist first.
+		self._create_user("frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"])
+		self.course = self._create_course(title="Redisearch Probe Course")
+		self.search = LearningRediSearch()
+		self.search.build_index()
+
+	def tearDown(self):
+		try:
+			self.search.drop_index()
+			frappe.db.set_single_value("LMS Settings", "search_backend", self._prev_backend)
+		finally:
+			super().tearDown()
+
+	def _course_found(self, term):
+		return self.course.name in {
+			r["name"] for r in self.search.search(term)["results"] if r["doctype"] == "LMS Course"
+		}
+
+	def test_index_exists_after_build(self):
+		self.assertTrue(self.search.index_exists())
+
+	def test_search_finds_course(self):
+		result = self.search.search("probe")
+		names = {r["name"] for r in result["results"] if r["doctype"] == "LMS Course"}
+		self.assertIn(self.course.name, names)
+
+	def test_result_shape(self):
+		result = self.search.search("probe")
+		self.assertTrue(result["results"])
+		row = next(r for r in result["results"] if r["name"] == self.course.name)
+		for key in ("doctype", "name", "title", "content", "author", "published", "modified"):
+			self.assertIn(key, row)
+		self.assertEqual(row["published"], 1)
+
+	def test_empty_query_returns_nothing(self):
+		for q in ("", "   ", "***"):
+			self.assertEqual(self.search.search(q)["results"], [])
+
+	def test_instructors_searchable_and_delete_isolated(self):
+		"""Each Course Instructor keeps its own index entry, so all instructors of
+		a course are searchable by name; deleting one drops only that entry and
+		leaves the other instructors — and the course itself — searchable."""
+		self._create_user("alice.q@example.com", "Alice", "Quibbleton", ["Moderator", "Course Creator"])
+		self._create_user("bob.z@example.com", "Bob", "Zephyrix", ["Moderator", "Course Creator"])
+		course = frappe.get_doc("LMS Course", self.course.name)
+		course.append("instructors", {"instructor": "alice.q@example.com"})
+		course.append("instructors", {"instructor": "bob.z@example.com"})
+		course.save()
+		self.search.build_index()
+
+		# Both instructors' distinctive names find the course.
+		self.assertTrue(self._course_found("Quibbleton"))
+		self.assertTrue(self._course_found("Zephyrix"))
+
+		bob_row = next(
+			r.name
+			for r in frappe.get_all(
+				"Course Instructor",
+				filters={"parenttype": "LMS Course", "parent": self.course.name},
+				fields=["name", "instructor"],
+			)
+			if r.instructor == "bob.z@example.com"
+		)
+		delete_index(frappe.get_doc("Course Instructor", bob_row))
+
+		# Bob's entry is gone; Alice and the course remain searchable.
+		self.assertFalse(self._course_found("Zephyrix"))
+		self.assertTrue(self._course_found("Quibbleton"))
+		self.assertTrue(self._course_found("probe"))
+
+	def test_command_palette_routes_to_redisearch(self):
+		from lms.command_palette import search_sqlite
+
+		groups = search_sqlite("probe")
+		courses = next((g["items"] for g in groups if g["title"] == "Courses"), [])
+		self.assertIn(self.course.name, {c["name"] for c in courses})
+
+	def test_parent_delete_drops_entries_even_without_child_rows(self):
+		"""Deleting a course drops its own entry AND its denormalised instructor
+		entries by querying the index, so it holds even when the child rows are
+		already gone from SQL by the time the trash event runs."""
+		# Simulate the delete flow where children are removed before the parent's
+		# trash hook: blow the Course Instructor rows away from the DB first.
+		frappe.db.delete(
+			"Course Instructor",
+			{"parenttype": "LMS Course", "parent": self.course.name},
+		)
+		delete_index(frappe.get_doc("LMS Course", self.course.name))
+		names = {r["name"] for r in self.search.search("probe")["results"]}
+		self.assertNotIn(self.course.name, names)
+
+	def test_instructor_removed_via_course_edit_drops_from_search(self):
+		"""Removing an instructor by editing the course (a child-row delete with
+		no trash event) still drops it from search, because the parent update
+		re-syncs all of its entries."""
+		self._create_user("carl.x@example.com", "Carl", "Xylophone", ["Moderator", "Course Creator"])
+		course = frappe.get_doc("LMS Course", self.course.name)
+		course.append("instructors", {"instructor": "carl.x@example.com"})
+		course.save()
+		self.search.build_index()
+		self.assertTrue(self._course_found("Xylophone"))
+
+		# Remove Carl from the instructors table and save — fires update_index.
+		course = frappe.get_doc("LMS Course", self.course.name)
+		course.instructors = [i for i in course.instructors if i.instructor != "carl.x@example.com"]
+		course.save()
+
+		self.assertFalse(self._course_found("Xylophone"))
+		self.assertTrue(self._course_found("probe"))
+
+	def test_sqlite_backend_still_works_end_to_end(self):
+		"""Regression: the SQLite backend keeps working when it is selected."""
+		frappe.db.set_single_value("LMS Settings", "search_backend", "SQLite")
+		try:
+			from lms.sqlite import LearningSearch
+
+			sqlite = LearningSearch()
+			self.assertTrue(sqlite.is_search_enabled())
+			sqlite.build_index()
+			self.assertTrue(sqlite.index_exists())
+			names = {r["name"] for r in sqlite.search("probe")["results"] if r["doctype"] == "LMS Course"}
+			self.assertIn(self.course.name, names)
+		finally:
+			frappe.db.set_single_value("LMS Settings", "search_backend", "RediSearch")
+
+	def test_sqlite_class_disabled_under_redisearch(self):
+		from lms.sqlite import LearningSearch
+
+		frappe.db.set_single_value("LMS Settings", "search_backend", "RediSearch")
+		self.assertFalse(LearningSearch().is_search_enabled())
+		frappe.db.set_single_value("LMS Settings", "search_backend", "SQLite")
+		self.assertTrue(LearningSearch().is_search_enabled())
+		frappe.db.set_single_value("LMS Settings", "search_backend", "RediSearch")


### PR DESCRIPTION
## Problem

`LearningSearch` (SQLite FTS) cannot run on a network filesystem. `SQLiteSearch` opens the index in WAL mode, and WAL requires a shared-memory `-shm` segment between all processes on the same host — it [does not work over a network filesystem](https://www.sqlite.org/wal.html) ("All processes using a database must be on the same host computer; WAL does not work over a network filesystem"). On Kubernetes / high-availability deployments with `sites/` on NFS, indexing and search fail with `database is locked`.

## What this does

Adds RediSearch as an **opt-in** storage backend, selected by a new `LMS Settings → Search Backend` field (**default `SQLite`**, so behaviour is unchanged unless an operator switches it). It requires the RediSearch module in the cache Redis.

- `LearningRediSearch` (`lms/redisearch.py`) mirrors `LearningSearch`'s public surface and **reuses its document preparation verbatim** — including the `Course Instructor` → parent course/batch denormalisation and the modified-date handling — so indexed content and the `command_palette` result shape are identical; only the storage engine changes.
- The SQLite class disables itself via `is_search_enabled()` while RediSearch is selected, so the core's global indexing orchestration skips it cleanly. **No frappe core change.**

## Incidental fix: double index build

`lms.sqlite.build_index_in_background` was enqueued from `after_migrate` and the `all` scheduler, while the core's `get_search_classes()` orchestration already builds the same SQLite index for classes registered under the `sqlite_search` hook — so the SQLite index was being built twice. This PR moves the app-level build hooks to the (gated) RediSearch build and leaves the SQLite index to the core path, matching how helpdesk drives its ticket index.

## Backward compatibility

- Default `SQLite` → zero behaviour change.
- No new dependency for SQLite users; RediSearch is only touched when enabled.
- No schema change or migration beyond the single opt-in Select field.

## Tests

Adds `lms/test_search_redisearch.py` — mock-free integration tests against a real RediSearch module: index build, search, result shape, command-palette routing, document removal, plus a SQLite regression case asserting the default backend still works end to end.
