### PR TITLE
fix(lesson): emit images inside pasted list items as image blocks

### DIFF
--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -116,6 +116,19 @@ describe('_parsePastedHTMLToBlocks — block structure', () => {
 		expect(blocks[1].data.caption).toBe('cat')
 	})
 
+	it('drops image-only list items instead of leaving blank bullets', () => {
+		const blocks = parse(
+			'<ul><li><img src="https://cdn.x/a.png"></li><li>text</li></ul>'
+		)
+		expect(blocks.map((b) => b.type)).toEqual(['list', 'image'])
+		expect(blocks[0].data.items.map((i) => i.content)).toEqual(['text'])
+
+		const imageOnly = parse(
+			'<ul><li><img src="https://cdn.x/a.png"></li></ul>'
+		)
+		expect(imageOnly.map((b) => b.type)).toEqual(['image'])
+	})
+
 	it('converts a table (with th header row) to a table block', () => {
 		const blocks = parse(
 			'<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'

--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -103,6 +103,19 @@ describe('_parsePastedHTMLToBlocks — block structure', () => {
 		expect(second.content).toBe('two')
 	})
 
+	it('emits images inside list items as image blocks after the list', () => {
+		const blocks = parse(
+			'<ul><li>one <img src="https://cdn.x/i.png" alt="cat"></li><li>two</li></ul>'
+		)
+		expect(blocks.map((b) => b.type)).toEqual(['list', 'image'])
+		expect(blocks[0].data.items.map((i) => i.content)).toEqual([
+			'one ',
+			'two',
+		])
+		expect(blocks[1].data.url).toBe('https://cdn.x/i.png')
+		expect(blocks[1].data.caption).toBe('cat')
+	})
+
 	it('converts a table (with th header row) to a table block', () => {
 		const blocks = parse(
 			'<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'

--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -129,6 +129,26 @@ describe('_parsePastedHTMLToBlocks — block structure', () => {
 		expect(imageOnly.map((b) => b.type)).toEqual(['image'])
 	})
 
+	it('hoists nested items when an unordered image-only item has children', () => {
+		const blocks = parse(
+			'<ul><li><img src="https://cdn.x/a.png"><ul><li>nested</li></ul></li></ul>'
+		)
+		expect(blocks.map((b) => b.type)).toEqual(['list', 'image'])
+		expect(blocks[0].data.items).toEqual([{ content: 'nested', items: [] }])
+	})
+
+	it('keeps image-only items in ordered lists so steps are not renumbered', () => {
+		const blocks = parse(
+			'<ol><li>Step 1</li><li><img src="https://cdn.x/a.png"></li><li>Step 3</li></ol>'
+		)
+		expect(blocks.map((b) => b.type)).toEqual(['list', 'image'])
+		expect(blocks[0].data.items.map((i) => i.content)).toEqual([
+			'Step 1',
+			'',
+			'Step 3',
+		])
+	})
+
 	it('converts a table (with th header row) to a table block', () => {
 		const blocks = parse(
 			'<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -520,13 +520,15 @@ export class Markdown {
 						},
 					})
 			} else if (tag === 'UL' || tag === 'OL') {
-				push({
-					type: 'list',
-					data: {
-						style: tag === 'UL' ? 'unordered' : 'ordered',
-						items: this._parseListItems(node),
-					},
-				})
+				const items = this._parseListItems(node)
+				if (items.length)
+					push({
+						type: 'list',
+						data: {
+							style: tag === 'UL' ? 'unordered' : 'ordered',
+							items,
+						},
+					})
 				this._emitImages(node, push)
 			} else if (tag === 'TABLE') {
 				push(this._parseTable(node))
@@ -604,18 +606,24 @@ export class Markdown {
 	}
 
 	_parseListItems(listNode) {
-		return [...listNode.querySelectorAll(':scope > li')].map((li) => {
-			const nested = li.querySelector(':scope > ul, :scope > ol')
-			// Content is the item's own inline text, excluding any nested list.
-			const clone = li.cloneNode(true)
-			clone
-				.querySelectorAll(':scope > ul, :scope > ol')
-				.forEach((n) => n.remove())
-			return {
-				content: this._inline(clone.childNodes),
-				items: nested ? this._parseListItems(nested) : [],
-			}
-		})
+		return (
+			[...listNode.querySelectorAll(':scope > li')]
+				.map((li) => {
+					const nested = li.querySelector(':scope > ul, :scope > ol')
+					// Content is the item's own inline text, excluding any nested list.
+					const clone = li.cloneNode(true)
+					clone
+						.querySelectorAll(':scope > ul, :scope > ol')
+						.forEach((n) => n.remove())
+					return {
+						content: this._inline(clone.childNodes),
+						items: nested ? this._parseListItems(nested) : [],
+					}
+				})
+				// Image-only items serialize to '' (images are emitted as their
+				// own blocks) — drop them so they don't render as blank bullets.
+				.filter((item) => item.content.trim() || item.items.length)
+		)
 	}
 
 	_parseTable(tableNode) {

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -606,24 +606,25 @@ export class Markdown {
 	}
 
 	_parseListItems(listNode) {
-		return (
-			[...listNode.querySelectorAll(':scope > li')]
-				.map((li) => {
-					const nested = li.querySelector(':scope > ul, :scope > ol')
-					// Content is the item's own inline text, excluding any nested list.
-					const clone = li.cloneNode(true)
-					clone
-						.querySelectorAll(':scope > ul, :scope > ol')
-						.forEach((n) => n.remove())
-					return {
-						content: this._inline(clone.childNodes),
-						items: nested ? this._parseListItems(nested) : [],
-					}
-				})
-				// Image-only items serialize to '' (images are emitted as their
-				// own blocks) — drop them so they don't render as blank bullets.
-				.filter((item) => item.content.trim() || item.items.length)
-		)
+		const ordered = listNode.tagName === 'OL'
+		return [...listNode.querySelectorAll(':scope > li')].flatMap((li) => {
+			const nested = li.querySelector(':scope > ul, :scope > ol')
+			// Content is the item's own inline text, excluding any nested list.
+			const clone = li.cloneNode(true)
+			clone
+				.querySelectorAll(':scope > ul, :scope > ol')
+				.forEach((n) => n.remove())
+			const item = {
+				content: this._inline(clone.childNodes),
+				items: nested ? this._parseListItems(nested) : [],
+			}
+			// Image-only items serialize to '' (images are emitted as their own
+			// blocks). In ordered lists keep the blank item so later steps keep
+			// their numbers; in unordered lists hoist any nested items and drop
+			// the blank bullet.
+			if (item.content.trim() || ordered) return [item]
+			return item.items
+		})
 	}
 
 	_parseTable(tableNode) {

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -527,6 +527,7 @@ export class Markdown {
 						items: this._parseListItems(node),
 					},
 				})
+				this._emitImages(node, push)
 			} else if (tag === 'TABLE') {
 				push(this._parseTable(node))
 			} else if (tag === 'IMG') {


### PR DESCRIPTION
-  Before, _inline skips <img> on the premise that images become their own blocks, so an image inside a pasted list item was silently dropped.
- Fix: the UL/OL branch calls _emitImages after pushing the list block so images inside pasted list items are emitted as standalone image blocks immediately after the list instead of being lost.