### PR TITLE
fix: harden access-control checks

### DIFF
--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -7,9 +7,7 @@ from frappe.desk.doctype.notification_log.notification_log import make_notificat
 from frappe.model.document import Document
 from frappe.utils import validate_url
 
-from lms.lms.utils import get_lms_route
-
-PRIVILEGED_ROLES = {"Moderator", "Course Creator", "Batch Evaluator", "System Manager"}
+from lms.lms.utils import PRIVILEGED_ROLES, get_lms_route
 
 
 class LMSAssignmentSubmission(Document):

--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -13,9 +13,27 @@ from lms.lms.utils import PRIVILEGED_ROLES, get_lms_route
 class LMSAssignmentSubmission(Document):
 	def validate(self):
 		self.enforce_member_ownership()
+		self.enforce_grading_permission()
 		self.validate_duplicates()
 		self.validate_url()
 		self.validate_status()
+
+	def enforce_grading_permission(self):
+		"""Only evaluators/instructors may set the grading fields.
+
+		Prevents a student from grading their own submission (e.g. flipping status from
+		"Not Graded" to "Pass" via frappe.client.set_value). On create the grading fields
+		are reset to their defaults; on update they are reverted to the stored values.
+		"""
+		if PRIVILEGED_ROLES & set(frappe.get_roles()):
+			return
+
+		# Revert grading fields to their stored values on update, or to safe defaults on
+		# create / when no baseline is available (fail closed, never fail open).
+		previous = None if self.is_new() else self.get_doc_before_save()
+		defaults = {"status": "Not Graded", "comments": None, "evaluator": None}
+		for field, default in defaults.items():
+			setattr(self, field, previous.get(field) if previous else default)
 
 	def enforce_member_ownership(self):
 		if PRIVILEGED_ROLES & set(frappe.get_roles()):
@@ -45,10 +63,13 @@ class LMSAssignmentSubmission(Document):
 			frappe.throw(_("Please enter a valid URL."))
 
 	def validate_status(self):
-		if not self.is_new():
-			doc_before_save = self.get_doc_before_save()
-			if doc_before_save.status != self.status or doc_before_save.comments != self.comments:
-				self.trigger_update_notification()
+		if self.is_new():
+			return
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+		if doc_before_save.status != self.status or doc_before_save.comments != self.comments:
+			self.trigger_update_notification()
 
 	def validate_private_attachments(self):
 		if self.type == "Text":

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -19,9 +19,7 @@ from frappe.utils import (
 	nowtime,
 )
 
-from lms.lms.utils import get_evaluator
-
-PRIVILEGED_ROLES = {"Moderator", "Course Creator", "Batch Evaluator", "System Manager"}
+from lms.lms.utils import PRIVILEGED_ROLES, get_evaluator
 
 
 class LMSCertificateRequest(Document):

--- a/lms/lms/doctype/lms_course_progress/lms_course_progress.json
+++ b/lms/lms/doctype/lms_course_progress/lms_course_progress.json
@@ -120,7 +120,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "email": 1,
    "export": 1,
    "if_owner": 1,

--- a/lms/lms/doctype/lms_course_progress/lms_course_progress.py
+++ b/lms/lms/doctype/lms_course_progress/lms_course_progress.py
@@ -5,11 +5,17 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from lms.lms.utils import recalculate_course_progress
+from lms.lms.utils import PRIVILEGED_ROLES, recalculate_course_progress
 
 
 class LMSCourseProgress(Document):
+	def validate(self):
+		# Guards updates too; before_insert also calls it so member is bound before the
+		# insert-time duplicate check below. The call is idempotent.
+		self.enforce_member_ownership()
+
 	def before_insert(self):
+		self.enforce_member_ownership()
 		if (
 			self.member
 			and self.lesson
@@ -19,6 +25,23 @@ class LMSCourseProgress(Document):
 				_("Progress is already recorded for this lesson."),
 				frappe.UniqueValidationError,
 			)
+
+	def enforce_member_ownership(self):
+		"""A non-privileged user may only record progress for their own account.
+
+		Prevents mass-assignment IDOR via the generic REST API, where a student could
+		POST a progress row for an arbitrary member and inflate that member's course
+		completion. Privileged roles (instructors/moderators, and the server-side
+		save_progress flow which runs with ignore_permissions) are exempt.
+		"""
+		if PRIVILEGED_ROLES & set(frappe.get_roles()):
+			return
+		if self.member and self.member != frappe.session.user:
+			frappe.throw(
+				_("You can only record progress for your own account."),
+				frappe.PermissionError,
+			)
+		self.member = frappe.session.user
 
 	def on_update(self):
 		recalculate_course_progress(self.course, self.member)

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -17,20 +17,23 @@ from lms.lms.utils import can_modify_course, get_membership, guest_access_allowe
 INSTRUCTOR_FIELDS = {"instructor_content", "instructor_notes"}
 
 
-def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str | None = None) -> bool:
-	"""Single source of truth for who may read a lesson's resources.
+def resolve_lesson_access(lesson: str, *, user: str | None = None) -> tuple[bool, bool]:
+	"""Return ``(is_instructor, can_access)`` for a lesson, computed in a single pass.
 
-	- instructors / moderators (can_modify_course) → all media (incl. instructor files)
-	- instructor_only=True → only the above; enrolled students denied
-	- else (student media): enrolled member OR (published course AND include_in_preview
-	  AND guest access allowed)
+	- ``is_instructor``: can author the lesson's course → all media, incl. instructor files.
+	- ``can_access``: ``is_instructor`` OR enrolled member OR (published course AND
+	  include_in_preview AND guest access allowed).
+
+	Callers needing only one flag should use :func:`can_access_lesson`; this exists so a
+	caller needing both (e.g. get_lesson, which decides instructor-field visibility on top
+	of the access gate) resolves the instructor check once instead of twice.
 	"""
 	if not isinstance(lesson, str) or not lesson:
-		return False
+		return False, False
 
 	lesson_row = frappe.db.get_value("Course Lesson", lesson, ["course", "include_in_preview"], as_dict=True)
 	if not lesson_row:
-		return False
+		return False, False
 
 	original_user = frappe.session.user
 	user = user or original_user
@@ -38,11 +41,9 @@ def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str |
 		# can_modify_course / get_membership / guest_access_allowed read session.user.
 		frappe.session.user = user
 		if can_modify_course(lesson_row.course):
-			return True
-		if instructor_only:
-			return False
+			return True, True
 		if get_membership(lesson_row.course, user):
-			return True
+			return False, True
 		# Preview is for prospective students of a LIVE course. Require the course to be
 		# published so draft lessons don't leak via this gate (matches get_course_details,
 		# which already hides unpublished courses from non-authors). Instructors/members
@@ -52,10 +53,22 @@ def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str |
 			and frappe.db.get_value("LMS Course", lesson_row.course, "published")
 			and guest_access_allowed()
 		):
-			return True
-		return False
+			return False, True
+		return False, False
 	finally:
 		frappe.session.user = original_user
+
+
+def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str | None = None) -> bool:
+	"""Single source of truth for who may read a lesson's resources.
+
+	- instructors / moderators (can_modify_course) → all media (incl. instructor files)
+	- instructor_only=True → only the above; enrolled students denied
+	- else (student media): enrolled member OR (published course AND include_in_preview
+	  AND guest access allowed)
+	"""
+	is_instructor, can_access = resolve_lesson_access(lesson, user=user)
+	return is_instructor if instructor_only else can_access
 
 
 def file_has_permission(doc, ptype="read", user=None):

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -11,7 +11,13 @@ core (frappe/permissions.py), CRM (crm.permissions.*), and Raven (raven.permissi
 
 import frappe
 
-from lms.lms.utils import can_modify_course, get_membership, guest_access_allowed
+from lms.lms.utils import (
+	can_modify_batch,
+	can_modify_course,
+	get_membership,
+	guest_access_allowed,
+	has_moderator_role,
+)
 
 # File fields that hold instructor-only lesson media (never served to students).
 INSTRUCTOR_FIELDS = {"instructor_content", "instructor_notes"}
@@ -69,6 +75,64 @@ def can_access_lesson(lesson: str, *, instructor_only: bool = False, user: str |
 	"""
 	is_instructor, can_access = resolve_lesson_access(lesson, user=user)
 	return is_instructor if instructor_only else can_access
+
+
+def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
+	"""Single source of truth for who may read a quiz's questions/answers.
+
+	Access is granted to:
+	- global moderators and the quiz's own author (so an unlinked/newly-created quiz
+	  can still be edited before it is embedded anywhere),
+	- course authors / moderators of any course the quiz belongs to, plus enrolled
+	  members of that course,
+	- batch instructors / enrolled members of any batch whose assessment references it.
+
+	A quiz's owning course/lesson is read from LMS Quiz.course / LMS Quiz.lesson (set
+	automatically by Course Lesson.save_lesson_details_in_quiz when the quiz is embedded
+	in a lesson). Course Lesson.quiz_id is also honoured for lessons that set it manually.
+	"""
+	if not isinstance(quiz, str) or not quiz:
+		return False
+
+	quiz_row = frappe.db.get_value("LMS Quiz", quiz, ["course", "owner"], as_dict=True)
+	if not quiz_row:
+		return False
+
+	original_user = frappe.session.user
+	user = user or original_user
+	try:
+		# The can_modify_* / get_membership helpers read session.user.
+		frappe.session.user = user
+
+		# Global admins and the quiz author may always reach it, even when unlinked.
+		if has_moderator_role(user) or quiz_row.owner == user:
+			return True
+
+		# Courses the quiz belongs to: the authoritative LMS Quiz.course link plus any
+		# lesson that references it via the manually-set quiz_id field.
+		courses = set()
+		if quiz_row.course:
+			courses.add(quiz_row.course)
+		courses.update(frappe.get_all("Course Lesson", filters={"quiz_id": quiz}, pluck="course"))
+		for course in courses:
+			if course and (can_modify_course(course) or get_membership(course, user)):
+				return True
+
+		assessment_batches = frappe.get_all(
+			"LMS Assessment",
+			filters={"assessment_type": "LMS Quiz", "assessment_name": quiz},
+			pluck="parent",
+		)
+		for batch in assessment_batches:
+			if batch and (
+				can_modify_batch(batch)
+				or frappe.db.exists("LMS Batch Enrollment", {"batch": batch, "member": user})
+			):
+				return True
+
+		return False
+	finally:
+		frappe.session.user = original_user
 
 
 def file_has_permission(doc, ptype="read", user=None):

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1244,15 +1244,24 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 
 	# Local import: permissions imports from utils at module load, so importing it
 	# at the top of utils would create a cycle.
-	from lms.lms.permissions import can_access_lesson
+	from lms.lms.permissions import resolve_lesson_access
 
-	if not can_access_lesson(lesson_name):
+	# Resolve instructor status (governs instructor-only field visibility) and overall
+	# access in one pass, so the instructor check isn't computed twice.
+	is_instructor, can_access = resolve_lesson_access(lesson_name)
+	if not can_access:
 		return {
 			"no_preview": 1,
 			"title": lesson_details.title,
 			"course_title": course_info.title,
 			"disable_self_learning": course_info.disable_self_learning,
 		}
+
+	# instructor_content / instructor_notes are instructor-only (permissions.INSTRUCTOR_FIELDS).
+	# Never leak them to students or preview guests, who also pass the gate above.
+	if not is_instructor:
+		lesson_details.instructor_content = None
+		lesson_details.instructor_notes = None
 
 	if frappe.session.user == "Guest":
 		progress = 0

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1460,9 +1460,16 @@ def get_quiz_with_questions(quiz: str) -> dict:
 		QUESTION_EXPLANATION_FIELDS,
 		QUESTION_OPTION_FIELDS,
 	)
+	from lms.lms.permissions import can_access_quiz
 
-	if not has_lms_role():
-		frappe.throw(_("You are not authorized to view this quiz."))
+	if not isinstance(quiz, str):
+		frappe.throw(_("Quiz must be a string."))
+
+	if not can_access_quiz(quiz):
+		frappe.logger("lms.security").warning(
+			"Quiz access denied: user=%s quiz=%s", frappe.session.user, quiz
+		)
+		frappe.throw(_("You are not authorized to view this quiz."), frappe.PermissionError)
 
 	quiz_doc = frappe.get_doc("LMS Quiz", quiz).as_dict()
 

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -34,6 +34,8 @@ from lms.lms.md import find_macros
 
 RE_SLUG_NOTALLOWED = re.compile("[^a-z0-9]+")
 LMS_ROLES = ["Moderator", "Course Creator", "Batch Evaluator", "LMS Student"]
+# Roles that bypass per-record LMS authorization checks (course/batch staff + admins).
+PRIVILEGED_ROLES = {"Moderator", "Course Creator", "Batch Evaluator", "System Manager"}
 
 
 def get_lms_path():

--- a/lms/tests/security/test_assignment_self_grading.py
+++ b/lms/tests/security/test_assignment_self_grading.py
@@ -1,0 +1,60 @@
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestAssignmentSelfGrading(BaseTestUtils, FrappeAPITestCase):
+	"""A student must not be able to grade their own assignment submission."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.student = self._create_user(f"astud-{hash}@example.com", "Ann", "Student", ["LMS Student"])
+		self.evaluator = self._create_user(f"aeval-{hash}@example.com", "Eve", "Aluator", ["Batch Evaluator"])
+		self.assignment = self._create_assignment(title=f"Grade Assignment {hash}")
+
+	def _make_submission(self, user, status="Not Graded"):
+		frappe.session.user = user
+		try:
+			doc = frappe.get_doc(
+				{
+					"doctype": "LMS Assignment Submission",
+					"assignment": self.assignment.name,
+					"member": user,
+					"answer": "my submission text",
+					"status": status,
+				}
+			)
+			doc.insert()
+			self.cleanup_items.append(("LMS Assignment Submission", doc.name))
+			return doc.name
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_student_cannot_pass_own_submission_on_create(self):
+		name = self._make_submission(self.student.email, status="Pass")
+		self.assertEqual(frappe.db.get_value("LMS Assignment Submission", name, "status"), "Not Graded")
+
+	def test_student_cannot_grade_own_submission_on_update(self):
+		name = self._make_submission(self.student.email)
+		frappe.session.user = self.student.email
+		try:
+			doc = frappe.get_doc("LMS Assignment Submission", name)
+			doc.status = "Pass"
+			doc.comments = "grading myself"
+			doc.save()
+		finally:
+			frappe.session.user = "Administrator"
+		self.assertEqual(frappe.db.get_value("LMS Assignment Submission", name, "status"), "Not Graded")
+
+	def test_evaluator_can_grade_submission(self):
+		name = self._make_submission(self.student.email)
+		frappe.session.user = self.evaluator.email
+		try:
+			doc = frappe.get_doc("LMS Assignment Submission", name)
+			doc.status = "Pass"
+			doc.save()
+		finally:
+			frappe.session.user = "Administrator"
+		self.assertEqual(frappe.db.get_value("LMS Assignment Submission", name, "status"), "Pass")

--- a/lms/tests/security/test_course_progress_idor.py
+++ b/lms/tests/security/test_course_progress_idor.py
@@ -1,0 +1,67 @@
+import json
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestCourseProgressIDOR(BaseTestUtils, FrappeAPITestCase):
+	"""A student must not be able to record progress for another member."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.attacker = self._create_user(f"atk-{hash}@example.com", "At", "Tacker", ["LMS Student"])
+		self.victim = self._create_user(f"vic-{hash}@example.com", "Vic", "Tim", ["LMS Student"])
+		self.instructor = self._create_user(
+			f"pinstr-{hash}@example.com", "Pat", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.course = self._create_course(title=f"Progress Course {hash}", instructor=self.instructor.email)
+		self.chapter = self._create_chapter(f"PChapter {hash}", self.course.name)
+		self.lesson = self._create_lesson(f"PLesson {hash}", self.chapter.name, self.course.name)
+
+	def test_lms_student_role_json_grants_no_create(self):
+		# Defense-in-depth: the doctype JSON must not grant LMS Student create (syncs to
+		# the DB permission layer on migrate). Read from disk to avoid mutating the site.
+		path = frappe.get_app_path("lms", "lms", "doctype", "lms_course_progress", "lms_course_progress.json")
+		with open(path) as f:
+			perms = json.load(f)["permissions"]
+		student = next(p for p in perms if p["role"] == "LMS Student")
+		self.assertNotEqual(student.get("create"), 1)
+
+	def test_student_cannot_insert_progress_for_another_member(self):
+		frappe.session.user = self.attacker.email
+		try:
+			doc = frappe.get_doc(
+				{
+					"doctype": "LMS Course Progress",
+					"member": self.victim.email,
+					"course": self.course.name,
+					"lesson": self.lesson.name,
+					"status": "Complete",
+				}
+			)
+			# ignore_permissions isolates the controller guard from the role-permission layer.
+			with self.assertRaises(frappe.PermissionError):
+				doc.insert(ignore_permissions=True)
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_controller_rebinds_member_to_session_user(self):
+		frappe.session.user = self.attacker.email
+		try:
+			doc = frappe.get_doc(
+				{
+					"doctype": "LMS Course Progress",
+					"member": self.attacker.email,  # own account is allowed
+					"course": self.course.name,
+					"lesson": self.lesson.name,
+					"status": "Complete",
+				}
+			)
+			doc.insert(ignore_permissions=True)
+			self.cleanup_items.append(("LMS Course Progress", doc.name))
+			self.assertEqual(doc.member, self.attacker.email)
+		finally:
+			frappe.session.user = "Administrator"

--- a/lms/tests/security/test_lesson_instructor_content.py
+++ b/lms/tests/security/test_lesson_instructor_content.py
@@ -1,0 +1,69 @@
+import json
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.test_helpers import BaseTestUtils
+from lms.lms.utils import get_lesson
+
+SECRET_MARKER = "ANSWER-KEY-8f21"
+
+
+def _editorjs(text):
+	return json.dumps(
+		{
+			"time": 1765194986690,
+			"blocks": [{"id": "abc123", "type": "markdown", "data": {"text": text}}],
+			"version": "2.29.0",
+		}
+	)
+
+
+class TestLessonInstructorContentLeak(BaseTestUtils, FrappeAPITestCase):
+	"""get_lesson must not return instructor-only fields to students or preview guests."""
+
+	SECRET_NOTES = "GRADING-NOTES-be-strict"
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"instr-{hash}@example.com", "Ada", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.student = self._create_user(f"stud-{hash}@example.com", "Sam", "Student", ["LMS Student"])
+
+		self.course = self._create_course(title=f"Leak Course {hash}", instructor=self.instructor.email)
+		self.chapter = self._create_chapter(f"Chapter {hash}", self.course.name)
+		self.lesson = self._create_lesson(f"Lesson {hash}", self.chapter.name, self.course.name)
+		# Preview + instructor-only content (content fields are EditorJS JSON blobs).
+		self.lesson.include_in_preview = 1
+		self.lesson.instructor_content = _editorjs(SECRET_MARKER)
+		self.lesson.instructor_notes = self.SECRET_NOTES
+		self.lesson.save()
+		self._create_chapter_reference(self.course.name, self.chapter.name, idx=1)
+		self._create_lesson_reference(self.chapter.name, self.lesson.name)
+		self._create_enrollment(self.student.email, self.course.name)
+
+	def _get(self, user):
+		frappe.session.user = user
+		try:
+			return get_lesson(self.course.name, 1, 1)
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_enrolled_student_does_not_receive_instructor_content(self):
+		result = self._get(self.student.email)
+		self.assertEqual(result.get("title"), self.lesson.title)  # gate passed
+		self.assertIsNone(result.get("instructor_content"))
+		self.assertIsNone(result.get("instructor_notes"))
+
+	def test_preview_guest_does_not_receive_instructor_content(self):
+		frappe.db.set_single_value("LMS Settings", "allow_guest_access", 1)
+		result = self._get("Guest")
+		self.assertIsNone(result.get("instructor_content"))
+		self.assertIsNone(result.get("instructor_notes"))
+
+	def test_instructor_receives_instructor_content(self):
+		result = self._get(self.instructor.email)
+		self.assertIn(SECRET_MARKER, result.get("instructor_content") or "")
+		self.assertEqual(result.get("instructor_notes"), self.SECRET_NOTES)

--- a/lms/tests/security/test_quiz_authorization.py
+++ b/lms/tests/security/test_quiz_authorization.py
@@ -1,0 +1,84 @@
+import json
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.test_helpers import BaseTestUtils
+from lms.lms.utils import get_quiz_with_questions
+
+
+def _quiz_block_content(quiz):
+	return json.dumps(
+		{
+			"time": 1765194986690,
+			"blocks": [{"id": "q1", "type": "quiz", "data": {"quiz": quiz}}],
+			"version": "2.29.0",
+		}
+	)
+
+
+class TestQuizAuthorization(BaseTestUtils, FrappeAPITestCase):
+	"""get_quiz_with_questions must require enrollment/ownership, not just an LMS role."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"qinstr-{hash}@example.com", "Ivy", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.enrolled = self._create_user(f"qstud-{hash}@example.com", "Ed", "Enrolled", ["LMS Student"])
+		self.outsider = self._create_user(f"qout-{hash}@example.com", "Ove", "Outsider", ["LMS Student"])
+
+		self.questions = self._create_quiz_questions()
+		self.quiz = self._create_quiz(title=f"Authz Quiz {hash}")
+		self.course = self._create_course(title=f"Quiz Course {hash}", instructor=self.instructor.email)
+		self.chapter = self._create_chapter(f"QChapter {hash}", self.course.name)
+		# Link the quiz to the course the way production does: embed it as a content block,
+		# which makes Course Lesson.save_lesson_details_in_quiz set LMS Quiz.course/lesson.
+		# (Course Lesson.quiz_id is a manual field that is never auto-populated.)
+		self.lesson = self._create_lesson(
+			f"QLesson {hash}", self.chapter.name, self.course.name, _quiz_block_content(self.quiz.name)
+		)
+		self._create_enrollment(self.enrolled.email, self.course.name)
+
+		# A second quiz never linked to any lesson or batch (e.g. mid-authoring).
+		self.unlinked_quiz = self._create_quiz(title=f"Unlinked Quiz {hash}")
+
+	def _call(self, user, quiz=None):
+		frappe.session.user = user
+		try:
+			return get_quiz_with_questions(quiz or self.quiz.name)
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_non_enrolled_user_cannot_read_quiz(self):
+		with self.assertRaises(frappe.PermissionError):
+			self._call(self.outsider.email)
+
+	def test_enrolled_student_can_read_quiz(self):
+		result = self._call(self.enrolled.email)
+		self.assertEqual(len(result["questions_by_name"]), len(self.questions))
+
+	def test_instructor_can_read_quiz(self):
+		result = self._call(self.instructor.email)
+		self.assertEqual(len(result["questions_by_name"]), len(self.questions))
+
+	def test_moderator_can_read_unlinked_quiz(self):
+		# Regression: an author/moderator must still reach a quiz not yet embedded anywhere.
+		result = self._call(self.instructor.email, quiz=self.unlinked_quiz.name)
+		self.assertEqual(len(result["questions_by_name"]), len(self.questions))
+
+	def test_non_enrolled_user_cannot_read_unlinked_quiz(self):
+		with self.assertRaises(frappe.PermissionError):
+			self._call(self.outsider.email, quiz=self.unlinked_quiz.name)
+
+	def test_non_string_quiz_is_rejected(self):
+		# A non-string quiz is rejected either by Frappe's whitelist type
+		# validation (FrappeTypeError, from the `quiz: str` annotation) or by
+		# our own isinstance guard (ValidationError) for non-whitelisted callers.
+		frappe.session.user = self.enrolled.email
+		try:
+			with self.assertRaises((frappe.ValidationError, frappe.FrappeTypeError)):
+				get_quiz_with_questions(["not", "a", "string"])
+		finally:
+			frappe.session.user = "Administrator"


### PR DESCRIPTION
## Summary
- Tightens server-side authorization on several LMS endpoints and doctypes so that each returns/accepts only what the current user is entitled to

## Changes
- Enforce enrollment/ownership when serving quiz content.
- Restrict instructor-only lesson fields to instructors.
- Bind course-progress records to the acting user and remove an over-broad create grant.
- Limit assignment grading fields to evaluators.
- Centralize the shared privileged-roles constant (no behavior change).