### PR TITLE
fix: miscellaneous fixes across payments, jobs, assignments, batches, and editor

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -11,6 +11,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AddressModal: typeof import('./src/components/Settings/Transactions/AddressModal.vue')['default']
     Apps: typeof import('./src/components/Sidebar/Apps.vue')['default']
     AppSidebar: typeof import('./src/components/Sidebar/AppSidebar.vue')['default']
     AssessmentModal: typeof import('./src/components/Modals/AssessmentModal.vue')['default']

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -47,7 +47,11 @@
 							:label="__('Save')"
 							combo="Mod+S"
 						>
-							<Button variant="solid" @click="submitAssignment()">
+							<Button
+								variant="solid"
+								:loading="isSubmitting"
+								@click="submitAssignment()"
+							>
 								{{ __('Save') }}
 							</Button>
 						</ShortcutTooltip>
@@ -284,7 +288,12 @@ watch(submissionResource, () => {
 	}
 })
 
+const isSubmitting = ref(false)
+
 const submitAssignment = () => {
+	if (isSubmitting.value) return
+	isSubmitting.value = true
+
 	if (props.submissionName != 'new') {
 		updateSubmission()
 	} else {
@@ -312,6 +321,7 @@ const addNewSubmission = () => {
 		toast.error(
 			__('Please provide an answer or upload a file before submitting.')
 		)
+		isSubmitting.value = false
 		return
 	}
 	call('frappe.client.insert', {
@@ -336,6 +346,9 @@ const addNewSubmission = () => {
 			toast.error(err.messages?.[0] || err)
 			console.error(err)
 		})
+		.finally(() => {
+			isSubmitting.value = false
+		})
 }
 
 const updateSubmission = () => {
@@ -355,9 +368,11 @@ const updateSubmission = () => {
 		{
 			onSuccess(data) {
 				isDirty.value = false
+				isSubmitting.value = false
 				toast.success(__('Changes saved successfully'))
 			},
 			onError(err) {
+				isSubmitting.value = false
 				toast.error(err.messages?.[0] || err)
 				console.error(err)
 			},

--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -7,6 +7,7 @@
 			class="mb-1.5"
 		/>
 		<Combobox
+			:open="isOpen"
 			:modelValue="value"
 			:options="resolvedOptions"
 			:placeholder="attrs.placeholder as string"
@@ -124,6 +125,7 @@ const valuePropPassed = computed<boolean>(() => 'value' in attrs)
 
 const creating = ref<boolean>(false)
 const newItemName = ref<string>('')
+const isOpen = ref<boolean>(false)
 let loaded = false
 
 const value = computed<string>(() =>
@@ -208,6 +210,7 @@ function reload(txt: string = ''): void {
 }
 
 function onOpen(open: boolean): void {
+	isOpen.value = open
 	if (open && !loaded) reload('')
 }
 
@@ -238,6 +241,8 @@ function handleCreate(): void {
 		creating.value = true
 		return
 	}
+	// Close the dropdown so it doesn't stack on top of the modal onCreate opens.
+	isOpen.value = false
 	props.onCreate?.(null)
 }
 

--- a/frontend/src/components/Notifications/NotificationPanel.vue
+++ b/frontend/src/components/Notifications/NotificationPanel.vue
@@ -156,11 +156,7 @@ const navigateToPage = (log) => {
 	if (link[2] == 'courses') {
 		router.push({ name: 'CourseDetail', params: { courseName: link[3] } })
 	} else if (link.includes('batches')) {
-		if (link.includes('details')) {
-			router.push({ name: 'BatchDetail', params: { batchName: link.pop() } })
-		} else {
-			router.push({ name: 'Batch', params: { batchName: link.pop() } })
-		}
+		router.push({ name: 'BatchDetail', params: { batchName: link.pop() } })
 	} else if (link.includes('assignment-submission')) {
 		router.push({
 			name: 'AssignmentSubmission',

--- a/frontend/src/components/RichTextEditor.vue
+++ b/frontend/src/components/RichTextEditor.vue
@@ -6,6 +6,8 @@
 		:placeholder="placeholder"
 		:upload-function="uploadFile"
 		format="html"
+		@focus="hasFocus = true"
+		@blur="hasFocus = false"
 	>
 		<template #default>
 			<EditorFixedMenu
@@ -128,10 +130,12 @@ function uploadFile(file: File) {
 }
 
 const html = ref(props.content ?? '')
+const hasFocus = ref(false)
 
 watch(
 	() => props.content,
 	(value) => {
+		if (hasFocus.value) return
 		if ((value ?? '') !== html.value) html.value = value ?? ''
 	}
 )

--- a/frontend/src/components/Settings/Transactions/AddressModal.vue
+++ b/frontend/src/components/Settings/Transactions/AddressModal.vue
@@ -1,0 +1,156 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{
+			title: __('New Address'),
+			size: 'xl',
+			actions: [
+				{
+					label: __('Create'),
+					variant: 'solid',
+					onClick: ({ close }) => createAddress(close),
+				},
+			],
+		}"
+	>
+		<template #body-content>
+			<div class="grid grid-cols-2 gap-5">
+				<FormControl
+					v-model="address.address_title"
+					:label="__('Address Title')"
+					type="text"
+					:required="true"
+				/>
+				<Select
+					v-model="address.address_type"
+					:label="__('Address Type')"
+					:options="addressTypeOptions"
+					:required="true"
+					class="w-full"
+				/>
+				<FormControl
+					v-model="address.address_line1"
+					:label="__('Address Line 1')"
+					type="text"
+					:required="true"
+				/>
+				<FormControl
+					v-model="address.address_line2"
+					:label="__('Address Line 2')"
+					type="text"
+				/>
+				<FormControl
+					v-model="address.city"
+					:label="__('City')"
+					type="text"
+					:required="true"
+				/>
+				<FormControl
+					v-model="address.state"
+					:label="__('State/Province')"
+					type="text"
+				/>
+				<Link
+					v-model="address.country"
+					:label="__('Country')"
+					doctype="Country"
+					:required="true"
+				/>
+				<FormControl
+					v-model="address.pincode"
+					:label="__('Postal Code')"
+					type="text"
+				/>
+				<FormControl
+					v-model="address.phone"
+					:label="__('Phone Number')"
+					type="text"
+				/>
+				<FormControl
+					v-model="address.email_id"
+					:label="__('Email Address')"
+					type="text"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+<script setup lang="ts">
+import { call, Dialog, FormControl, Select, toast } from 'frappe-ui'
+import { reactive, watch } from 'vue'
+import Link from '@/components/Controls/Link.vue'
+
+interface Address {
+	address_title: string
+	address_type: string
+	address_line1: string
+	address_line2: string
+	city: string
+	state: string
+	country: string
+	pincode: string
+	phone: string
+	email_id: string
+}
+
+const show = defineModel<boolean>('show')
+
+const emit = defineEmits<{
+	(e: 'created', name: string): void
+}>()
+
+const addressTypeOptions = [
+	'Billing',
+	'Shipping',
+	'Office',
+	'Personal',
+	'Postal',
+	'Other',
+]
+
+const emptyAddress = (): Address => ({
+	address_title: '',
+	address_type: 'Billing',
+	address_line1: '',
+	address_line2: '',
+	city: '',
+	state: '',
+	country: '',
+	pincode: '',
+	phone: '',
+	email_id: '',
+})
+
+const address = reactive<Address>(emptyAddress())
+
+watch(show, (isOpen) => {
+	if (isOpen) Object.assign(address, emptyAddress())
+})
+
+const createAddress = (close: () => void) => {
+	const missing = (
+		['address_title', 'address_line1', 'city', 'country'] as const
+	).find((field) => !address[field]?.trim())
+	if (missing) {
+		toast.error(
+			__('Address Title, Address Line 1, City and Country are required.')
+		)
+		return
+	}
+	call('frappe.client.insert', {
+		doc: {
+			doctype: 'Address',
+			...address,
+		},
+	})
+		.then((doc: { name: string }) => {
+			emit('created', doc.name)
+			close()
+			toast.success(__('Address created successfully'))
+		})
+		.catch((err: { messages?: string[] }) => {
+			toast.error(err.messages?.[0] || __('Error creating Address'))
+			console.error(err)
+		})
+}
+</script>

--- a/frontend/src/components/Settings/Transactions/TransactionDetails.vue
+++ b/frontend/src/components/Settings/Transactions/TransactionDetails.vue
@@ -142,6 +142,7 @@
 					v-model="transactionData.address"
 					doctype="Address"
 					:required="!!fieldMeta.address?.reqd"
+					:onCreate="() => (showAddressModal = true)"
 				/>
 				<FormControl
 					:label="__('GSTIN')"
@@ -165,6 +166,7 @@
 				/>
 			</div>
 		</div>
+		<AddressModal v-model:show="showAddressModal" @created="onAddressCreated" />
 	</SettingsLayout>
 </template>
 <script setup lang="ts">
@@ -174,9 +176,15 @@ import { computed, ref, watch } from 'vue'
 import Link from '@/components/Controls/Link.vue'
 import SettingsLayout from '@/components/Layouts/SettingsLayout.vue'
 import Select from '@/components/Controls/Select.vue'
+import AddressModal from '@/components/Settings/Transactions/AddressModal.vue'
 
 const router = useRouter()
 const transactionData = ref<{ [key: string]: any } | null>(null)
+const showAddressModal = ref<boolean>(false)
+
+const onAddressCreated = (name: string) => {
+	if (transactionData.value) transactionData.value.address = name
+}
 const emit = defineEmits(['updateStep'])
 const show = defineModel('show')
 

--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -539,13 +539,13 @@ const steps = reactive([
 			let batch = await getFirstBatch()
 			if (batch) {
 				router.push({
-					name: 'Batch',
+					name: 'BatchDetail',
 					params: {
 						batchName: batch,
 					},
 				})
 			} else {
-				router.push({ name: 'Batch' })
+				router.push({ name: 'Batches' })
 			}
 		},
 	},
@@ -560,14 +560,14 @@ const steps = reactive([
 			let batch = await getFirstBatch()
 			if (batch) {
 				router.push({
-					name: 'Batch',
+					name: 'BatchDetail',
 					params: {
 						batchName: batch,
 					},
 					hash: '#courses',
 				})
 			} else {
-				router.push({ name: 'Batch' })
+				router.push({ name: 'Batches' })
 			}
 		},
 	},

--- a/frontend/src/pages/Batches/components/BatchOverlay.vue
+++ b/frontend/src/pages/Batches/components/BatchOverlay.vue
@@ -110,9 +110,7 @@ import { Badge, Button, createResource, toast } from 'frappe-ui'
 import { formatNumberIntoCurrency, formatTime } from '@/utils'
 import DateRange from '@/components/Common/DateRange.vue'
 import VideoPreview from '@/components/VideoPreview.vue'
-import { useRouter } from 'vue-router'
 
-const router = useRouter()
 const user = inject('$user')
 const readOnlyMode = window.read_only_mode
 
@@ -135,18 +133,17 @@ const enroll = createResource({
 const enrollInBatch = () => {
 	if (!user.data) {
 		window.location.href = `/login?redirect-to=/batches/${props.batch.data.name}`
+		return
 	}
 	enroll.submit(
 		{},
 		{
 			onSuccess(data) {
 				toast.success(__('You have been enrolled in this batch'))
-				router.push({
-					name: 'Batch',
-					params: {
-						batchName: props.batch.data.name,
-					},
-				})
+				// BatchOverlay lives on the batch detail page, so navigating there is a
+				// no-op. Refetch the batch instead: once `students` includes the user,
+				// BatchDetail swaps the enroll view for the enrolled one reactively.
+				props.batch.reload()
 			},
 			onError(err) {
 				toast.error(__(err.messages?.[0] || err))

--- a/frontend/src/pages/Billing.vue
+++ b/frontend/src/pages/Billing.vue
@@ -257,9 +257,6 @@ const showConsentWarning = ref(false)
 const { capture } = useTelemetry()
 
 onMounted(() => {
-	const script = document.createElement('script')
-	script.src = `https://checkout.razorpay.com/v1/checkout.js`
-	document.body.appendChild(script)
 	if (user.data?.name) {
 		access.submit()
 	}
@@ -356,6 +353,12 @@ const generatePaymentLink = () => {
 				return validateAddress()
 			},
 			onSuccess(data) {
+				if (typeof data !== 'string' || !data) {
+					toast.error(
+						__('Could not start the payment. Please contact the administrator.')
+					)
+					return
+				}
 				capture('checkout_initiated', { type: props.type })
 				window.location.href = data
 			},

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -21,7 +21,7 @@
 				class="flex items-center gap-x-2"
 			>
 				<router-link
-					v-if="canManageJob && applicationCount.data > 0"
+					v-if="canManageJob && applicantCount > 0"
 					:to="{
 						name: 'JobApplications',
 						params: { job: job.data?.name },
@@ -118,14 +118,12 @@
 							</template>
 							{{ job.data.work_mode }}
 						</Badge>
-						<Badge v-if="applicationCount.data" size="lg">
+						<Badge v-if="applicantCount" size="lg">
 							<template #prefix>
 								<span class="lucide-square-user-round size-3 text-ink-gray-7" />
 							</template>
-							{{ applicationCount.data }}
-							{{
-								applicationCount.data == 1 ? __('applicant') : __('applicants')
-							}}
+							{{ applicantCount }}
+							{{ applicantCount == 1 ? __('applicant') : __('applicants') }}
 						</Badge>
 					</div>
 				</div>
@@ -199,24 +197,13 @@ const jobApplication = createResource({
 	},
 })
 
-const applicationCount = createResource({
-	url: 'frappe.client.get_count',
-	makeParams() {
-		return {
-			doctype: 'LMS Job Application',
-			filters: {
-				job: job.data?.name,
-			},
-		}
-	},
-})
+const applicantCount = computed(() => job.data?.applicants || 0)
 
 const stopWatch = watch(
 	() => [job.data?.name, user.data?.name],
 	([jobName, userName]) => {
 		if (jobName && userName) {
 			jobApplication.submit()
-			applicationCount.submit()
 			nextTick(() => stopWatch())
 		}
 	},

--- a/frontend/src/utils/assignment.js
+++ b/frontend/src/utils/assignment.js
@@ -2,7 +2,6 @@ import { Pencil } from 'lucide-vue-next'
 import { createApp, h } from 'vue'
 import AssessmentPlugin from '@/components/AssessmentPlugin.vue'
 import translationPlugin from '../translation'
-import { usersStore } from '@/stores/user'
 import { call } from 'frappe-ui'
 import router from '@/router'
 import { getLmsRoute } from '@/utils/basePath'
@@ -44,21 +43,19 @@ export class Assignment {
 
 	renderAssignment(assignment) {
 		if (this.readOnly) {
-			const { userResource } = usersStore()
-			call('frappe.client.get_value', {
-				doctype: 'LMS Assignment Submission',
-				filters: {
-					assignment: assignment,
-					member: userResource.data?.name,
-				},
-				fieldname: ['name'],
-			}).then((data) => {
-				let submission = data.name || 'new'
+			const renderSubmission = (submission) => {
 				const submissionPath = getLmsRoute(
-					`assignment-submission/${assignment}/${submission}?fromLesson=1`
+					`assignment-submission/${assignment}/${
+						submission || 'new'
+					}?fromLesson=1`
 				)
 				this.wrapper.innerHTML = `<iframe src="${submissionPath}" class="w-full h-[500px]"></iframe>`
+			}
+			call('lms.lms.api.get_own_assignment_submission', {
+				assignment: assignment,
 			})
+				.then(renderSubmission)
+				.catch(() => renderSubmission('new'))
 			return
 		}
 		call('frappe.client.get_value', {

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,6 +1,60 @@
 import { Code } from "lucide-vue-next"
 import { h, createApp } from "vue"
+// `lib/core` registers no languages, so every highlight call was a no-op; the
+// full build fixes that but bundles ~190 languages. Register only the ones the
+// picker offers (COMMON_LANGUAGES below) under their picker key, so bare-class
+// detection matches and apache/nginx/toml/http — which `lib/common` omits —
+// still highlight, without the long-tail bloat.
 import hljs from 'highlight.js/lib/core';
+import apache from 'highlight.js/lib/languages/apache';
+import bash from 'highlight.js/lib/languages/bash';
+import csharp from 'highlight.js/lib/languages/csharp';
+import cpp from 'highlight.js/lib/languages/cpp';
+import css from 'highlight.js/lib/languages/css';
+import coffeescript from 'highlight.js/lib/languages/coffeescript';
+import diff from 'highlight.js/lib/languages/diff';
+import go from 'highlight.js/lib/languages/go';
+import xml from 'highlight.js/lib/languages/xml';
+import http from 'highlight.js/lib/languages/http';
+import json from 'highlight.js/lib/languages/json';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import kotlin from 'highlight.js/lib/languages/kotlin';
+import less from 'highlight.js/lib/languages/less';
+import lua from 'highlight.js/lib/languages/lua';
+import makefile from 'highlight.js/lib/languages/makefile';
+import markdown from 'highlight.js/lib/languages/markdown';
+import nginx from 'highlight.js/lib/languages/nginx';
+import objectivec from 'highlight.js/lib/languages/objectivec';
+import php from 'highlight.js/lib/languages/php';
+import perl from 'highlight.js/lib/languages/perl';
+import properties from 'highlight.js/lib/languages/properties';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import scss from 'highlight.js/lib/languages/scss';
+import sql from 'highlight.js/lib/languages/sql';
+import shell from 'highlight.js/lib/languages/shell';
+import swift from 'highlight.js/lib/languages/swift';
+import ini from 'highlight.js/lib/languages/ini';
+import typescript from 'highlight.js/lib/languages/typescript';
+import yaml from 'highlight.js/lib/languages/yaml';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+
+// Register under canonical hljs names. Each module also declares its own aliases
+// (csharp -> `cs`, xml -> `html`, ini -> `toml`), so the picker keys used as the
+// block's class still resolve, and grammars that embed a sublanguage by its
+// canonical name (e.g. a ```xml markdown fence) find it too. `none` stays
+// unregistered so it falls through to hljs auto-detection.
+const HLJS_LANGUAGES: Record<string, any> = {
+	apache, bash, csharp, cpp, css, coffeescript, diff, go, xml, http,
+	json, java, javascript, kotlin, less, lua, makefile, markdown, nginx,
+	objectivec, php, perl, properties, python, ruby, rust, scss, sql, shell,
+	swift, ini, typescript, yaml, plaintext,
+};
+for (const [name, language] of Object.entries(HLJS_LANGUAGES)) {
+	hljs.registerLanguage(name, language);
+}
 
 
 const DEFAULT_THEMES = ['light', 'dark'];
@@ -91,17 +145,32 @@ export class CodeBox {
 		this.codeArea.setAttribute('class', `codeBoxTextArea ${this.config.useDefaultTheme} ${this.data.language}`);
 		this.codeArea.setAttribute('contenteditable', 'true');
 		this.codeArea.innerHTML = this.data.code;
-		this.api.listeners.on(this.codeArea, 'blur', event => this._highlightCodeArea(event), false);
 		this.api.listeners.on(this.codeArea, 'paste', event => this._handleCodeAreaPaste(event), false);
+
+		if (!this.readOnly) {
+			// `this.data.code` is the canonical un-highlighted source. Keep editing on
+			// clean source (focus strips display markup, input re-captures it) so
+			// save() never serializes hljs spans back into the stored code.
+			this.api.listeners.on(this.codeArea, 'focus', () => this._syncFromSource(), false);
+			this.api.listeners.on(this.codeArea, 'input', () => this._captureSource(), false);
+			this.api.listeners.on(this.codeArea, 'blur', event => this._onBlur(event), false);
+		}
 
 		codeAreaHolder.appendChild(this.codeArea);
 		!this.readOnly && codeAreaHolder.appendChild(languageSelect);
+
+		// Highlight saved blocks on load only in read-only (student) view. In edit
+		// mode the block is contenteditable, so highlighting is applied on blur /
+		// language change as display-only markup that save() never reads.
+		if (this.readOnly && this.data.code) this._highlightCodeArea();
 
 		return codeAreaHolder;
 	}
 
 	save(blockContent) {
-		return Object.assign(this.data, { code: this.codeArea.innerHTML, theme: this._getThemeURLFromConfig() });
+		// Return the canonical source, never the highlighted DOM. `this.data.code`
+		// is kept in sync by _captureSource on every edit and on blur.
+		return Object.assign(this.data, { theme: this._getThemeURLFromConfig() });
 	}
 
 	validate(savedData) {
@@ -111,7 +180,9 @@ export class CodeBox {
 
 	destroy() {
 		this.api.listeners.off(window, 'click', this._closeAllLanguageSelects, true);
-		this.api.listeners.off(this.codeArea, 'blur', event => this._highlightCodeArea(event), false);
+		this.api.listeners.off(this.codeArea, 'focus', () => this._syncFromSource(), false);
+		this.api.listeners.off(this.codeArea, 'input', () => this._captureSource(), false);
+		this.api.listeners.off(this.codeArea, 'blur', event => this._onBlur(event), false);
 		this.api.listeners.off(this.codeArea, 'paste', event => this._handleCodeAreaPaste(event), false);
 		this.api.listeners.off(this.selectInput, 'click', event => this._handleSelectInputClick(event), false);
 	}
@@ -150,8 +221,72 @@ export class CodeBox {
 		return selectHolder;
 	}
 
-	_highlightCodeArea(event) {
-		hljs.highlightBlock(this.codeArea);
+	_captureSource() {
+		// Canonical source is the un-highlighted innerHTML. Editing always happens on
+		// clean source (see _syncFromSource), so this never captures hljs markup.
+		this.data.code = this.codeArea.innerHTML;
+	}
+
+	_syncFromSource() {
+		// On focus, drop any display-only highlight markup so both the edit surface
+		// and the innerHTML that _captureSource reads stay on clean source. Preserve
+		// the caret across the rewrite so clicking into a highlighted block doesn't
+		// jump the cursor to the start.
+		if (this.codeArea.innerHTML === this.data.code) return;
+		const offset = this._getCaretOffset();
+		this.codeArea.innerHTML = this.data.code;
+		this._setCaretOffset(offset);
+	}
+
+	_getCaretOffset(): number | null {
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) return null;
+		const range = selection.getRangeAt(0);
+		if (!this.codeArea.contains(range.endContainer)) return null;
+		// Character count from the block's start to the caret. Highlight spans add
+		// no characters, so this offset maps cleanly onto the un-highlighted source.
+		const preCaret = range.cloneRange();
+		preCaret.selectNodeContents(this.codeArea);
+		preCaret.setEnd(range.endContainer, range.endOffset);
+		return preCaret.toString().length;
+	}
+
+	_setCaretOffset(offset: number | null) {
+		if (offset == null) return;
+		const selection = window.getSelection();
+		if (!selection) return;
+		const walker = document.createTreeWalker(this.codeArea, NodeFilter.SHOW_TEXT);
+		let remaining = offset;
+		for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+			const length = node.textContent?.length ?? 0;
+			if (remaining <= length) {
+				const range = document.createRange();
+				range.setStart(node, remaining);
+				range.collapse(true);
+				selection.removeAllRanges();
+				selection.addRange(range);
+				return;
+			}
+			remaining -= length;
+		}
+		// Offset past the end (e.g. empty block): place the caret at the end.
+		const range = document.createRange();
+		range.selectNodeContents(this.codeArea);
+		range.collapse(false);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	}
+
+	_onBlur(event) {
+		this._captureSource();
+		this._highlightCodeArea(event);
+	}
+
+	_highlightCodeArea(event?) {
+		// hljs skips elements it has already highlighted; saved blocks are
+		// re-highlighted on every render and after every edit.
+		this.codeArea.removeAttribute('data-highlighted');
+		hljs.highlightElement(this.codeArea);
 	}
 
 	_handleCodeAreaPaste(event) {
@@ -168,8 +303,8 @@ export class CodeBox {
 		this.codeArea.removeAttribute('class');
 		this.data.language = language[0];
 		this.codeArea.setAttribute('class', `codeBoxTextArea ${this.config.useDefaultTheme} ${this.data.language}`);
-	
-		hljs.highlightElement(this.codeArea);
+
+		this._highlightCodeArea();
 	}
 
 	_closeAllLanguageSelects() {

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -245,6 +245,28 @@ def get_job_details(job: str):
 	return job_details
 
 
+@frappe.whitelist(allow_guest=True)
+def get_own_assignment_submission(assignment: str):
+	"""Name of the current user's submission for an assignment, if any.
+
+	Mirrors the uniqueness rule enforced in LMS Assignment Submission.validate_duplicates,
+	which keys on `member`. A permission-filtered lookup (frappe.client.get_value) keys on
+	`owner` for students, so a submission created on the student's behalf reads back as
+	absent and the client tries to insert a duplicate.
+
+	Guest-allowed because the read-only assignment view renders on public lessons; a guest
+	owns no submission, so this returns None and the client routes to a new submission.
+	"""
+	if not isinstance(assignment, str):
+		frappe.throw(_("Assignment must be a string."))
+
+	return frappe.db.get_value(
+		"LMS Assignment Submission",
+		{"assignment": assignment, "member": frappe.session.user},
+		"name",
+	)
+
+
 @frappe.whitelist()
 def get_application_users(user_names: list | str):
 	# temp function workaround:reverting once upstream restores dotted-field JOINs in `frappe.client.get_list`

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -216,7 +216,10 @@ def verify_billing_access(doctype, name, billing_type):
 
 @frappe.whitelist(allow_guest=True)
 def get_job_details(job: str):
-	return frappe.db.get_value(
+	if not isinstance(job, str):
+		frappe.throw(_("Job must be a string."))
+
+	job_details = frappe.db.get_value(
 		"Job Opportunity",
 		job,
 		[
@@ -235,6 +238,11 @@ def get_job_details(job: str):
 		],
 		as_dict=1,
 	)
+
+	if job_details:
+		job_details.applicants = frappe.db.count("LMS Job Application", {"job": job})
+
+	return job_details
 
 
 @frappe.whitelist()

--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -53,10 +53,12 @@ class LMSAssignmentSubmission(Document):
 			"LMS Assignment Submission",
 			{"assignment": self.assignment, "member": self.member, "name": ["!=", self.name]},
 		):
-			lesson_title = frappe.db.get_value("Course Lesson", self.lesson, "title")
-			frappe.throw(
-				_("Assignment for Lesson {0} by {1} already exists.").format(lesson_title, self.member_name)
+			title = (
+				frappe.db.get_value("Course Lesson", self.lesson, "title")
+				if self.lesson
+				else frappe.db.get_value("LMS Assignment", self.assignment, "title")
 			)
+			frappe.throw(_("A submission for {0} by {1} already exists.").format(title, self.member_name))
 
 	def validate_url(self):
 		if self.type == "URL" and not validate_url(self.answer, True, ["http", "https"]):

--- a/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
+++ b/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
@@ -92,6 +92,9 @@ class LMSBatchEnrollment(Document):
 
 		for live_class in live_classes:
 			if live_class.event:
+				# Scoped bypass: adds only self.member to events of this batch's own live
+				# classes. A self-enrolling student has no create permission on Event
+				# Participants; the authorization boundary is enrollment creation itself.
 				frappe.get_doc(
 					{
 						"doctype": "Event Participants",
@@ -102,7 +105,7 @@ class LMSBatchEnrollment(Document):
 						"parenttype": "Event",
 						"parentfield": "event_participants",
 					}
-				).save()
+				).save(ignore_permissions=True)
 
 
 @frappe.whitelist()

--- a/lms/lms/payments.py
+++ b/lms/lms/payments.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 from lms.lms.utils import (
 	complete_enrollment,
@@ -6,21 +7,42 @@ from lms.lms.utils import (
 	get_order_summary,
 )
 
+GATEWAY_NOT_CONFIGURED_TITLE = "Payment Gateway Not Configured"
+
 
 def get_payment_gateway():
 	return frappe.db.get_single_value("LMS Settings", "payment_gateway")
 
 
 def get_controller(payment_gateway):
-	if "payments" in frappe.get_installed_apps():
-		from payments.utils import get_payment_gateway_controller
+	validate_payment_gateway(payment_gateway)
 
-		return get_payment_gateway_controller(payment_gateway)
+	from payments.utils import get_payment_gateway_controller
+
+	return get_payment_gateway_controller(payment_gateway)
 
 
-def validate_currency(payment_gateway, currency):
-	controller = get_controller(payment_gateway)
-	controller().validate_transaction_currency(currency)
+def validate_payment_gateway(payment_gateway):
+	"""Fail with an actionable message instead of a permission error from the payments app."""
+	if "payments" not in frappe.get_installed_apps():
+		frappe.throw(
+			_("The Payments app is not installed. Please contact the administrator."),
+			title=_(GATEWAY_NOT_CONFIGURED_TITLE),
+		)
+
+	if not payment_gateway:
+		frappe.throw(
+			_("No payment gateway is configured. Please contact the administrator."),
+			title=_(GATEWAY_NOT_CONFIGURED_TITLE),
+		)
+
+	if not frappe.db.exists("Payment Gateway", payment_gateway):
+		frappe.throw(
+			_("The configured payment gateway {0} does not exist. Please contact the administrator.").format(
+				frappe.bold(payment_gateway)
+			),
+			title=_(GATEWAY_NOT_CONFIGURED_TITLE),
+		)
 
 
 @frappe.whitelist()
@@ -47,6 +69,11 @@ def get_payment_link(
 	coupon = details.get("coupon")
 	total_amount = amount_with_gst if amount_with_gst else amount
 
+	# Resolve the controller before writing anything: get_controller validates the
+	# gateway and fails with an actionable message, so a misconfigured gateway
+	# doesn't leave an orphan Address / LMS Payment row behind.
+	controller = get_controller(payment_gateway) if total_amount > 0 else None
+
 	payment = record_payment(
 		address,
 		doctype,
@@ -65,8 +92,6 @@ def get_payment_link(
 		frappe.db.set_value("LMS Payment", payment.name, "payment_received", 1)
 		complete_enrollment(payment.name, doctype, docname)
 		return redirect_to
-
-	controller = get_controller(payment_gateway)
 
 	payment_details = {
 		"amount": total_amount,


### PR DESCRIPTION
## Summary

Fixes 7 bugs users hit across payments, jobs, assignments, batches, and the lesson editor, plus a small settings enhancement.

### Payments
- Show a clear error instead of crashing when the payment gateway isn't set up.
- Validate the gateway **before** writing any rows, surfacing an actionable error instead of a permission crash.
- Drop the dead Razorpay script.

(Closes #2457, closes #2458, closes #2459)

### Jobs
- Applicant count now matches between the list and detail pages.

(Closes #2562)

### Assignments
- Fix accidental duplicate submissions.
- Add a new `get_own_assignment_submission` endpoint keyed on member, plus a double-submit guard, to prevent duplicates.

(Closes #2284)

### Batches
- Enrolling now works even when the batch has a live class.
- Fix broken route names, add the participant to the live-class event with `ignore_permissions`, and refresh in place on enroll.

(Closes #2553, closes #2554)

### Editor
- Code blocks now get syntax highlighting — register hljs languages (code blocks were never highlighted).
- Autosave no longer overwrites what you're typing — guard autosave while the field has focus.

(Closes #2403, closes #2510, closes #2539)

### Settings
- Add a new address inline via a modal (wasn't possible before).