### PR TITLE
fix(editor): don't send null docname on lesson file upload

### DIFF
--- a/frontend/src/components/UploadPlugin.vue
+++ b/frontend/src/components/UploadPlugin.vue
@@ -20,22 +20,24 @@ const props = defineProps({
 		type: Function,
 		required: true,
 	},
-	docname: {
-		type: String,
-		default: null,
-	},
-	fieldname: {
-		type: String,
-		default: 'content',
+	uploadContext: {
+		type: Object,
+		default: () => ({}),
 	},
 })
 
-const uploadArgs = computed(() => ({
-	private: true,
-	doctype: 'Course Lesson',
-	docname: props.docname,
-	fieldname: props.fieldname,
-}))
+// Attach to the lesson only once it exists: a null docname with doctype set
+// makes the File doctype reject the upload.
+const uploadArgs = computed(() => {
+	const args = { private: true }
+	const docname = props.uploadContext?.docname
+	if (docname) {
+		args.doctype = 'Course Lesson'
+		args.docname = docname
+		args.fieldname = props.uploadContext?.fieldname || 'content'
+	}
+	return args
+})
 
 onMounted(async () => {
 	await nextTick()

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -121,11 +121,12 @@ function autoGrowTitle() {
 	el.style.height = `${el.scrollHeight}px`
 }
 
-const contentUploadContext = { docname: null, fieldname: 'content' }
-const instructorUploadContext = {
+// reactive so the upload block picks up `docname` once the lesson is saved.
+const contentUploadContext = reactive({ docname: null, fieldname: 'content' })
+const instructorUploadContext = reactive({
 	docname: null,
 	fieldname: 'instructor_content',
-}
+})
 const { capture } = useTelemetry()
 const { updateOnboardingStep } = useOnboarding('learning')
 

--- a/frontend/src/tests/UploadPlugin.test.ts
+++ b/frontend/src/tests/UploadPlugin.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Stub FileUploader so we can read the uploadArgs it receives.
+vi.mock('frappe-ui', () => ({
+	FileUploader: {
+		name: 'FileUploader',
+		props: ['uploadArgs', 'fileTypes', 'validateFile'],
+		template: '<div class="file-uploader" />',
+	},
+}))
+
+import { mount } from '@vue/test-utils'
+import { reactive, nextTick } from 'vue'
+import UploadPlugin from '@/components/UploadPlugin.vue'
+
+const mountPlugin = (uploadContext: any) =>
+	mount(UploadPlugin, {
+		props: { onFileUploaded: () => {}, uploadContext },
+		global: { mocks: { __: (s: string) => s } },
+	})
+
+const args = (wrapper: any) =>
+	wrapper.findComponent({ name: 'FileUploader' }).props('uploadArgs')
+
+describe('UploadPlugin — uploadArgs', () => {
+	it('omits doctype/docname when the lesson has no docname yet', () => {
+		const wrapper = mountPlugin({ docname: null, fieldname: 'content' })
+		const a = args(wrapper)
+		expect(a.private).toBe(true)
+		expect('doctype' in a).toBe(false)
+		expect('docname' in a).toBe(false)
+	})
+
+	it('attaches to the lesson when a docname is present', () => {
+		const wrapper = mountPlugin({
+			docname: 'lesson-123',
+			fieldname: 'content',
+		})
+		const a = args(wrapper)
+		expect(a.doctype).toBe('Course Lesson')
+		expect(a.docname).toBe('lesson-123')
+		expect(a.fieldname).toBe('content')
+	})
+
+	it('picks up a docname set on the live context after mount (lazy read)', async () => {
+		const context = reactive({ docname: null as string | null, fieldname: 'content' })
+		const wrapper = mountPlugin(context)
+		expect('docname' in args(wrapper)).toBe(false)
+
+		context.docname = 'lesson-456'
+		await nextTick()
+
+		const a = args(wrapper)
+		expect(a.doctype).toBe('Course Lesson')
+		expect(a.docname).toBe('lesson-456')
+	})
+})

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -82,8 +82,7 @@ export class Upload {
 
 	renderFileUploader() {
 		const app = createApp(UploadPlugin, {
-			docname: this.config.docname || null,
-			fieldname: this.config.fieldname || 'content',
+			uploadContext: this.config,
 			onFileUploaded: (file) => {
 				this.data.file_url = file.file_url
 				this.data.file_type = file.file_type


### PR DESCRIPTION
## Summary
- Uploading a file on a new, unsaved lesson failed with HTTP 417, because it tried to attach the file to a lesson that didn't exist yet.
- Now, if the lesson isn't saved yet, the file uploads as a standalone private file instead of failing.
- Once the lesson is saved, uploads attach to it as before.