### PR TITLE
fix: lesson code blocks render, highlight, and store correctly

### DIFF
--- a/frontend/src/tests/codeBox.test.ts
+++ b/frontend/src/tests/codeBox.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest'
+import CodeBox from '@/utils/code'
+
+const makeBox = (data: Record<string, any>, readOnly = true) =>
+	new CodeBox({
+		data,
+		api: { listeners: { on: vi.fn(), off: vi.fn() } },
+		config: {},
+		readOnly,
+	})
+
+const renderArea = (data: Record<string, any>, readOnly = true) => {
+	const holder = makeBox(data, readOnly).render()
+	return holder.querySelector('.codeBoxTextArea') as HTMLElement
+}
+
+describe('CodeBox legacy data normalization', () => {
+	it('preserves line breaks stored as <br> when highlighting', () => {
+		const area = renderArea({
+			code: 'def add(a, b):<br>    return a + b<br><br>print(add(1, 2))',
+			language: 'python',
+		})
+		expect(area.textContent).toBe(
+			'def add(a, b):\n    return a + b\n\nprint(add(1, 2))'
+		)
+	})
+
+	it('preserves line breaks stored as <div> rows', () => {
+		const area = renderArea({
+			code: 'line1<div>line2</div><div>line3</div>',
+			language: 'plaintext',
+		})
+		expect(area.textContent).toBe('line1\nline2\nline3')
+	})
+
+	it('strips pasted style markup, keeping its text', () => {
+		const area = renderArea({
+			code: '<span style="color:red">const</span> x = <b>1</b>',
+			language: 'javascript',
+		})
+		expect(area.textContent).toBe('const x = 1')
+	})
+
+	it('renders escaped markup as text, never as elements', () => {
+		const area = renderArea({
+			code: '&lt;img src=x onerror=alert(1)&gt;',
+			language: 'Auto-detect',
+		})
+		expect(area.querySelector('img')).toBeNull()
+		expect(area.textContent).toContain('<img src=x onerror=alert(1)>')
+	})
+
+	it('never re-normalizes plain-text data (format: text)', () => {
+		const area = renderArea({
+			code: 'if (a < b) { render("<div>") }',
+			format: 'text',
+			language: 'javascript',
+		})
+		expect(area.textContent).toBe('if (a < b) { render("<div>") }')
+	})
+})
+
+describe('CodeBox strict language highlighting', () => {
+	it('highlights the saved language', () => {
+		const area = renderArea({
+			code: 'def add(a, b):<br>    return a + b',
+			language: 'python',
+		})
+		const keywords = Array.from(area.querySelectorAll('.hljs-keyword')).map(
+			(el) => el.textContent
+		)
+		expect(keywords).toContain('def')
+	})
+
+	it('never auto-detects: legacy Auto-detect renders as plaintext', () => {
+		const box = makeBox({
+			code: 'def add(a, b):<br>    return a + b',
+			language: 'Auto-detect',
+		})
+		const area = box.render().querySelector('.codeBoxTextArea') as HTMLElement
+		// the stored language is preserved verbatim (resolution happens at render),
+		// so a later grammar registration can pick it back up
+		expect(box.data.language).toBe('Auto-detect')
+		expect(box.save(null).language).toBe('Auto-detect')
+		expect(area.querySelectorAll('[class*="hljs-"]').length).toBe(0)
+		expect(area.textContent).toBe('def add(a, b):\n    return a + b')
+	})
+
+	it('defaults new blocks to plaintext', () => {
+		const box = makeBox({ code: '' })
+		expect(box.data.language).toBe('plaintext')
+	})
+})
+
+describe('CodeBox save', () => {
+	it('saves normalized plain text flagged as format: text', () => {
+		const box = makeBox({
+			code: '<span style="font-family:Consolas">a</span><br>b',
+			language: 'python',
+		})
+		box.render()
+		const saved = box.save(null)
+		expect(saved.code).toBe('a\nb')
+		expect(saved.format).toBe('text')
+	})
+})
+
+describe('CodeBox theme styles', () => {
+	it('injects a self-hosted token palette instead of the CDN stylesheet', () => {
+		makeBox({ code: 'x = 1', language: 'python' })
+		const styleEl = document.getElementById('highlightJSCSSElement')
+		expect(styleEl?.tagName).toBe('STYLE')
+		expect(styleEl?.textContent).toContain('.codeBoxHolder')
+		expect(document.querySelector('link[href*="jsdelivr"]')).toBeNull()
+	})
+})
+
+describe('CodeBox editing surface', () => {
+	it('is plaintext-only editable in edit mode', () => {
+		const area = renderArea({ code: 'x', format: 'text' }, false)
+		expect(area.getAttribute('contenteditable')).toBe('plaintext-only')
+	})
+
+	it('is not editable in read-only mode', () => {
+		const area = renderArea({ code: 'x', format: 'text' }, true)
+		expect(area.hasAttribute('contenteditable')).toBe(false)
+	})
+
+	it('paste inserts the clipboard text/plain payload only', () => {
+		const box = makeBox({ code: '', format: 'text' }, false)
+		const area = box.render().querySelector('.codeBoxTextArea') as HTMLElement
+		document.body.appendChild(area.parentElement as HTMLElement)
+		const event = {
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+			clipboardData: {
+				getData: (type: string) =>
+					type === 'text/plain'
+						? 'plain\ncode'
+						: '<span style="color:red">styled</span>',
+			},
+		}
+		box._handleCodeAreaPaste(event)
+		expect(event.preventDefault).toHaveBeenCalled()
+		expect(box.data.code).toBe('plain\ncode')
+		expect(area.querySelector('span')).toBeNull()
+	})
+})
+
+describe('CodeBox caret visibility', () => {
+	it('bundled theme sets a visible caret color on the dark editing surface', () => {
+		makeBox({ code: 'x', format: 'text' }, false)
+		const styleEl = document.getElementById('highlightJSCSSElement')
+		expect(styleEl?.textContent).toMatch(
+			/\.codeBoxTextArea\.dark[^{]*\{[^}]*caret-color/
+		)
+	})
+})
+
+describe('CodeBox storage escaping (server sanitizer safety)', () => {
+	it('save() entity-escapes the plain text so nh3 cannot mangle it', () => {
+		const stored = 'a -&gt; b &amp;&amp; c &lt; d'
+		const box = makeBox({ code: stored, format: 'text', language: 'plaintext' }, false)
+		box.render()
+		expect(box.data.code).toBe('a -> b && c < d')
+		const saved = box.save(null)
+		expect(saved.code).toBe(stored)
+		expect(box.data.code).toBe('a -> b && c < d')
+	})
+
+	it('decodes stored entities on load (round-trip)', () => {
+		const area = renderArea({
+			code: '&lt;div class="x"&gt; &amp;&amp; a -&gt; b',
+			format: 'text',
+			language: 'plaintext',
+		})
+		expect(area.textContent).toBe('<div class="x"> && a -> b')
+	})
+})
+
+describe('CodeBox long lines', () => {
+	it('bundled theme makes the code area scroll horizontally inside the block', () => {
+		makeBox({ code: 'x', format: 'text' }, false)
+		const styleEl = document.getElementById('highlightJSCSSElement')
+		expect(styleEl?.textContent).toMatch(
+			/\.codeBoxHolder \.codeBoxTextArea[^{]*\{[^}]*overflow-x:\s*auto/
+		)
+	})
+})
+
+describe('CodeBox review fixes', () => {
+	it('converts legacy <p>/<li> block boundaries to line breaks', () => {
+		const p = renderArea({
+			code: '<p>line1</p><p>line2</p>',
+			language: 'plaintext',
+		})
+		expect(p.textContent).toBe('line1\nline2')
+		const li = renderArea({
+			code: 'intro<ul><li>x</li><li>y</li></ul>',
+			language: 'plaintext',
+		})
+		expect(li.textContent).toBe('intro\nx\ny')
+	})
+
+	it('decodes quote/backtick entities from storage (escapeHTML output)', () => {
+		const area = renderArea({
+			code: '&quot;hi&quot; &#39;s &#x27;t&#x27; &#x60;tick&#x60; &amp;lt;',
+			format: 'text',
+			language: 'plaintext',
+		})
+		expect(area.textContent).toBe('"hi" \'s \'t\' `tick` &lt;')
+	})
+
+	it('keeps an unregistered language verbatim but renders it as plaintext', () => {
+		const box = makeBox(
+			{ code: 'FROM alpine', format: 'text', language: 'dockerfile' },
+			false
+		)
+		const area = box.render().querySelector('.codeBoxTextArea') as HTMLElement
+		expect(box.data.language).toBe('dockerfile')
+		expect(box.save(null).language).toBe('dockerfile')
+		expect(area.querySelectorAll('[class*="hljs-"]').length).toBe(0)
+	})
+})
+
+describe('CodeBox review fixes, round 2', () => {
+	it('preserves a deliberate trailing blank line from legacy <br><br>', () => {
+		const area = renderArea({ code: 'end<br><br>', language: 'plaintext' })
+		expect(area.textContent).toBe('end\n\n')
+	})
+
+	it('does not double line breaks for nested legacy block wrappers', () => {
+		const area = renderArea({
+			code: '<ul><li><div>a</div></li><li>b</li></ul>',
+			language: 'plaintext',
+		})
+		expect(area.textContent).toBe('a\nb')
+	})
+
+	it('decodes every escapeHTML entity, including &#x3D;', () => {
+		const area = renderArea({
+			code: 'a &#x3D; b &#x60;t&#x60;',
+			format: 'text',
+			language: 'plaintext',
+		})
+		expect(area.textContent).toBe('a = b `t`')
+	})
+
+	it('custom theme configs keep their own <link> without evicting the bundled <style>', () => {
+		makeBox({ code: 'x', format: 'text' })
+		const style = document.getElementById('highlightJSCSSElement')
+		expect(style?.tagName).toBe('STYLE')
+		new CodeBox({
+			data: { code: 'y', format: 'text' },
+			api: { listeners: { on: vi.fn(), off: vi.fn() } },
+			config: { themeURL: 'https://example.test/theme.css' },
+			readOnly: true,
+		})
+		expect(document.getElementById('highlightJSCSSElement')?.tagName).toBe('STYLE')
+		const link = document.getElementById('highlightJSCSSLinkElement')
+		expect(link?.tagName).toBe('LINK')
+		expect(link?.getAttribute('href')).toBe('https://example.test/theme.css')
+	})
+})

--- a/frontend/src/tests/pasteHtml.test.ts
+++ b/frontend/src/tests/pasteHtml.test.ts
@@ -277,3 +277,51 @@ describe('_onNativePaste — routing', () => {
 		expect(block._insertMarkdownAsBlocks).not.toHaveBeenCalled()
 	})
 })
+
+describe('pasted code block language detection', () => {
+	it('reads language- class from an inner <code>', () => {
+		const blocks = parse('<pre><code class="language-python">x = 1</code></pre>')
+		expect(blocks[0].type).toBe('codeBox')
+		expect(blocks[0].data.language).toBe('python')
+	})
+
+	it('reads language- class from the <pre> itself (Prism markup)', () => {
+		const blocks = parse('<pre class="language-javascript"><code>let x</code></pre>')
+		expect(blocks[0].data.language).toBe('javascript')
+	})
+
+	it('reads lang- and brush: variants', () => {
+		expect(
+			parse('<pre><code class="lang-ruby">x</code></pre>')[0].data.language
+		).toBe('ruby')
+		expect(
+			parse('<pre class="brush: php">x</pre>')[0].data.language
+		).toBe('php')
+	})
+
+	it('falls back to plaintext when no language class is present', () => {
+		expect(parse('<pre>plain</pre>')[0].data.language).toBe('plaintext')
+	})
+})
+
+describe('pasted code language detection edge cases', () => {
+	it('ignores language- as a substring of an unrelated class', () => {
+		expect(
+			parse('<pre class="prism-language-toolbar">x</pre>')[0].data.language
+		).toBe('plaintext')
+	})
+
+	it('prefers the inner <code> language over a generic <pre> class', () => {
+		const blocks = parse(
+			'<pre class="language-markup"><code class="language-python">x = 1</code></pre>'
+		)
+		expect(blocks[0].data.language).toBe('python')
+	})
+
+	it('still reads a language- class on the <pre> when the inner <code> has none', () => {
+		expect(
+			parse('<pre class="language-javascript"><code>x</code></pre>')[0].data
+				.language
+		).toBe('javascript')
+	})
+})

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,10 +1,7 @@
 import { Code } from "lucide-vue-next"
 import { h, createApp } from "vue"
-// `lib/core` registers no languages, so every highlight call was a no-op; the
-// full build fixes that but bundles ~190 languages. Register only the ones the
-// picker offers (COMMON_LANGUAGES below) under their picker key, so bare-class
-// detection matches and apache/nginx/toml/http — which `lib/common` omits —
-// still highlight, without the long-tail bloat.
+import { HTML_ESCAPE_MAP } from "@/utils/format"
+// lib/core registers no languages; register just the picker's set to avoid bundling all ~190.
 import hljs from 'highlight.js/lib/core';
 import apache from 'highlight.js/lib/languages/apache';
 import bash from 'highlight.js/lib/languages/bash';
@@ -41,11 +38,7 @@ import typescript from 'highlight.js/lib/languages/typescript';
 import yaml from 'highlight.js/lib/languages/yaml';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 
-// Register under canonical hljs names. Each module also declares its own aliases
-// (csharp -> `cs`, xml -> `html`, ini -> `toml`), so the picker keys used as the
-// block's class still resolve, and grammars that embed a sublanguage by its
-// canonical name (e.g. a ```xml markdown fence) find it too. `none` stays
-// unregistered so it falls through to hljs auto-detection.
+// Canonical names; each module's aliases (cs, html, toml) resolve the picker keys too.
 const HLJS_LANGUAGES: Record<string, any> = {
 	apache, bash, csharp, cpp, css, coffeescript, diff, go, xml, http,
 	json, java, javascript, kotlin, less, lua, makefile, markdown, nginx,
@@ -57,23 +50,144 @@ for (const [name, language] of Object.entries(HLJS_LANGUAGES)) {
 }
 
 
+// Atom One Dark, self-hosted and scoped tightly to out-specify frappe-ui's .ProseMirror .hljs-* rules.
+const CODEBOX_THEME_CSS = `
+.codeBoxHolder { max-width: 100%; }
+.codeBoxHolder .codeBoxTextArea { overflow-x: auto; max-width: 100%; }
+.codeBoxHolder .codeBoxTextArea.dark.hljs { color: #abb2bf; background: #282c34; }
+.codeBoxHolder .codeBoxTextArea.dark { caret-color: #abb2bf; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-comment,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-quote { color: #5c6370; font-style: italic; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-doctag,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-keyword,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-formula { color: #c678dd; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-section,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-name,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-selector-tag,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-deletion,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-subst { color: #e06c75; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-literal { color: #56b6c2; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-string,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-regexp,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-addition,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-attribute,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-meta .hljs-string { color: #98c379; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-attr,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-variable,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-template-variable,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-type,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-selector-class,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-selector-attr,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-selector-pseudo,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-number { color: #d19a66; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-symbol,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-bullet,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-link,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-meta,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-selector-id,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-title { color: #61aeee; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-built_in,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-title.class_,
+.codeBoxHolder .codeBoxTextArea.dark .hljs-class .hljs-title { color: #e6c07b; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-emphasis { font-style: italic; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-strong { font-weight: bold; }
+.codeBoxHolder .codeBoxTextArea.dark .hljs-link { text-decoration: underline; }
+`;
+
+// Convert legacy contenteditable HTML to plain text: block tags -> line breaks,
+// <br> -> \n, inline tags stripped. DOMParser is inert (no scripts/loads).
+const LEGACY_BLOCK_TAGS = new Set([
+	'DIV', 'P', 'LI', 'UL', 'OL', 'PRE', 'BLOCKQUOTE', 'TABLE', 'TR', 'TD', 'TH',
+	'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'SECTION', 'ARTICLE',
+]);
+
+function legacyHTMLToPlainText(html: string): string {
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+	let text = '';
+	// A trailing \n from a block boundary is trimmed; an explicit <br> is kept.
+	let endsOnBlockBreak = false;
+	const walk = (node: Node) => {
+		for (const child of Array.from(node.childNodes)) {
+			if (child.nodeType === Node.TEXT_NODE) {
+				if (child.textContent) {
+					text += child.textContent;
+					endsOnBlockBreak = false;
+				}
+				continue;
+			}
+			if (child.nodeType !== Node.ELEMENT_NODE) continue;
+			const tag = (child as Element).tagName;
+			if (tag === 'BR') {
+				text += '\n';
+				endsOnBlockBreak = false;
+				continue;
+			}
+			const isBlock = LEGACY_BLOCK_TAGS.has(tag);
+			if (isBlock && text && !text.endsWith('\n')) text += '\n';
+			walk(child);
+			if (isBlock && text && !text.endsWith('\n')) {
+				text += '\n';
+				endsOnBlockBreak = true;
+			}
+		}
+	};
+	walk(doc.body);
+	return endsOnBlockBreak ? text.replace(/\n$/, '') : text;
+}
+
+// nh3 sanitizes the lesson content field on save, mangling raw < > &. Keep stored
+// code entity-escaped (nh3 preserves entities) and decode on load. New format:'text'
+// data must be escaped with escapeForStorage only.
+function escapeForStorage(text: string): string {
+	return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Reverses escapeHTML (derived from HTML_ESCAPE_MAP so they can't drift), plus numeric
+// synonyms. Broader than escapeForStorage on purpose: covers legacy escapeHTML-built data.
+const STORAGE_ENTITIES: Record<string, string> = {
+	...Object.fromEntries(
+		Object.entries(HTML_ESCAPE_MAP as Record<string, string>)
+			.map(([char, entity]) => [entity.toLowerCase(), char])
+	),
+	'&#34;': '"', '&#x22;': '"',
+	'&#x27;': "'",
+	'&#96;': '`',
+	'&#61;': '=',
+};
+const STORAGE_ENTITY_RE = new RegExp(`(?:${Object.keys(STORAGE_ENTITIES).join('|')})`, 'gi');
+
+function decodeFromStorage(stored: string): string {
+	// Leftmost-first: "&amp;lt;" -> "&lt;", never double-decoded.
+	return stored.replace(STORAGE_ENTITY_RE, (entity) =>
+		STORAGE_ENTITIES[entity.toLowerCase()] ?? entity);
+}
+
+// Honor a language only if hljs has the grammar; the raw value is stored so a
+// later registration can pick it up.
+function resolveCodeBoxLanguage(language: unknown): string {
+	return language && typeof language === 'string' && hljs.getLanguage(language)
+		? language
+		: 'plaintext';
+}
+
 const DEFAULT_THEMES = ['light', 'dark'];
 const COMMON_LANGUAGES = {
-	none: 'Auto-detect', apache: 'Apache', bash: 'Bash', cs: 'C#', cpp: 'C++', css: 'CSS', coffeescript: 'CoffeeScript', diff: 'Diff',
+	plaintext: 'Plaintext', apache: 'Apache', bash: 'Bash', cs: 'C#', cpp: 'C++', css: 'CSS', coffeescript: 'CoffeeScript', diff: 'Diff',
 	go: 'Go', html: 'HTML, XML', http: 'HTTP', json: 'JSON', java: 'Java', javascript: 'JavaScript', kotlin: 'Kotlin',
 	less: 'Less', lua: 'Lua', makefile: 'Makefile', markdown: 'Markdown', nginx: 'Nginx', objectivec: 'Objective-C',
 	php: 'PHP', perl: 'Perl', properties: 'Properties', python: 'Python', ruby: 'Ruby', rust: 'Rust', scss: 'SCSS',
 	sql: 'SQL', shell: 'Shell Session', swift: 'Swift', toml: 'TOML, also INI', typescript: 'TypeScript', yaml: 'YAML',
-	plaintext: 'Plaintext'
 };
 
 export class CodeBox {
 	api: any;
 	config: { themeName: any; themeURL: any; useDefaultTheme: any; };
 	readOnly: boolean;
-	data: { code: any; language: any; theme: any; };
+	data: { code: string; format: 'text'; language: string; theme: string; };
+	highlighted = false;
 	highlightScriptID: string;
 	highlightCSSID: string;
+	highlightCSSLinkID: string;
 	codeArea: HTMLDivElement;
 	selectInput: HTMLInputElement;
 	selectDropIcon: HTMLElement;
@@ -87,13 +201,16 @@ export class CodeBox {
 			useDefaultTheme: (config.useDefaultTheme && typeof config.useDefaultTheme === 'string'
 				&& DEFAULT_THEMES.includes(config.useDefaultTheme.toLowerCase())) ? config.useDefaultTheme : 'dark',
 		};
+		const rawCode = data.code && typeof data.code === 'string' ? data.code : '';
 		this.data = {
-			code: data.code && typeof data.code === 'string' ? data.code : '',
-			language: data.language && typeof data.language === 'string' ? data.language : 'Auto-detect',
+			code: data.format === 'text' ? decodeFromStorage(rawCode) : legacyHTMLToPlainText(rawCode),
+			format: 'text',
+			language: data.language && typeof data.language === 'string' ? data.language : 'plaintext',
 			theme: data.theme && typeof data.theme === 'string' ? data.theme : this._getThemeURLFromConfig(),
 		};
 		this.highlightScriptID = 'highlightJSScriptElement';
 		this.highlightCSSID = 'highlightJSCSSElement';
+		this.highlightCSSLinkID = 'highlightJSCSSLinkElement';
 		this.codeArea = document.createElement('div');
 		this.selectInput = document.createElement('input');
 		this.selectDropIcon = document.createElement('i');
@@ -110,6 +227,7 @@ export class CodeBox {
 	static get sanitize() {
 		return {
 			code: true,
+			format: false,
 			language: false,
 			theme: false,
 		}
@@ -143,14 +261,13 @@ export class CodeBox {
 
 		codeAreaHolder.setAttribute('class', 'codeBoxHolder');
 		this.codeArea.setAttribute('class', `codeBoxTextArea ${this.config.useDefaultTheme} ${this.data.language}`);
-		this.codeArea.setAttribute('contenteditable', 'true');
-		this.codeArea.innerHTML = this.data.code;
-		this.api.listeners.on(this.codeArea, 'paste', event => this._handleCodeAreaPaste(event), false);
+		this.codeArea.textContent = this.data.code;
 
 		if (!this.readOnly) {
-			// `this.data.code` is the canonical un-highlighted source. Keep editing on
-			// clean source (focus strips display markup, input re-captures it) so
-			// save() never serializes hljs spans back into the stored code.
+			// plaintext-only strips rich formatting; editing works on plain source so
+			// save() never stores hljs spans. Paste handler covers engines lacking it.
+			this.codeArea.setAttribute('contenteditable', 'plaintext-only');
+			this.api.listeners.on(this.codeArea, 'paste', event => this._handleCodeAreaPaste(event), false);
 			this.api.listeners.on(this.codeArea, 'focus', () => this._syncFromSource(), false);
 			this.api.listeners.on(this.codeArea, 'input', () => this._captureSource(), false);
 			this.api.listeners.on(this.codeArea, 'blur', event => this._onBlur(event), false);
@@ -159,18 +276,18 @@ export class CodeBox {
 		codeAreaHolder.appendChild(this.codeArea);
 		!this.readOnly && codeAreaHolder.appendChild(languageSelect);
 
-		// Highlight saved blocks on load only in read-only (student) view. In edit
-		// mode the block is contenteditable, so highlighting is applied on blur /
-		// language change as display-only markup that save() never reads.
-		if (this.readOnly && this.data.code) this._highlightCodeArea();
+		// Highlight on load in both modes; edit mode strips it back on focus.
+		if (this.data.code) this._highlightCodeArea();
 
 		return codeAreaHolder;
 	}
 
 	save(blockContent) {
-		// Return the canonical source, never the highlighted DOM. `this.data.code`
-		// is kept in sync by _captureSource on every edit and on blur.
-		return Object.assign(this.data, { theme: this._getThemeURLFromConfig() });
+		// Canonical plain source, entity-escaped for storage — never the highlighted DOM.
+		return Object.assign({}, this.data, {
+			code: escapeForStorage(this.data.code),
+			theme: this._getThemeURLFromConfig(),
+		});
 	}
 
 	validate(savedData) {
@@ -199,7 +316,8 @@ export class CodeBox {
 		this.selectInput.setAttribute('class', `codeBoxSelectInput ${this.config.useDefaultTheme}`);
 		this.selectInput.setAttribute('type', 'text');
 		this.selectInput.setAttribute('readonly', 'true');
-		this.selectInput.value = this.data.language;
+		this.selectInput.value =
+			(COMMON_LANGUAGES as Record<string, string>)[this.data.language] ?? this.data.language;
 		this.api.listeners.on(this.selectInput, 'click', event => this._handleSelectInputClick(event), false);
 
 		selectPreview.setAttribute('class', 'codeBoxSelectPreview');
@@ -222,19 +340,16 @@ export class CodeBox {
 	}
 
 	_captureSource() {
-		// Canonical source is the un-highlighted innerHTML. Editing always happens on
-		// clean source (see _syncFromSource), so this never captures hljs markup.
-		this.data.code = this.codeArea.innerHTML;
+		// innerText keeps rendered line breaks; textContent is the jsdom fallback.
+		this.data.code = this.codeArea.innerText ?? this.codeArea.textContent ?? '';
 	}
 
 	_syncFromSource() {
-		// On focus, drop any display-only highlight markup so both the edit surface
-		// and the innerHTML that _captureSource reads stay on clean source. Preserve
-		// the caret across the rewrite so clicking into a highlighted block doesn't
-		// jump the cursor to the start.
-		if (this.codeArea.innerHTML === this.data.code) return;
+		// On focus, strip highlight markup and restore the caret.
+		if (!this.highlighted) return;
 		const offset = this._getCaretOffset();
-		this.codeArea.innerHTML = this.data.code;
+		this.codeArea.textContent = this.data.code;
+		this.highlighted = false;
 		this._setCaretOffset(offset);
 	}
 
@@ -243,8 +358,7 @@ export class CodeBox {
 		if (!selection || selection.rangeCount === 0) return null;
 		const range = selection.getRangeAt(0);
 		if (!this.codeArea.contains(range.endContainer)) return null;
-		// Character count from the block's start to the caret. Highlight spans add
-		// no characters, so this offset maps cleanly onto the un-highlighted source.
+		// Highlight spans add no characters, so the char offset maps onto plain source.
 		const preCaret = range.cloneRange();
 		preCaret.selectNodeContents(this.codeArea);
 		preCaret.setEnd(range.endContainer, range.endOffset);
@@ -269,7 +383,7 @@ export class CodeBox {
 			}
 			remaining -= length;
 		}
-		// Offset past the end (e.g. empty block): place the caret at the end.
+		// Past the end: caret to end.
 		const range = document.createRange();
 		range.selectNodeContents(this.codeArea);
 		range.collapse(false);
@@ -283,14 +397,41 @@ export class CodeBox {
 	}
 
 	_highlightCodeArea(event?) {
-		// hljs skips elements it has already highlighted; saved blocks are
-		// re-highlighted on every render and after every edit.
-		this.codeArea.removeAttribute('data-highlighted');
-		hljs.highlightElement(this.codeArea);
+		// Highlight by the chosen language only; hljs.highlight escapes the source.
+		const result = hljs.highlight(this.data.code, { language: resolveCodeBoxLanguage(this.data.language) });
+		this.codeArea.innerHTML = result.value;
+		this.codeArea.classList.add('hljs');
+		this.highlighted = true;
 	}
 
 	_handleCodeAreaPaste(event) {
+		// Insert the plain-text payload only — no outside styling.
+		event.preventDefault();
 		event.stopPropagation();
+		const text = event.clipboardData?.getData('text/plain') ?? '';
+		if (text) {
+			// execCommand preserves native undo where supported.
+			const inserted = typeof document.execCommand === 'function'
+				&& document.execCommand('insertText', false, text);
+			if (!inserted) this._insertTextAtCaret(text);
+		}
+		this._captureSource();
+	}
+
+	_insertTextAtCaret(text: string) {
+		const selection = window.getSelection();
+		const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+		if (!selection || !range || !this.codeArea.contains(range.startContainer)) {
+			this.codeArea.appendChild(document.createTextNode(text));
+			return;
+		}
+		range.deleteContents();
+		const node = document.createTextNode(text);
+		range.insertNode(node);
+		range.setStartAfter(node);
+		range.collapse(true);
+		selection.removeAllRanges();
+		selection.addRange(range);
 	}
 
 	_handleSelectInputClick(event) {
@@ -313,18 +454,32 @@ export class CodeBox {
 	}
 
 	_injectHighlightJSCSSElement() {
-		const highlightJSCSSElement = document.querySelector(`#${this.highlightCSSID}`);
-		let highlightJSCSSURL = this._getThemeURLFromConfig();
-		if (!highlightJSCSSElement) {
-			const link = document.createElement('link');
-			const head = document.querySelector('head');
-			link.setAttribute('rel', 'stylesheet');
-			link.setAttribute('href', highlightJSCSSURL);
-			link.setAttribute('id', this.highlightCSSID);
+		const head = document.querySelector('head');
 
-			if (head) head.appendChild(link);
+		// Default theme is a bundled <style>; custom themes get a separate <link> id
+		// so instances with different configs don't evict each other.
+		if (!this.config.themeName && !this.config.themeURL) {
+			const existing = document.querySelector(`#${this.highlightCSSID}`);
+			if (existing?.tagName === 'STYLE') return;
+			existing?.remove(); // stale <link> from the old CDN theme
+			const style = document.createElement('style');
+			style.setAttribute('id', this.highlightCSSID);
+			style.textContent = CODEBOX_THEME_CSS;
+			if (head) head.appendChild(style);
+			return;
 		}
-		else highlightJSCSSElement.setAttribute('href', highlightJSCSSURL);
+
+		const highlightJSCSSURL = this._getThemeURLFromConfig();
+		const existingLink = document.querySelector(`#${this.highlightCSSLinkID}`);
+		if (existingLink?.tagName === 'LINK') {
+			existingLink.setAttribute('href', highlightJSCSSURL);
+			return;
+		}
+		const link = document.createElement('link');
+		link.setAttribute('rel', 'stylesheet');
+		link.setAttribute('href', highlightJSCSSURL);
+		link.setAttribute('id', this.highlightCSSLinkID);
+		if (head) head.appendChild(link);
 	}
 
 	_getThemeURLFromConfig() {

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -10,22 +10,20 @@ export const formatSeconds = (time) => {
 	return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`
 }
 
+// Single source of truth; decoders derive their inverse from this map.
+export const HTML_ESCAPE_MAP = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+	'`': '&#x60;',
+	'=': '&#x3D;',
+}
+
 export const escapeHTML = (text) => {
 	if (!text) return ''
-	let escape_html_mapping = {
-		'&': '&amp;',
-		'<': '&lt;',
-		'>': '&gt;',
-		'"': '&quot;',
-		"'": '&#39;',
-		'`': '&#x60;',
-		'=': '&#x3D;',
-	}
-
-	return String(text).replace(
-		/[&<>"'`=]/g,
-		(char) => escape_html_mapping[char]
-	)
+	return String(text).replace(/[&<>"'`=]/g, (char) => HTML_ESCAPE_MAP[char])
 }
 
 export const formatTimestamp = (seconds) => {

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -2,6 +2,13 @@ import { CodeXml } from 'lucide-vue-next'
 import { createApp, h } from 'vue'
 import { escapeHTML } from '@/utils/format'
 
+// Language-class hints on pasted code (hljs/Prism/SyntaxHighlighter). Anchored to
+// a class-token boundary so 'language-' matches only as its own class.
+const CODE_LANGUAGE_PATTERNS = [
+	/(?:^|\s)(?:language|lang)-([\w+#-]+)/i,
+	/(?:^|\s)brush:\s*([\w+#-]+)/i,
+]
+
 // Inline tags we keep when pasting rich HTML, normalized to the same tags the
 // editor's own inline tools emit. Everything else (span/font/div wrappers,
 // colors, styles) is dropped while its text is preserved. The stored content is
@@ -507,7 +514,7 @@ export class Markdown {
 					type: 'codeBox',
 					data: {
 						code: escapeHTML(node.textContent),
-						language: 'Auto-detect',
+						language: this._codeLanguageFrom(node),
 					},
 				})
 			} else if (/^H[1-6]$/.test(tag)) {
@@ -562,6 +569,19 @@ export class Markdown {
 
 		for (const child of doc.body.childNodes) handle(child)
 		return blocks
+	}
+
+	// Inner <code> carries the most specific hint, so check it before the <pre>.
+	_codeLanguageFrom(pre) {
+		for (const el of [pre.querySelector('code'), pre]) {
+			const className =
+				typeof el?.className === 'string' ? el.className : ''
+			for (const pattern of CODE_LANGUAGE_PATTERNS) {
+				const match = className.match(pattern)
+				if (match) return match[1]
+			}
+		}
+		return 'plaintext'
 	}
 
 	// True when a node carries visible text (nbsp-aware).


### PR DESCRIPTION
## Summary
- Reworks the lesson editor's code block (EditorJS CodeBox) so it renders and edits correctly.
- Code blocks were broken several ways: syntax highlighting never ran; once it did, multi-line blocks collapsed onto one line; token colors and the caret were unreadable on the dark background; pasting rich text dumped styled markup into the block; and long lines spilled across the page.

## Changes

- Store code as plain text (`format: 'text'`), entity-escaped so Frappe's sanitizer can't mangle it; legacy HTML blocks convert on load.
- Highlight strictly by the author's chosen language (Auto-detect removed, Plaintext default).
- Paste inserts plain text only; student view is no longer editable.
- Bundle the Atom One Dark theme locally (drops the CDN dependency) with a visible caret and horizontal scroll for long lines.
