### PR TITLE
fix(settings): checkbox toggle doesn't render until another field changes

### DIFF
--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -119,7 +119,7 @@
 							<BooleanSwitch
 								v-if="field.type == 'checkbox'"
 								size="sm"
-								v-model="field.value"
+								v-model="data[field.name]"
 							/>
 							<Link
 								v-else-if="field.type == 'Link'"
@@ -184,20 +184,9 @@ const fileName = (value) => {
 		: (url || '').split('/').pop()
 }
 
-const resolveInitialValue = (field, dataValue) => {
-	if (dataValue !== null && dataValue !== undefined && dataValue !== '') {
-		return field.type === 'checkbox' ? !!dataValue : dataValue
-	}
-	if (field.default !== undefined) {
-		return field.type === 'checkbox' ? !!field.default : field.default
-	}
-	return field.type === 'checkbox' ? false : ''
-}
-
-// Seed from the doc reactively, not just onMounted: the panel can mount before
-// the settings doc has loaded, in which case every checkbox would read false —
-// and the sync watcher below would then write that false straight back into the
-// doc, silently turning settings off.
+// Seed each checkbox's default into the doc when it loads empty, without
+// overwriting an already-saved value. Watches props.data because the panel can
+// mount before the settings doc has loaded.
 watch(
 	() => props.data,
 	(data) => {
@@ -205,28 +194,15 @@ watch(
 		props.sections.forEach((section) => {
 			section.columns.forEach((column) => {
 				column.fields.forEach((field) => {
-					field.value = resolveInitialValue(field, data[field.name])
-				})
-			})
-		})
-	},
-	{ immediate: true }
-)
-
-watch(
-	() => props.sections,
-	(newSections) => {
-		newSections.forEach((section) => {
-			section.columns.forEach((column) => {
-				column.fields.forEach((field) => {
 					if (field.type !== 'checkbox') return
-					if (props.data[field.name] != field.value) {
-						props.data[field.name] = field.value
+					const current = data[field.name]
+					if (current === null || current === undefined || current === '') {
+						data[field.name] = field.default ? 1 : 0
 					}
 				})
 			})
 		})
 	},
-	{ deep: true }
+	{ immediate: true }
 )
 </script>

--- a/frontend/src/tests/SettingFields.test.ts
+++ b/frontend/src/tests/SettingFields.test.ts
@@ -29,8 +29,8 @@ vi.mock('frappe-ui', () => ({
 	FileUploader: { template: '<div />' },
 	Button: { template: '<button />' },
 }))
-// Checkboxes use the project-local BooleanSwitch (v-modeled on field.value), not
-// the frappe-ui one — mock it so toggling emits update:modelValue.
+// Checkboxes use the project-local BooleanSwitch (v-modeled on data[field.name],
+// the persisted source of truth) — mock it so toggling emits update:modelValue.
 vi.mock('@/components/Controls/BooleanSwitch.vue', () => ({
 	default: {
 		props: ['modelValue'],
@@ -206,8 +206,8 @@ describe('SettingFields — Upload field renders both object and string values',
 	})
 })
 
-describe('SettingFields — defaults surface in the input when data is empty', () => {
-	it('uses field.default when data[field.name] is undefined', async () => {
+describe('SettingFields — checkbox defaults seed the persisted doc when empty', () => {
+	it('does not seed non-checkbox defaults into data (parity: numbers bind data directly)', async () => {
 		const sections = reactive([
 			{
 				columns: [
@@ -229,14 +229,12 @@ describe('SettingFields — defaults surface in the input when data is empty', (
 		await flushPromises()
 		await nextTick()
 
-		// After onMounted runs, field.value should be the default;
-		// the watcher (on the next mutation) is checkbox-only, but the
-		// resolveInitialValue helper sets field.value at mount time.
-		const field = sections[0].columns[0].fields[0] as any
-		expect(field.value).toBe(30)
+		// Number/text/select fields bind data[field.name] directly and are never
+		// seeded — matching prior behavior where an empty doc showed an empty input.
+		expect(data.lesson_dwell_time).toBeUndefined()
 	})
 
-	it('checkbox default of 1 maps to true', async () => {
+	it('checkbox default of 1 seeds data[field.name] = 1 (renders on)', async () => {
 		const sections = reactive([
 			{
 				columns: [
@@ -257,11 +255,13 @@ describe('SettingFields — defaults surface in the input when data is empty', (
 		const wrapper = mountFields(sections, data)
 		await flushPromises()
 
-		const field = sections[0].columns[0].fields[0] as any
-		expect(field.value).toBe(true)
+		expect(data.enforce_quiz_completion).toBe(1)
+		expect(wrapper.get('[data-testid="switch"]').attributes('data-checked')).toBe(
+			'true'
+		)
 	})
 
-	it('checkbox default of 0 maps to false', async () => {
+	it('checkbox default of 0 seeds data[field.name] = 0 (renders off)', async () => {
 		const sections = reactive([
 			{
 				columns: [
@@ -282,7 +282,34 @@ describe('SettingFields — defaults surface in the input when data is empty', (
 		const wrapper = mountFields(sections, data)
 		await flushPromises()
 
-		const field = sections[0].columns[0].fields[0] as any
-		expect(field.value).toBe(false)
+		expect(data.enforce_video_completion).toBe(0)
+		expect(wrapper.get('[data-testid="switch"]').attributes('data-checked')).toBe(
+			'false'
+		)
+	})
+
+	it('does not overwrite a saved checkbox value with its default', async () => {
+		const sections = reactive([
+			{
+				columns: [
+					{
+						fields: [
+							{
+								label: 'Enforce quiz',
+								name: 'enforce_quiz_completion',
+								type: 'checkbox',
+								default: 1,
+							},
+						],
+					},
+				],
+			},
+		])
+		// Saved as off; the default (1) must not flip it back on.
+		const data = reactive<Record<string, unknown>>({ enforce_quiz_completion: 0 })
+		const wrapper = mountFields(sections, data)
+		await flushPromises()
+
+		expect(data.enforce_quiz_completion).toBe(0)
 	})
 })


### PR DESCRIPTION
Clicking a Settings checkbox didn't flip the switch until another field changed.

It was the only field bound to `field.value` instead of `data[field.name]`, and reached the doc via two bridging watchers — so a toggle only rendered once some other `data` change forced a re-render.

Now the checkbox binds `data[field.name]` directly, and a single seeder fills a checkbox default only when the doc loads empty (never overwriting a saved value).
