### PR TITLE
fix : speed controls for youtube embed videos

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -809,6 +809,7 @@ const setupPlyrForVideo = (video, players) => {
 		'current-time',
 		'mute',
 		'volume',
+		'settings',
 		'fullscreen',
 	]
 


### PR DESCRIPTION
## Summary

Fixes #2585 

This PR enables playback speed controls for embedded YouTube videos.

Added the `settings` control to the Plyr controls array.

Before fix:
<img width="1600" height="837" alt="image" src="https://github.com/user-attachments/assets/9eeefeb9-2e85-483b-a7aa-887c0a616bdf" />

After fix:
<img width="1128" height="683" alt="image" src="https://github.com/user-attachments/assets/f446fd82-0bcc-47e4-8c13-07712f1cc244" />
