### PR TITLE
fix(styles): import frappe-ui list stylesheet explicitely

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import 'frappe-ui/style.css';
+@import 'frappe-ui/list-style.css';
 @import './styles/blockEditor.css';
 
 /* This build makes --surface-sidebar transparent in dark mode; point it at


### PR DESCRIPTION
- frappe-ui/style.css has none of the list structural rules (display:grid per row, column tracks, dividers). The frappe-ui/list barrel imports them as a side effect, but our Vite tree-shakes that away so import explicitly.

Issues
- Closes #2596