### PR TITLE
fix(lessons): inline pdf.js PDF viewer for iOS Safari + macro fixes

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -112,6 +112,7 @@ declare module 'vue' {
     PageModal: typeof import('./src/components/Modals/PageModal.vue')['default']
     PaymentGatewayDetails: typeof import('./src/components/Settings/PaymentGatewayDetails.vue')['default']
     PaymentGateways: typeof import('./src/components/Settings/PaymentGateways.vue')['default']
+    PdfBlock: typeof import('./src/components/PdfBlock.vue')['default']
     PersonaCard: typeof import('./src/components/Persona/PersonaCard.vue')['default']
     PersonaOutcomeStep: typeof import('./src/components/Persona/PersonaOutcomeStep.vue')['default']
     PersonaTagStep: typeof import('./src/components/Persona/PersonaTagStep.vue')['default']

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "lucide-static": "1.17.0",
     "lucide-vue-next": "0.383.0",
     "markdown-it": "14.0.0",
+    "pdfjs-dist": "4.10.38",
     "pinia": "2.0.33",
     "plyr": "3.7.8",
     "socket.io-client": "4.7.2",
@@ -49,6 +50,7 @@
     "unplugin-auto-import": "^20.3.0",
     "vite": "5.0.11",
     "vite-plugin-pwa": "^1.2.0",
+    "vite-plugin-static-copy": "^1.0.6",
     "vitest": "^4.1.7"
   }
 }

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -34,13 +34,7 @@
 			</video>
 		</div>
 		<div v-else-if="block.includes('{{ PDF')">
-			<iframe
-				:src="getPDFSource(block)"
-				width="100%"
-				height="700px"
-				frameborder="0"
-				allowfullscreen
-			></iframe>
+			<PdfBlock :file="getId(block)" />
 		</div>
 		<div v-else-if="block.includes('{{ Audio')">
 			<audio width="100%" controls controlsList="nodownload">
@@ -65,9 +59,11 @@
 </template>
 <script setup>
 import Quiz from '@/components/QuizBlock.vue'
+import PdfBlock from '@/components/PdfBlock.vue'
 import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import { useScreenSize } from '@/utils/composables'
+import { getMacroArg } from '@/utils/lessonMacros'
 
 const screenSize = useScreenSize()
 
@@ -100,11 +96,9 @@ const getYouTubeVideoSource = (block) => {
 	return `https://www.youtube.com/embed/${block}`
 }
 
-const getPDFSource = (block) => {
-	return `${getId(block)}#toolbar=0`
-}
-
 const getId = (block) => {
-	return block.match(/\(["']([^"']+?)["']\)/)[1]
+	// Guard the match: a malformed `{{ PDF() }}` / unbalanced-quote macro yields
+	// null, and the old unguarded [1] threw and killed the whole lesson render.
+	return getMacroArg(block) ?? ''
 }
 </script>

--- a/frontend/src/components/PdfBlock.vue
+++ b/frontend/src/components/PdfBlock.vue
@@ -1,0 +1,487 @@
+<template>
+	<div class="pdf-block mb-4">
+		<div class="pdf-toolbar">
+			<div class="pdf-toolbar-group">
+				<button
+					type="button"
+					class="pdf-btn"
+					:disabled="loading || !!error || currentPage <= 1"
+					aria-label="Previous page"
+					@click="goToPage(currentPage - 1)"
+				>
+					<ChevronLeft :size="18" :stroke-width="1.5" />
+				</button>
+				<span class="pdf-page-indicator">
+					<template v-if="numPages"
+						>{{ currentPage }} / {{ numPages }}</template
+					>
+					<template v-else>—</template>
+				</span>
+				<button
+					type="button"
+					class="pdf-btn"
+					:disabled="loading || !!error || currentPage >= numPages"
+					aria-label="Next page"
+					@click="goToPage(currentPage + 1)"
+				>
+					<ChevronRight :size="18" :stroke-width="1.5" />
+				</button>
+			</div>
+			<div class="pdf-toolbar-group">
+				<button
+					type="button"
+					class="pdf-btn"
+					:disabled="loading || !!error"
+					aria-label="Zoom out"
+					@click="zoomOut"
+				>
+					<ZoomOut :size="18" :stroke-width="1.5" />
+				</button>
+				<button
+					type="button"
+					class="pdf-btn"
+					:disabled="loading || !!error"
+					aria-label="Fit width"
+					@click="fitWidth"
+				>
+					<Maximize2 :size="16" :stroke-width="1.5" />
+				</button>
+				<button
+					type="button"
+					class="pdf-btn"
+					:disabled="loading || !!error"
+					aria-label="Zoom in"
+					@click="zoomIn"
+				>
+					<ZoomIn :size="18" :stroke-width="1.5" />
+				</button>
+				<a
+					class="pdf-btn"
+					:href="file"
+					target="_blank"
+					rel="noopener"
+					aria-label="Open in new tab"
+				>
+					<ExternalLink :size="16" :stroke-width="1.5" />
+				</a>
+			</div>
+		</div>
+
+		<div ref="scrollEl" class="pdf-scroll" @scroll.passive="scheduleUpdate">
+			<div v-if="loading" class="pdf-status">
+				<Loader2 :size="20" :stroke-width="1.5" class="pdf-spin" />
+				<span>Loading PDF…</span>
+			</div>
+			<div v-else-if="error" class="pdf-status pdf-error">
+				<span>{{ error }}</span>
+				<a
+					class="pdf-fallback-link"
+					:href="file"
+					target="_blank"
+					rel="noopener"
+				>
+					Open the PDF in a new tab
+				</a>
+			</div>
+			<div
+				v-for="(meta, i) in pageMeta"
+				v-else
+				:key="i"
+				:ref="(el) => setPageEl(el, i)"
+				class="pdf-page"
+				:style="{
+					width: Math.floor(meta.width * scale) + 'px',
+					height: Math.floor(meta.height * scale) + 'px',
+				}"
+			>
+				<canvas :ref="(el) => setCanvasEl(el, i)"></canvas>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue'
+import { createPdfWorker } from '@/utils/pdfWorker'
+import {
+	ChevronLeft,
+	ChevronRight,
+	ZoomIn,
+	ZoomOut,
+	Maximize2,
+	ExternalLink,
+	Loader2,
+} from 'lucide-vue-next'
+
+const props = defineProps({
+	file: { type: String, required: true },
+})
+
+// iOS Safari blanks a canvas past its area/memory limit — pdf.js's own failure
+// mode on large or high-DPI pages. Cap the backing store to pdf.js's default.
+const MAX_CANVAS_PIXELS = 16_777_216
+const MIN_SCALE = 0.25
+const MAX_SCALE = 5
+
+const scrollEl = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const numPages = ref(0)
+const currentPage = ref(1)
+const scale = ref(1)
+const pageMeta = ref([]) // per-page { width, height } at scale 1
+
+// Heavy pdf.js objects are kept out of Vue reactivity on purpose.
+let pdfjsLib = null
+let pdfDoc = null
+let pageEls = []
+let canvasEls = []
+let renderTasks = [] // active RenderTask per page index
+let rendered = [] // bool per page index
+let rafId = null
+
+// --- shared, ref-counted worker (multi-instance safe; terminated on last unmount) ---
+// A leaked pdf.js worker is worse than a leaked <audio>, so we always release it.
+// The ref is taken synchronously at mount and dropped on unmount, so an unmount
+// that races an in-flight load() can never strand a ref (and its worker).
+let heldWorker = false
+let disposed = false
+
+function setPageEl(el, i) {
+	if (el) pageEls[i] = el
+}
+function setCanvasEl(el, i) {
+	if (el) canvasEls[i] = el
+}
+
+async function load() {
+	try {
+		// Dynamic import: there is no manualChunks here, so a static import would
+		// fold ~144kB gzip of pdf.js into the main entry that every LMS page pays.
+		pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs')
+		if (disposed) return
+		if (sharedWorker) pdfjsLib.GlobalWorkerOptions.workerPort = sharedWorker
+
+		const base = import.meta.env.BASE_URL || '/'
+		const loadingTask = pdfjsLib.getDocument({
+			url: props.file,
+			cMapUrl: `${base}pdfjs/cmaps/`,
+			cMapPacked: true,
+			standardFontDataUrl: `${base}pdfjs/standard_fonts/`,
+		})
+		pdfDoc = await loadingTask.promise
+		if (disposed) return
+		numPages.value = pdfDoc.numPages
+
+		// Fetch each page's intrinsic size (metadata only, no render) so the
+		// continuous-scroll placeholders have correct heights up front.
+		const meta = []
+		for (let n = 1; n <= pdfDoc.numPages; n++) {
+			const page = await pdfDoc.getPage(n)
+			const vp = page.getViewport({ scale: 1 })
+			meta.push({ width: vp.width, height: vp.height })
+		}
+		if (disposed) return
+		pageMeta.value = meta
+		renderTasks = new Array(meta.length).fill(null)
+		rendered = new Array(meta.length).fill(false)
+		loading.value = false
+
+		await nextFrame()
+		if (disposed) return
+		fitWidth()
+	} catch (e) {
+		loading.value = false
+		error.value = 'This PDF could not be displayed.'
+		// eslint-disable-next-line no-console
+		console.error('PdfBlock: failed to load PDF', e)
+	}
+}
+
+// Synchronous so the ref is taken at mount, before load()'s first await — the
+// GlobalWorkerOptions.workerPort wiring happens later in load() once pdf.js is
+// imported. pdf.js falls back to its main-thread worker if none is available.
+function acquireWorker() {
+	if (heldWorker) return
+	heldWorker = true
+	sharedWorkerRefs++
+	if (!sharedWorker) {
+		try {
+			sharedWorker = createPdfWorker()
+		} catch (e) {
+			// No worker (blocked / unsupported) -> pdf.js falls back to its
+			// main-thread fake worker. Slower, but the viewer still works.
+			sharedWorker = null
+			// eslint-disable-next-line no-console
+			console.warn('PdfBlock: pdf.js worker unavailable', e)
+		}
+	}
+}
+
+function releaseWorker() {
+	if (!heldWorker) return
+	heldWorker = false
+	sharedWorkerRefs = Math.max(0, sharedWorkerRefs - 1)
+	if (sharedWorkerRefs === 0 && sharedWorker) {
+		sharedWorker.terminate()
+		sharedWorker = null
+		if (pdfjsLib) pdfjsLib.GlobalWorkerOptions.workerPort = null
+	}
+}
+
+async function renderPage(i) {
+	if (rendered[i] || renderTasks[i]) return
+	const canvas = canvasEls[i]
+	if (!canvas || !pdfDoc) return
+	rendered[i] = true // claim the slot before awaiting to avoid double-render races
+	try {
+		const page = await pdfDoc.getPage(i + 1)
+		const viewport = page.getViewport({ scale: scale.value })
+
+		let outputScale = window.devicePixelRatio || 1
+		let bw = Math.floor(viewport.width * outputScale)
+		let bh = Math.floor(viewport.height * outputScale)
+		if (bw * bh > MAX_CANVAS_PIXELS) {
+			outputScale *= Math.sqrt(MAX_CANVAS_PIXELS / (bw * bh))
+			bw = Math.floor(viewport.width * outputScale)
+			bh = Math.floor(viewport.height * outputScale)
+		}
+		canvas.width = bw
+		canvas.height = bh
+		canvas.style.width = Math.floor(viewport.width) + 'px'
+		canvas.style.height = Math.floor(viewport.height) + 'px'
+
+		const task = page.render({
+			canvasContext: canvas.getContext('2d'),
+			viewport,
+			transform:
+				outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null,
+		})
+		renderTasks[i] = task
+		await task.promise
+		renderTasks[i] = null
+	} catch (e) {
+		renderTasks[i] = null
+		rendered[i] = false
+		// RenderingCancelledException on scale change / teardown is expected.
+		if (e?.name !== 'RenderingCancelledException') {
+			// eslint-disable-next-line no-console
+			console.error('PdfBlock: failed to render page', i + 1, e)
+		}
+	}
+}
+
+function clearPage(i) {
+	const task = renderTasks[i]
+	if (task) {
+		task.cancel()
+		renderTasks[i] = null
+	}
+	rendered[i] = false
+	const canvas = canvasEls[i]
+	if (canvas) {
+		canvas.width = 0
+		canvas.height = 0
+	}
+}
+
+// Render pages within a screenful of the viewport, clear the rest, and track
+// the most-visible page as `currentPage`. Bounds memory so iOS doesn't OOM.
+function updateVisible() {
+	const el = scrollEl.value
+	if (!el || loading.value || error.value) return
+	const cRect = el.getBoundingClientRect()
+	const margin = cRect.height
+	let best = { i: 0, area: -1 }
+	for (let i = 0; i < pageEls.length; i++) {
+		const pel = pageEls[i]
+		if (!pel) continue
+		const r = pel.getBoundingClientRect()
+		const near =
+			r.bottom >= cRect.top - margin && r.top <= cRect.bottom + margin
+		if (near) renderPage(i)
+		else clearPage(i)
+		const visible =
+			Math.min(r.bottom, cRect.bottom) - Math.max(r.top, cRect.top)
+		if (visible > best.area) best = { i, area: visible }
+	}
+	currentPage.value = best.i + 1
+}
+
+function scheduleUpdate() {
+	if (rafId != null) return
+	rafId = requestAnimationFrame(() => {
+		rafId = null
+		updateVisible()
+	})
+}
+
+function nextFrame() {
+	return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+function relayout() {
+	// scale changed: drop every canvas, then re-render what's on screen.
+	for (let i = 0; i < pageEls.length; i++) clearPage(i)
+	scheduleUpdate()
+}
+
+function setScale(next) {
+	const clamped = Math.min(MAX_SCALE, Math.max(MIN_SCALE, next))
+	if (clamped === scale.value) return
+	scale.value = clamped
+	nextFrame().then(relayout)
+}
+
+function zoomIn() {
+	setScale(scale.value * 1.25)
+}
+function zoomOut() {
+	setScale(scale.value * 0.8)
+}
+function fitWidth() {
+	const el = scrollEl.value
+	if (!el || !pageMeta.value.length) return
+	const widest = Math.max(...pageMeta.value.map((m) => m.width))
+	// leave room for scrollbar / padding
+	const avail = el.clientWidth - 24
+	if (widest > 0 && avail > 0) setScale(avail / widest)
+}
+
+function goToPage(n) {
+	const target = Math.min(numPages.value, Math.max(1, n))
+	const pel = pageEls[target - 1]
+	const el = scrollEl.value
+	if (pel && el) {
+		el.scrollTop = pel.offsetTop
+		currentPage.value = target
+		scheduleUpdate()
+	}
+}
+
+acquireWorker()
+load()
+
+onBeforeUnmount(() => {
+	disposed = true
+	if (rafId != null) cancelAnimationFrame(rafId)
+	for (let i = 0; i < renderTasks.length; i++) {
+		try {
+			renderTasks[i]?.cancel()
+		} catch (e) {
+			/* already settled */
+		}
+	}
+	renderTasks = []
+	try {
+		pdfDoc?.destroy()
+	} catch (e) {
+		/* noop */
+	}
+	pdfDoc = null
+	releaseWorker()
+})
+
+defineExpose({ fitWidth, goToPage })
+</script>
+
+<script>
+// Module-scoped so every PdfBlock instance shares one pdf.js worker.
+let sharedWorker = null
+let sharedWorkerRefs = 0
+</script>
+
+<style scoped>
+.pdf-block {
+	border: 1px solid var(--gray-200, #e5e7eb);
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--gray-50, #f9fafb);
+}
+.pdf-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 6px 8px;
+	border-bottom: 1px solid var(--gray-200, #e5e7eb);
+	background: var(--white, #fff);
+}
+.pdf-toolbar-group {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+.pdf-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 28px;
+	min-width: 28px;
+	padding: 0 6px;
+	border-radius: 6px;
+	color: var(--gray-700, #374151);
+	background: transparent;
+	cursor: pointer;
+	border: none;
+}
+.pdf-btn:hover:not(:disabled) {
+	background: var(--gray-100, #f3f4f6);
+}
+.pdf-btn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.pdf-page-indicator {
+	min-width: 56px;
+	text-align: center;
+	font-size: 13px;
+	color: var(--gray-700, #374151);
+	font-variant-numeric: tabular-nums;
+}
+.pdf-scroll {
+	height: 700px;
+	max-height: 80vh;
+	overflow: auto;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	padding: 12px;
+	/* Keep the browser's native pinch-zoom and panning on touch devices. */
+	touch-action: pan-x pan-y pinch-zoom;
+	-webkit-overflow-scrolling: touch;
+}
+.pdf-page {
+	background: var(--white, #fff);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+	flex: 0 0 auto;
+}
+.pdf-page canvas {
+	display: block;
+}
+.pdf-status {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 40px 12px;
+	color: var(--gray-600, #4b5563);
+	font-size: 14px;
+}
+.pdf-error {
+	flex-direction: column;
+}
+.pdf-fallback-link,
+.pdf-status a {
+	color: var(--blue-600, #2563eb);
+	text-decoration: underline;
+}
+.pdf-spin {
+	animation: pdf-spin 1s linear infinite;
+}
+@keyframes pdf-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -91,6 +91,7 @@ import { ChevronRight, NotebookPen } from 'lucide-vue-next'
 import { useDebounceFn } from '@vueuse/core'
 import { enablePlyr, sanitizeEditorJs } from '@/utils'
 import { hasEditorContent, shouldSkipLessonSave } from '@/utils/lessonForm'
+import { convertBodyToBlocks as convertToJSON } from '@/utils/lessonMacros'
 import { hasVideoContent } from '@/utils/video'
 import BlockEditor from '@/components/BlockEditor.vue'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
@@ -335,114 +336,6 @@ const lessonReference = createResource({
 		}
 	},
 })
-
-const convertToJSON = (lessonData) => {
-	let blocks = []
-	// Dedupe a video shared by the youtube field and body macro.
-	const seenYoutube = new Set()
-	const youtubeKey = (url) => url.split('/').pop().split('?')[0]
-	const pushYoutube = (embedUrl) => {
-		const key = youtubeKey(embedUrl)
-		if (seenYoutube.has(key)) return
-		seenYoutube.add(key)
-		blocks.push({
-			type: 'embed',
-			data: { service: 'youtube', embed: embedUrl },
-		})
-	}
-	if (lessonData.youtube) {
-		let youtubeID = lessonData.youtube.split('/').pop()
-		pushYoutube(`https://www.youtube.com/embed/${youtubeID}`)
-	}
-	lessonData.body.split('\n').forEach((block) => {
-		if (block.includes('{{ YouTubeVideo')) {
-			let youtubeID = block.match(/\(["']([^"']+?)["']\)/)[1]
-			if (!youtubeID.includes('https://'))
-				youtubeID = `https://www.youtube.com/embed/${youtubeID}`
-			pushYoutube(youtubeID)
-		} else if (block.includes('{{ Quiz')) {
-			let quiz = block.match(/\(["']([^"']+?)["']\)/)[1]
-			blocks.push({
-				type: 'quiz',
-				data: {
-					quiz: quiz,
-				},
-			})
-		} else if (block.includes('{{ Video')) {
-			let video = block.match(/\(["']([^"']+?)["']\)/)[1]
-			blocks.push({
-				type: 'upload',
-				data: {
-					file_url: video,
-					file_type: video.split('.').pop(),
-				},
-			})
-		} else if (block.includes('{{ Audio')) {
-			let audio = block.match(/\(["']([^"']+?)["']\)/)[1]
-			blocks.push({
-				type: 'upload',
-				data: {
-					file_url: audio,
-					file_type: audio.split('.').pop(),
-				},
-			})
-		} else if (block.includes('{{ PDF')) {
-			let pdf = block.match(/\(["']([^"']+?)["']\)/)[1]
-			blocks.push({
-				type: 'upload',
-				data: {
-					file_url: pdf,
-					file_type: 'pdf',
-				},
-			})
-		} else if (block.includes('{{ Embed')) {
-			let embed = block.match(/\(["']([^"']+?)["']\)/)[1]
-			blocks.push({
-				type: 'embed',
-				data: {
-					service: embed.split('|||')[0],
-					embed: embed.split('|||')[1],
-				},
-			})
-		} else if (block.includes('![]')) {
-			let image = block.match(/\((.*?)\)/)[1]
-			blocks.push({
-				type: 'upload',
-				data: {
-					file_url: image,
-					file_type: 'image',
-				},
-			})
-		} else if (block.includes('#')) {
-			let level = (block.match(/#/g) || []).length
-			blocks.push({
-				type: 'header',
-				data: {
-					text: block.replace(/#/g, '').trim(),
-					level: level,
-				},
-			})
-		} else {
-			blocks.push({
-				type: 'paragraph',
-				data: {
-					text: block,
-				},
-			})
-		}
-	})
-
-	if (lessonData.quizId) {
-		blocks.push({
-			type: 'quiz',
-			data: {
-				quiz: lessonData.quizId,
-			},
-		})
-	}
-
-	return blocks
-}
 
 // Stored body has real content? Lets title-only edits skip re-serialising.
 const storedContentHasBody = () => {

--- a/frontend/src/tests/PdfBlock.test.ts
+++ b/frontend/src/tests/PdfBlock.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+// pdf.js can't be imported in vitest+jsdom (ReferenceError: DOMMatrix), and it
+// needs no real rendering to test the lifecycle — mock it. A shared `state`
+// lets each test steer getDocument to resolve or reject.
+const state = vi.hoisted(() => ({
+	shouldReject: false,
+	destroy: vi.fn(),
+	cancel: vi.fn(),
+	workerPort: null as unknown,
+}))
+
+const makePdf = () => ({
+	numPages: 3,
+	destroy: state.destroy,
+	getPage: vi.fn(async () => ({
+		getViewport: () => ({ width: 600, height: 800 }),
+		render: () => ({ promise: Promise.resolve(), cancel: state.cancel }),
+	})),
+})
+
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+	getDocument: vi.fn(() => ({
+		promise: state.shouldReject
+			? Promise.reject(new Error('boom'))
+			: Promise.resolve(makePdf()),
+	})),
+	GlobalWorkerOptions: {
+		set workerPort(v: unknown) {
+			state.workerPort = v
+		},
+		get workerPort() {
+			return state.workerPort
+		},
+	},
+}))
+
+// Worker creation is mocked at its module boundary (Vite's worker transform
+// can't run pdf.js's worker in jsdom). Count creations + terminations to prove
+// the shared, ref-counted worker lifecycle.
+const terminate = vi.fn()
+const createPdfWorker = vi.hoisted(() => vi.fn())
+vi.mock('@/utils/pdfWorker', () => ({ createPdfWorker }))
+
+beforeEach(() => {
+	state.shouldReject = false
+	state.destroy.mockClear()
+	state.cancel.mockClear()
+	state.workerPort = null
+	terminate.mockClear()
+	createPdfWorker.mockReset()
+	createPdfWorker.mockImplementation(() => ({ terminate, postMessage: vi.fn() }))
+})
+afterEach(() => {
+	vi.resetModules()
+})
+
+async function mountPdf() {
+	const { default: PdfBlock } = await import('@/components/PdfBlock.vue')
+	const wrapper = mount(PdfBlock, { props: { file: '/files/x.pdf' } })
+	await flushPromises()
+	await flushPromises()
+	return wrapper
+}
+
+describe('PdfBlock', () => {
+	it('shows a loading state, then renders one placeholder per page', async () => {
+		const wrapper = await mountPdf()
+		expect(wrapper.findAll('.pdf-page')).toHaveLength(3)
+		expect(wrapper.text()).toContain('1 / 3')
+		expect(wrapper.find('.pdf-status').exists()).toBe(false)
+		wrapper.unmount()
+	})
+
+	it('shows an error state with a fallback link when the PDF fails to load', async () => {
+		state.shouldReject = true
+		const wrapper = await mountPdf()
+		expect(wrapper.find('.pdf-error').exists()).toBe(true)
+		expect(wrapper.find('.pdf-fallback-link').attributes('href')).toBe(
+			'/files/x.pdf'
+		)
+		wrapper.unmount()
+	})
+
+	it('destroys the document and terminates the worker on unmount', async () => {
+		const wrapper = await mountPdf()
+		expect(state.destroy).not.toHaveBeenCalled()
+		wrapper.unmount()
+		expect(state.destroy).toHaveBeenCalledTimes(1)
+		// last holder released -> worker terminated + port cleared
+		expect(terminate).toHaveBeenCalledTimes(1)
+		expect(state.workerPort).toBeNull()
+	})
+
+	it('releases the worker even if unmounted before load() finishes', async () => {
+		// The ref is taken synchronously at mount, so an unmount that races the
+		// in-flight dynamic import must still balance it (no stranded worker).
+		const { default: PdfBlock } = await import('@/components/PdfBlock.vue')
+		const wrapper = mount(PdfBlock, { props: { file: '/files/x.pdf' } })
+		expect(createPdfWorker).toHaveBeenCalledTimes(1)
+		wrapper.unmount() // before any flushPromises -> load() still pending
+		expect(terminate).toHaveBeenCalledTimes(1)
+		await flushPromises()
+		await flushPromises()
+		// the late-resolving load() must not re-acquire a worker
+		expect(createPdfWorker).toHaveBeenCalledTimes(1)
+	})
+
+	it('ref-counts the shared worker across instances', async () => {
+		const { default: PdfBlock } = await import('@/components/PdfBlock.vue')
+		const a = mount(PdfBlock, { props: { file: '/files/a.pdf' } })
+		const b = mount(PdfBlock, { props: { file: '/files/b.pdf' } })
+		await flushPromises()
+		await flushPromises()
+		// one worker shared by both
+		expect(createPdfWorker).toHaveBeenCalledTimes(1)
+
+		a.unmount()
+		expect(terminate).not.toHaveBeenCalled() // b still holds it
+		b.unmount()
+		expect(terminate).toHaveBeenCalledTimes(1) // last holder released
+	})
+})

--- a/frontend/src/tests/lessonMacros.test.ts
+++ b/frontend/src/tests/lessonMacros.test.ts
@@ -20,9 +20,10 @@ describe('convertBodyToBlocks — PDF macro casing', () => {
 
 	it('keeps other upload macros on their existing lowercase file_type', () => {
 		const blocks = convertBodyToBlocks({
-			body: [`{{ Video("/files/intro.mp4") }}`, `{{ Audio("/files/a.mp3") }}`].join(
-				'\n'
-			),
+			body: [
+				`{{ Video("/files/intro.mp4") }}`,
+				`{{ Audio("/files/a.mp3") }}`,
+			].join('\n'),
 		})
 		expect(blocks[0].data.file_type).toBe('mp4')
 		expect(blocks[1].data.file_type).toBe('mp3')
@@ -32,6 +33,44 @@ describe('convertBodyToBlocks — PDF macro casing', () => {
 		expect(convertBodyToBlocks({ body: 'hello world' })).toEqual([
 			{ type: 'paragraph', data: { text: 'hello world' } },
 		])
+	})
+})
+
+// Regression: a stored lesson with a malformed macro (empty parens / unbalanced
+// quotes) used to hit an unguarded `.match(...)[1]` in every macro branch and
+// throw, crashing the lesson editor on open. Every branch now routes through
+// getMacroArg and must degrade to an empty arg instead of throwing.
+describe('convertBodyToBlocks — malformed macros never crash the editor', () => {
+	const malformed = [
+		'{{ Video() }}',
+		'{{ Audio() }}',
+		'{{ PDF() }}',
+		'{{ Quiz() }}',
+		'{{ Embed() }}',
+		'{{ YouTubeVideo() }}',
+		'![]', // image macro with no parens
+		`{{ PDF("unterminated }}`,
+	]
+
+	it.each(malformed)('does not throw on %s', (line) => {
+		expect(() => convertBodyToBlocks({ body: line })).not.toThrow()
+	})
+
+	it('does not throw when a bad macro is mixed with good content', () => {
+		const body = [
+			'# Heading',
+			'{{ Video() }}',
+			'{{ PDF("/files/ok.pdf") }}',
+			'plain text',
+		].join('\n')
+		let blocks: ReturnType<typeof convertBodyToBlocks> = []
+		expect(() => (blocks = convertBodyToBlocks({ body }))).not.toThrow()
+		// the well-formed PDF still resolves correctly alongside the bad macro
+		expect(
+			blocks.some(
+				(b) => b.type === 'upload' && b.data.file_url === '/files/ok.pdf',
+			),
+		).toBe(true)
 	})
 })
 

--- a/frontend/src/tests/lessonMacros.test.ts
+++ b/frontend/src/tests/lessonMacros.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { convertBodyToBlocks, getMacroArg } from '@/utils/lessonMacros'
+
+// Bug 1: a legacy `{{ PDF("...") }}` lesson, when re-opened in the editor, was
+// tagged file_type 'pdf' (lowercase). utils/upload.js renders on `== 'PDF'`
+// (uppercase, matching Frappe's File.set_file_type), so the block fell through
+// to the <img> branch and rendered as a broken image on EVERY browser.
+describe('convertBodyToBlocks — PDF macro casing', () => {
+	it('tags a PDF macro block with uppercase file_type "PDF"', () => {
+		const blocks = convertBodyToBlocks({
+			body: `{{ PDF("/files/handbook.pdf") }}`,
+		})
+		expect(blocks).toEqual([
+			{
+				type: 'upload',
+				data: { file_url: '/files/handbook.pdf', file_type: 'PDF' },
+			},
+		])
+	})
+
+	it('keeps other upload macros on their existing lowercase file_type', () => {
+		const blocks = convertBodyToBlocks({
+			body: [`{{ Video("/files/intro.mp4") }}`, `{{ Audio("/files/a.mp3") }}`].join(
+				'\n'
+			),
+		})
+		expect(blocks[0].data.file_type).toBe('mp4')
+		expect(blocks[1].data.file_type).toBe('mp3')
+	})
+
+	it('maps a plain text line to a paragraph block (happy path preserved)', () => {
+		expect(convertBodyToBlocks({ body: 'hello world' })).toEqual([
+			{ type: 'paragraph', data: { text: 'hello world' } },
+		])
+	})
+})
+
+// Bug 2: getId() (via getMacroArg) ran `.match(...)[1]` unguarded. A malformed
+// macro made .match() return null, and null[1] threw — taking down the whole
+// lesson render instead of just skipping the bad block.
+describe('getMacroArg — malformed-macro guard', () => {
+	it('extracts the quoted argument from a well-formed macro', () => {
+		expect(getMacroArg(`{{ PDF("/files/a.pdf") }}`)).toBe('/files/a.pdf')
+		expect(getMacroArg(`{{ PDF('/files/b.pdf') }}`)).toBe('/files/b.pdf')
+	})
+
+	it('returns null instead of throwing on a malformed macro', () => {
+		expect(getMacroArg(`{{ PDF() }}`)).toBeNull()
+		expect(getMacroArg(`{{ PDF("unterminated }}`)).toBeNull()
+		expect(getMacroArg('')).toBeNull()
+	})
+})

--- a/frontend/src/utils/lessonMacros.ts
+++ b/frontend/src/utils/lessonMacros.ts
@@ -1,0 +1,140 @@
+interface EditorBlock {
+	type: string
+	data: Record<string, unknown>
+}
+
+interface LessonBodyData {
+	body: string
+	youtube?: string
+	quizId?: string
+}
+
+/**
+ * Pull the single quoted argument out of a legacy `{{ Macro("value") }}` line,
+ * e.g. `{{ PDF("/files/a.pdf") }}` -> `/files/a.pdf`.
+ *
+ * Returns null when the line has no quoted argument. Callers MUST handle null:
+ * a malformed macro (empty parens, unbalanced quotes) would otherwise make an
+ * unguarded `.match(...)[1]` throw and take down the whole render.
+ */
+export function getMacroArg(block: string): string | null {
+	const match = block.match(/\(["']([^"']+?)["']\)/)
+	return match ? match[1] : null
+}
+
+/**
+ * Convert a lesson's legacy markdown/macro `body` into EditorJS blocks.
+ *
+ * Moved out of LessonForm.vue so the macro-to-block mapping is unit-testable.
+ * The PDF branch tags the block `file_type: 'PDF'` (uppercase) to match
+ * Frappe's File.set_file_type() and the `== 'PDF'` check in utils/upload.js;
+ * the previous lowercase 'pdf' fell through to the image branch and rendered
+ * legacy PDF lessons as a broken image on every browser.
+ */
+export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
+	let blocks: EditorBlock[] = []
+	// Dedupe a video shared by the youtube field and body macro.
+	const seenYoutube = new Set<string>()
+	const youtubeKey = (url: string) => url.split('/').pop()!.split('?')[0]
+	const pushYoutube = (embedUrl: string) => {
+		const key = youtubeKey(embedUrl)
+		if (seenYoutube.has(key)) return
+		seenYoutube.add(key)
+		blocks.push({
+			type: 'embed',
+			data: { service: 'youtube', embed: embedUrl },
+		})
+	}
+	if (lessonData.youtube) {
+		let youtubeID = lessonData.youtube.split('/').pop()
+		pushYoutube(`https://www.youtube.com/embed/${youtubeID}`)
+	}
+	lessonData.body.split('\n').forEach((block) => {
+		if (block.includes('{{ YouTubeVideo')) {
+			let youtubeID = block.match(/\(["']([^"']+?)["']\)/)![1]
+			if (!youtubeID.includes('https://'))
+				youtubeID = `https://www.youtube.com/embed/${youtubeID}`
+			pushYoutube(youtubeID)
+		} else if (block.includes('{{ Quiz')) {
+			let quiz = block.match(/\(["']([^"']+?)["']\)/)![1]
+			blocks.push({
+				type: 'quiz',
+				data: {
+					quiz: quiz,
+				},
+			})
+		} else if (block.includes('{{ Video')) {
+			let video = block.match(/\(["']([^"']+?)["']\)/)![1]
+			blocks.push({
+				type: 'upload',
+				data: {
+					file_url: video,
+					file_type: video.split('.').pop(),
+				},
+			})
+		} else if (block.includes('{{ Audio')) {
+			let audio = block.match(/\(["']([^"']+?)["']\)/)![1]
+			blocks.push({
+				type: 'upload',
+				data: {
+					file_url: audio,
+					file_type: audio.split('.').pop(),
+				},
+			})
+		} else if (block.includes('{{ PDF')) {
+			let pdf = block.match(/\(["']([^"']+?)["']\)/)![1]
+			blocks.push({
+				type: 'upload',
+				data: {
+					file_url: pdf,
+					file_type: 'PDF',
+				},
+			})
+		} else if (block.includes('{{ Embed')) {
+			let embed = block.match(/\(["']([^"']+?)["']\)/)![1]
+			blocks.push({
+				type: 'embed',
+				data: {
+					service: embed.split('|||')[0],
+					embed: embed.split('|||')[1],
+				},
+			})
+		} else if (block.includes('![]')) {
+			let image = block.match(/\((.*?)\)/)![1]
+			blocks.push({
+				type: 'upload',
+				data: {
+					file_url: image,
+					file_type: 'image',
+				},
+			})
+		} else if (block.includes('#')) {
+			let level = (block.match(/#/g) || []).length
+			blocks.push({
+				type: 'header',
+				data: {
+					text: block.replace(/#/g, '').trim(),
+					level: level,
+				},
+			})
+		} else {
+			blocks.push({
+				type: 'paragraph',
+				data: {
+					text: block,
+				},
+			})
+		}
+	})
+
+	if (lessonData.quizId) {
+		blocks.push({
+			type: 'quiz',
+			data: {
+				quiz: lessonData.quizId,
+			},
+		})
+	}
+
+	return blocks
+}

--- a/frontend/src/utils/lessonMacros.ts
+++ b/frontend/src/utils/lessonMacros.ts
@@ -30,6 +30,10 @@ export function getMacroArg(block: string): string | null {
  * Frappe's File.set_file_type() and the `== 'PDF'` check in utils/upload.js;
  * the previous lowercase 'pdf' fell through to the image branch and rendered
  * legacy PDF lessons as a broken image on every browser.
+ *
+ * Every macro branch pulls its argument through getMacroArg (guarded) rather
+ * than an unchecked `.match(...)[1]`: a stored lesson with a malformed macro
+ * (empty parens, unbalanced quotes) must not throw and crash the editor on open.
  */
 export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 	let blocks: EditorBlock[] = []
@@ -51,12 +55,12 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 	}
 	lessonData.body.split('\n').forEach((block) => {
 		if (block.includes('{{ YouTubeVideo')) {
-			let youtubeID = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let youtubeID = getMacroArg(block) ?? ''
 			if (!youtubeID.includes('https://'))
 				youtubeID = `https://www.youtube.com/embed/${youtubeID}`
 			pushYoutube(youtubeID)
 		} else if (block.includes('{{ Quiz')) {
-			let quiz = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let quiz = getMacroArg(block) ?? ''
 			blocks.push({
 				type: 'quiz',
 				data: {
@@ -64,7 +68,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				},
 			})
 		} else if (block.includes('{{ Video')) {
-			let video = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let video = getMacroArg(block) ?? ''
 			blocks.push({
 				type: 'upload',
 				data: {
@@ -73,7 +77,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				},
 			})
 		} else if (block.includes('{{ Audio')) {
-			let audio = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let audio = getMacroArg(block) ?? ''
 			blocks.push({
 				type: 'upload',
 				data: {
@@ -82,7 +86,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				},
 			})
 		} else if (block.includes('{{ PDF')) {
-			let pdf = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let pdf = getMacroArg(block) ?? ''
 			blocks.push({
 				type: 'upload',
 				data: {
@@ -91,7 +95,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				},
 			})
 		} else if (block.includes('{{ Embed')) {
-			let embed = block.match(/\(["']([^"']+?)["']\)/)![1]
+			let embed = getMacroArg(block) ?? ''
 			blocks.push({
 				type: 'embed',
 				data: {
@@ -100,7 +104,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				},
 			})
 		} else if (block.includes('![]')) {
-			let image = block.match(/\((.*?)\)/)![1]
+			let image = block.match(/\((.*?)\)/)?.[1] ?? ''
 			blocks.push({
 				type: 'upload',
 				data: {

--- a/frontend/src/utils/pdfWorker.js
+++ b/frontend/src/utils/pdfWorker.js
@@ -1,0 +1,12 @@
+// Vite's `?worker` import bundles pdf.js's worker as a first-class worker module:
+// it hands back a Worker *constructor*, picks the right classic/module type in
+// dev, and emits a plain `.js` in prod (so nginx <1.21.1 never serves it as
+// application/octet-stream — the failure the `?url`/raw-`.mjs` idiom trips on).
+//
+// Isolated in its own module so tests can mock worker creation without tripping
+// over the worker transform (which can't run pdf.js's worker under vitest+jsdom).
+import PdfWorker from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs?worker'
+
+export function createPdfWorker() {
+	return new PdfWorker()
+}

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -1,5 +1,6 @@
 import AudioBlock from '@/components/AudioBlock.vue'
 import VideoBlock from '@/components/VideoBlock.vue'
+import PdfBlock from '@/components/PdfBlock.vue'
 import UploadPlugin from '@/components/UploadPlugin.vue'
 import { h, createApp } from 'vue'
 import { Upload as UploadIcon } from 'lucide-vue-next'
@@ -66,11 +67,14 @@ export class Upload {
 			app.mount(this.wrapper)
 			return
 		} else if (file.file_type == 'PDF') {
-			this.wrapper.innerHTML = `<iframe src="${
-				window.location.origin
-			}${encodeURI(
-				file.file_url
-			)}" width='100%' height='700px' class="mb-4" type="application/pdf"></iframe>`
+			// iOS Safari (all WebKit browsers) refuses to scroll a PDF in an
+			// <iframe>, so render it inline via pdf.js. mount()/unmount() is tracked
+			// so destroy() can tear the pdf.js worker + render tasks down.
+			this.app = createApp(PdfBlock, {
+				file: file.file_url,
+			})
+			this.app.use(translationPlugin)
+			this.app.mount(this.wrapper)
 			return
 		} else {
 			this.wrapper.innerHTML = `<img class="mb-4" src=${encodeURI(
@@ -105,6 +109,16 @@ export class Upload {
 			file_url: this.data.file_url,
 			file_type: this.data.file_type,
 			quizzes: this.data.quizzes || [],
+		}
+	}
+
+	// EditorJS calls destroy() when a block is removed or the editor is torn down.
+	// Unmounting the PdfBlock app fires its onBeforeUnmount, which cancels render
+	// tasks, destroys the document, and releases the shared pdf.js worker.
+	destroy() {
+		if (this.app) {
+			this.app.unmount()
+			this.app = null
 		}
 	}
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 import { VitePWA } from 'vite-plugin-pwa'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig(async ({ mode }) => {
 	const isDev = mode === 'development'
@@ -43,6 +44,22 @@ export default defineConfig(async ({ mode }) => {
 					],
 				},
 				manifest: false,
+			}),
+			// pdf.js needs cMaps (JPEG2000/JBIG2 + CJK) and standard_fonts (non-embedded
+			// fonts) as sibling assets, or those PDFs render blank and look like a pdf.js
+			// bug. Copy them under pdfjs/; PdfBlock.vue points cMapUrl/standardFontDataUrl
+			// at `${BASE_URL}pdfjs/...`. Served in dev too (static-copy dev middleware).
+			viteStaticCopy({
+				targets: [
+					{
+						src: 'node_modules/pdfjs-dist/cmaps/*',
+						dest: 'pdfjs/cmaps',
+					},
+					{
+						src: 'node_modules/pdfjs-dist/standard_fonts/*',
+						dest: 'pdfjs/standard_fonts',
+					},
+				],
 			}),
 		],
 		server: {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1594,6 +1594,78 @@
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
+"@napi-rs/canvas-android-arm64@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz#b7c68b91d57702a5fc523fa82de72ea741e6766e"
+  integrity sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==
+
+"@napi-rs/canvas-darwin-arm64@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz#d1686fa6ca699b07640efa5f45425db0a4e725e2"
+  integrity sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==
+
+"@napi-rs/canvas-darwin-x64@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz#92978fd7eca21f7f1b59bd13ba3ce7c0e7c879a1"
+  integrity sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==
+
+"@napi-rs/canvas-linux-arm-gnueabihf@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz#95f9892e1d5a8274871d8ee406374e9ef692bd9f"
+  integrity sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==
+
+"@napi-rs/canvas-linux-arm64-gnu@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz#6b2b7c4bb016b8f5308115ac9ae909df4967a94b"
+  integrity sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==
+
+"@napi-rs/canvas-linux-arm64-musl@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz#48cf6342543e4f87cf1f8e9b1aaa19ad85bcc178"
+  integrity sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==
+
+"@napi-rs/canvas-linux-riscv64-gnu@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz#71b011007b03755c834a961735302c5837b041da"
+  integrity sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==
+
+"@napi-rs/canvas-linux-x64-gnu@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz#3f479d3b8b8c4658e5dec1b943ad7d2eefd2811f"
+  integrity sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==
+
+"@napi-rs/canvas-linux-x64-musl@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz#1beaca22c1fe97709a9c287115cb3c90194ddec6"
+  integrity sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==
+
+"@napi-rs/canvas-win32-arm64-msvc@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz#8a1728b455dd17965f95c0bfdf6753be8c5851c0"
+  integrity sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==
+
+"@napi-rs/canvas-win32-x64-msvc@0.1.100":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz#1e52883f8784ffdbe52dc2d47b05a0886aa6e9cf"
+  integrity sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==
+
+"@napi-rs/canvas@^0.1.65":
+  version "0.1.100"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas/-/canvas-0.1.100.tgz#2c89a15c28a62e1372be23fd474762ae1a8b16b7"
+  integrity sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==
+  optionalDependencies:
+    "@napi-rs/canvas-android-arm64" "0.1.100"
+    "@napi-rs/canvas-darwin-arm64" "0.1.100"
+    "@napi-rs/canvas-darwin-x64" "0.1.100"
+    "@napi-rs/canvas-linux-arm-gnueabihf" "0.1.100"
+    "@napi-rs/canvas-linux-arm64-gnu" "0.1.100"
+    "@napi-rs/canvas-linux-arm64-musl" "0.1.100"
+    "@napi-rs/canvas-linux-riscv64-gnu" "0.1.100"
+    "@napi-rs/canvas-linux-x64-gnu" "0.1.100"
+    "@napi-rs/canvas-linux-x64-musl" "0.1.100"
+    "@napi-rs/canvas-win32-arm64-msvc" "0.1.100"
+    "@napi-rs/canvas-win32-x64-msvc" "0.1.100"
+
 "@napi-rs/wasm-runtime@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
@@ -2797,7 +2869,7 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^3.6.0:
+chokidar@^3.5.3, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -3381,7 +3453,7 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.3.2:
+fast-glob@^3.2.11, fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -3538,6 +3610,15 @@ frappe-ui@^1.0.0-beta.24:
     unplugin-icons "^22.1.0"
     unplugin-vue-components "^32.0.0"
     vue-sonner "^2.0.9"
+
+fs-extra@^11.1.0:
+  version "11.3.6"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.6.tgz#f7cb80e9df550cd1db6f537fa5cdd568d3e70d10"
+  integrity sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.1:
   version "9.1.0"
@@ -4631,6 +4712,13 @@ pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pdfjs-dist@4.10.38:
+  version "4.10.38"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz#3ee698003790dc266cc8b55c0e662ccb9ae18f53"
+  integrity sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==
+  optionalDependencies:
+    "@napi-rs/canvas" "^0.1.65"
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -6041,6 +6129,16 @@ vite-plugin-pwa@^1.2.0:
     tinyglobby "^0.2.10"
     workbox-build "^7.4.0"
     workbox-window "^7.4.0"
+
+vite-plugin-static-copy@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-1.0.6.tgz#ff457c16e8cfa564472aafd1698790ac89d05508"
+  integrity sha512-3uSvsMwDVFZRitqoWHj0t4137Kz7UynnJeq1EZlRW7e25h2068fyIZX4ORCCOAkfp1FklGxJNVJBkBOD+PZIew==
+  dependencies:
+    chokidar "^3.5.3"
+    fast-glob "^3.2.11"
+    fs-extra "^11.1.0"
+    picocolors "^1.0.0"
 
 vite@5.0.11:
   version "5.0.11"

--- a/lms/plugins.py
+++ b/lms/plugins.py
@@ -186,18 +186,38 @@ def youtube_video_renderer(video_id):
     """
 
 
+def _pdf_embed(src, width="100%", height="700px"):
+	"""Server-rendered PDF embed that stays usable on iOS.
+
+	iOS Safari (every iOS browser is WebKit) won't scroll a PDF inside an
+	<iframe> — it shows page 1 or nothing. There's no Vue here to mount the
+	pdf.js viewer (that's the SPA path), so we degrade gracefully: keep the
+	inline <iframe> for desktop and always surface an "Open PDF" link that hands
+	the file to the browser's native full-screen viewer, which scrolls on iOS.
+	"""
+	safe = quote(src, safe="/:?=&%#")
+	return f"""
+	<div style="display:flex;flex-direction:column;gap:8px">
+		<a href="{safe}" target="_blank" rel="noopener"
+			style="align-self:flex-start;text-decoration:underline">
+			{_("Open PDF in a new tab")} ↗
+		</a>
+		<iframe src="{safe}#toolbar=0" width="{width}" height="{height}"
+			title="PDF" frameborder="0"
+			style="border-radius: var(--border-radius-lg)"></iframe>
+	</div>
+	"""
+
+
 def embed_renderer(details):
 	type = details.split("|||")[0]
 	src = details.split("|||")[1]
-	width = "100%"
-	height = "400"
 
 	if type == "pdf":
-		width = "75%"
-		height = "600"
+		return _pdf_embed(src, width="75%", height="600")
 
 	return f"""
-	<iframe width="{width}" height="{height}"
+	<iframe width="100%" height="400"
 		src="{quote(src, safe='/:?=&#')}"
 		title="Embedded Content"
 		frameborder="0"
@@ -217,7 +237,7 @@ def audio_renderer(src):
 
 
 def pdf_renderer(src):
-	return f"<iframe src='{quote(src)}#toolbar=0' width='100%' height='700px'></iframe>"
+	return _pdf_embed(src)
 
 
 def assignment_renderer(detail):

--- a/lms/tests/test_plugins.py
+++ b/lms/tests/test_plugins.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021, FOSS United and Contributors
+# See license.txt
+import unittest
+
+from lms.plugins import embed_renderer, pdf_renderer
+
+
+class TestPdfRenderers(unittest.TestCase):
+	"""The server-rendered (non-SPA) PDF macros must stay usable on iOS Safari,
+	which won't scroll a PDF inside an <iframe> — so both renderers surface an
+	"Open PDF" link to the browser's native viewer alongside the inline frame."""
+
+	def test_pdf_renderer_has_open_link_and_iframe(self):
+		html = pdf_renderer("/files/a.pdf")
+		self.assertIn('<a href="/files/a.pdf"', html)
+		self.assertIn('target="_blank"', html)
+		self.assertIn("<iframe", html)
+		self.assertIn("/files/a.pdf#toolbar=0", html)
+
+	def test_pdf_renderer_preserves_serve_resource_query(self):
+		# Regression: the old quote(src) mangled the ?file_url= query, breaking
+		# gated /private media URLs.
+		src = "/api/method/lms...serve_resource?file_url=/private/files/a.pdf"
+		html = pdf_renderer(src)
+		self.assertIn("?file_url=/private/files/a.pdf", html)
+
+	def test_embed_renderer_pdf_uses_the_open_link(self):
+		html = embed_renderer("pdf|||/files/b.pdf")
+		self.assertIn('<a href="/files/b.pdf"', html)
+		self.assertIn("<iframe", html)
+
+	def test_embed_renderer_non_pdf_is_a_plain_iframe(self):
+		html = embed_renderer("youtube|||https://example.com/v")
+		self.assertIn("<iframe", html)
+		self.assertNotIn("Open PDF", html)


### PR DESCRIPTION
## Summary
- Problem: Lesson PDFs render in an <iframe>. iOS browsers (all WebKit) won't scroll a PDF in an iframe — students on iPhone/iPad can't read them.
- Change: New PdfBlock.vue renders PDFs to <canvas> via pdfjs-dist. Wired into upload.js (editor block) and LessonContent.vue (legacy macro). Viewer: continuous scroll, lazy render, prev/next, zoom/fit-width, pinch-zoom, loading/error states with "open in new tab" fallback.
- LessonForm.vue wrote file_type: 'pdf'. Frappe uppercases to 'PDF', so legacy PDF lessons rendered as a broken <img>. Now 'PDF'.


