### PR TITLE
feat: allow chart colors to be themed via CSS custom properties (--chart-1..--chart-5)

### DIFF
--- a/frontend/src/pages/Batches/components/AdminBatchDashboard.vue
+++ b/frontend/src/pages/Batches/components/AdminBatchDashboard.vue
@@ -169,6 +169,7 @@
 								type: 'bar',
 							},
 						],
+						...(chartColors ? { colors: chartColors } : {}),
 					}"
 				/>
 
@@ -209,6 +210,7 @@ import {
 import { computed, inject, ref, watch } from 'vue'
 import type dayjsType from 'dayjs'
 import { formatAmount } from '@/utils'
+import { getChartColors } from '@/utils/chartColors'
 import BatchFeedback from '@/pages/Batches/components/BatchFeedback.vue'
 import BatchStudentProgress from '@/pages/Batches/components/BatchStudentProgress.vue'
 import NumberChartGraph from '@/components/NumberChartGraph.vue'
@@ -220,6 +222,7 @@ const searchFilter = ref<string | null>(null)
 const showEnrollmentModal = ref<boolean>(false)
 const showProgressModal = ref<boolean>(false)
 const currentStudent = ref<any>(null)
+const chartColors = getChartColors()
 
 function openEnrollModal() {
 	showEnrollmentModal.value = true

--- a/frontend/src/pages/Courses/CourseDashboard.vue
+++ b/frontend/src/pages/Courses/CourseDashboard.vue
@@ -155,20 +155,13 @@
 						<div class="flex flex-col space-y-4 flex-1 text-sm">
 							<div
 								class="flex items-center text-ink-gray-7"
-								v-for="row in chartDetails.data?.progress_distribution"
+								v-for="(row, index) in chartDetails.data?.progress_distribution"
 							>
 								<div
 									class="size-2 rounded"
 									:style="{
-										backgroundColor: `var(--${
-											row.name.startsWith('Just')
-												? 'red'
-												: row.name.startsWith('In')
-												? 'amber'
-												: row.name.startsWith('Adv')
-												? 'blue'
-												: 'green'
-										}-400)`,
+										backgroundColor:
+											progressColors[index % progressColors.length],
 									}"
 								></div>
 								<Tooltip :text="row.name.split('(')[1].replace(')', '')">
@@ -307,6 +300,7 @@ import Select from '@/components/Controls/Select.vue'
 import { computed, inject, ref, watch } from 'vue'
 import type dayjsType from 'dayjs'
 import { formatAmount } from '@/utils'
+import { getChartColors } from '@/utils/chartColors'
 import CourseEnrollmentModal from '@/pages/Courses/CourseEnrollmentModal.vue'
 import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
 import NumberChartGraph from '@/components/NumberChartGraph.vue'
@@ -412,8 +406,10 @@ const showStudentsEmptyState = computed(
 		!progressList.loading && !progressList.data?.length && !searchFilter.value
 )
 
-const progressColors = computed(() =>
-	['red', 'amber', 'blue', 'green'].map((color) => `var(--${color}-400)`)
+const progressColors = computed(
+	() =>
+		getChartColors(4) ??
+		['red', 'amber', 'blue', 'green'].map((color) => `var(--${color}-400)`)
 )
 
 const progressColumns = computed(() => {

--- a/frontend/src/pages/Programs/ProgramProgressSummary.vue
+++ b/frontend/src/pages/Programs/ProgramProgressSummary.vue
@@ -28,13 +28,7 @@
 						title: __('Progress Distribution'),
 						categoryColumn: 'category',
 						valueColumn: 'count',
-						colors: [
-							'var(--red-400)',
-							'var(--amber-400)',
-							'var(--pink-400)',
-							'var(--blue-400)',
-							'var(--green-400)',
-						],
+						colors: chartColors,
 					}"
 				/>
 
@@ -75,10 +69,18 @@ import {
 	NumberChart,
 } from 'frappe-ui'
 import type { ProgramMember } from '@/types'
+import { getChartColors } from '@/utils/chartColors'
 import { computed, ref, watch } from 'vue'
 
 const show = defineModel<boolean>({ default: false })
 const searchFilter = ref<string | null>(null)
+const chartColors = getChartColors() ?? [
+	'var(--red-400)',
+	'var(--amber-400)',
+	'var(--pink-400)',
+	'var(--blue-400)',
+	'var(--green-400)',
+]
 
 const props = defineProps<{
 	programName: string

--- a/frontend/src/pages/Statistics.vue
+++ b/frontend/src/pages/Statistics.vue
@@ -71,6 +71,7 @@
 								title: 'Signups',
 							},
 							series: [{ name: 'signups', type: 'line', showDataPoints: true }],
+							...(chartColors ? { colors: chartColors } : {}),
 						}"
 					/>
 				</div>
@@ -93,6 +94,7 @@
 							series: [
 								{ name: 'enrollments', type: 'line', showDataPoints: true },
 							],
+							...(chartColors ? { colors: chartColors } : {}),
 						}"
 					/>
 				</div>
@@ -119,6 +121,7 @@
 									showDataPoints: true,
 								},
 							],
+							...(chartColors ? { colors: chartColors } : {}),
 						}"
 					/>
 				</div>
@@ -131,6 +134,7 @@
 							subtitle: 'Course Completion',
 							categoryColumn: 'label',
 							valueColumn: 'value',
+							...(chartColors ? { colors: chartColors } : {}),
 						}"
 					/>
 				</div>
@@ -151,8 +155,11 @@ import {
 } from 'frappe-ui'
 import { computed } from 'vue'
 import { sessionStore } from '../stores/session'
+import { getChartColors } from '@/utils/chartColors'
 
 const { brand } = sessionStore()
+
+const chartColors = getChartColors()
 
 const breadcrumbs = computed(() => {
 	return [

--- a/frontend/src/utils/chartColors.ts
+++ b/frontend/src/utils/chartColors.ts
@@ -1,0 +1,19 @@
+/**
+ * Chart series colors either come from ECharts' built-in palette (when no
+ * colors are passed) or are hardcoded per page, so a theme that restyles the
+ * app through CSS custom properties cannot recolor them. Themes can opt in
+ * by defining --chart-1 .. --chart-5 on :root.
+ *
+ * Returns the resolved values of the defined tokens, in order. When no token
+ * is defined it returns undefined so callers keep their current default
+ * colors — themes that don't define the tokens see no change at all.
+ */
+export function getChartColors(count: number = 5): string[] | undefined {
+	const styles = getComputedStyle(document.documentElement)
+	const colors: string[] = []
+	for (let i = 1; i <= count; i++) {
+		const color = styles.getPropertyValue(`--chart-${i}`).trim()
+		if (color) colors.push(color)
+	}
+	return colors.length ? colors : undefined
+}


### PR DESCRIPTION
### Problem

The frontend can be restyled almost entirely through CSS custom properties, but chart series colors can't:

- `AxisChart`/`DonutChart` call sites that pass no `colors` (Statistics page, admin batch dashboard) fall back to ECharts' built-in palette, which no CSS can reach.
- Pages that do pass colors hardcode a per-page list (course dashboard pie, program progress summary donut).

So a theme with no blue in it still gets blue charts.

### Solution

Opt-in theme tokens, with the current behavior kept intact as fallback:

- New util `frontend/src/utils/chartColors.ts`: `getChartColors(count)` reads `--chart-1` .. `--chart-5` from the root element's computed style and returns the defined values in order — or `undefined` when none are defined.
- Call sites only pass `colors` when tokens exist:
  - `Statistics.vue` — 3× AxisChart + 1× DonutChart get `colors` via conditional spread.
  - `AdminBatchDashboard.vue` — AxisChart, same conditional spread.
  - `ProgramProgressSummary.vue` — DonutChart prefers tokens; the existing `var(--red-400)`/`--amber-400`/`--pink-400`/`--blue-400`/`--green-400` list stays as the fallback.
  - `CourseDashboard.vue` — `progressColors` prefers tokens with the existing red/amber/blue/green list as fallback. The legend dots next to the pie now read from the same `progressColors` by index, so legend and pie stay in sync when a theme overrides the tokens (identical output by default: the backend returns the distribution in a fixed order that matches the previous name-based mapping in `get_progress_distribution`).

When no `--chart-N` token is defined, nothing changes — the spread contributes nothing and the fallback lists are the ones already in the code.

Notes:
- Values are resolved through `getComputedStyle`, so any valid CSS color works, and ECharts receives concrete colors (it can derive emphasis/dimmed variants from them).
- Tokens are read once at component setup.

Context: we (LetItGrowth) run the LMS in production re-themed entirely via CSS custom properties; the charts are currently the only surface that theming approach cannot recolor, which is what motivated this change.

`yarn build` passes; touched files verified against Prettier (no formatting drift on the changed lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
