### PR TITLE
fix: miscellaneous fixes (sidebar request dedup, popovers, 404 routes, signup, lesson conversion)

### DIFF
--- a/frontend/src/components/Controls/IconPicker.vue
+++ b/frontend/src/components/Controls/IconPicker.vue
@@ -3,9 +3,8 @@
 		<FormLabel :label="label" />
 		<div class="w-full">
 			<Popover>
-				<template #trigger="{ toggle }">
+				<template #trigger>
 					<button
-						@click="openPopover(toggle)"
 						class="flex w-full items-center gap-x-2 focus:outline-none transition-colors border border-[--surface-gray-2] bg-surface-gray-2 rounded h-7 py-1.5 px-2 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0"
 					>
 						<component
@@ -105,8 +104,4 @@ const filteredIcons = computed(() => {
 			return result
 		}, {})
 })
-
-const openPopover = (togglePopover) => {
-	togglePopover()
-}
 </script>

--- a/frontend/src/components/Layouts/EmptyStateLayout.vue
+++ b/frontend/src/components/Layouts/EmptyStateLayout.vue
@@ -13,6 +13,7 @@
 					{{ computedDescription }}
 				</span>
 			</div>
+			<slot />
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -69,7 +69,7 @@ import { toggleNotifications } from '@/stores/notifications'
 
 const { logout, user } = sessionStore()
 let { isLoggedIn } = sessionStore()
-const { sidebarSettings } = useSettings()
+const { sidebarSettings, loadSidebarSettings } = useSettings()
 const router = useRouter()
 let { userResource } = usersStore()
 const sidebarLinks = ref([])
@@ -137,21 +137,18 @@ const addLink = (label, icon, to = '') => {
 const updateSidebarLinks = () => {
 	sidebarLinks.value = getSidebarLinks(true)
 	destructureSidebarLinks()
-	sidebarSettings.reload(
-		{},
-		{
-			onSuccess: async (data) => {
-				filterLinksToShow(data)
-				await addPrograms()
-				if (isModerator.value || isInstructor.value) {
-					addQuizzes()
-					addAssignments()
-					addProgrammingExercises()
-				}
-				addOtherLinks()
-			},
+	loadSidebarSettings().then(async () => {
+		const data = sidebarSettings.data
+		if (!data) return
+		filterLinksToShow(data)
+		await addPrograms()
+		if (isModerator.value || isInstructor.value) {
+			addQuizzes()
+			addAssignments()
+			addProgrammingExercises()
 		}
-	)
+		addOtherLinks()
+	})
 }
 
 const addQuizzes = () => {
@@ -193,6 +190,8 @@ watch(
 	},
 	{ immediate: true }
 )
+
+watch(() => sidebarSettings.data, updateSidebarLinks, { deep: true })
 
 const checkIfCanAddProgram = async () => {
 	if (!userResource.data) return false

--- a/frontend/src/components/Settings/SettingDetails.vue
+++ b/frontend/src/components/Settings/SettingDetails.vue
@@ -21,6 +21,9 @@
 import { Button, Badge, toast } from 'frappe-ui'
 import SettingFields from '@/components/Settings/SettingFields.vue'
 import SettingsLayout from '@/components/Layouts/SettingsLayout.vue'
+import { useSettings } from '@/stores/settings'
+
+const settingsStore = useSettings()
 
 const props = defineProps({
 	sections: {
@@ -44,6 +47,9 @@ const update = () => {
 	props.data.save.submit(
 		{},
 		{
+			onSuccess() {
+				settingsStore.loadSidebarSettings(true)
+			},
 			onError(err) {
 				toast.error(err.messages?.[0] || err)
 			},

--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -310,7 +310,13 @@ const showPageModal = ref(false)
 const isModerator = ref(false)
 const isInstructor = ref(false)
 const pageToEdit = ref(null)
-const { sidebarSettings, activeTab, isSettingsOpen, programs } = useSettings()
+const {
+	sidebarSettings,
+	activeTab,
+	isSettingsOpen,
+	programs,
+	loadSidebarSettings,
+} = useSettings()
 const settingsStore = useSettings()
 const showOnboarding = ref(false)
 const showIntermediateModal = ref(false)
@@ -336,22 +342,19 @@ onMounted(() => {
 })
 
 const updateSidebarLinksVisibility = () => {
-	sidebarSettings.reload(
-		{},
-		{
-			onSuccess(data) {
-				Object.keys(data).forEach((key) => {
-					if (!parseInt(data[key])) {
-						sidebarLinks.value.forEach((link) => {
-							link.items = link.items.filter(
-								(item) => item.label.toLowerCase().split(' ').join('_') !== key
-							)
-						})
-					}
+	loadSidebarSettings().then(() => {
+		const data = sidebarSettings.data
+		if (!data) return
+		Object.keys(data).forEach((key) => {
+			if (!parseInt(data[key])) {
+				sidebarLinks.value.forEach((link) => {
+					link.items = link.items.filter(
+						(item) => item.label.toLowerCase().split(' ').join('_') !== key
+					)
 				})
-			},
-		}
-	)
+			}
+		})
+	})
 }
 
 const addKeyboardShortcut = () => {
@@ -410,7 +413,7 @@ const deletePage = (link) => {
 		doctype: 'LMS Sidebar Item',
 		documents: [link.name],
 	}).then(() => {
-		sidebarSettings.reload()
+		loadSidebarSettings(true)
 		toast.success(__('Page deleted successfully'))
 	})
 }
@@ -663,6 +666,12 @@ watch(userResource, async () => {
 watch(settingsStore.settings, () => {
 	updateSidebarLinks()
 })
+
+watch(
+	() => sidebarSettings.data,
+	() => updateSidebarLinks(),
+	{ deep: true }
+)
 
 const updateSidebarLinks = () => {
 	sidebarLinks.value = getSidebarLinks()

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -74,6 +74,7 @@ import {
 	Badge,
 	Button,
 	Switch,
+	call,
 	createResource,
 	toast,
 	Tooltip,
@@ -443,7 +444,7 @@ const createNewLesson = () => {
 	)
 }
 
-const editCurrentLesson = () => {
+const editCurrentLesson = (isRetry = false) => {
 	// Catch the re-thrown rejection: a save racing a delete 404s harmlessly.
 	editLesson
 		.submit(
@@ -467,9 +468,36 @@ const editCurrentLesson = () => {
 		)
 		.catch((err) => {
 			if (lessonDeleted) return
+			// The daily untitled-lesson rename can move the docname under an open
+			// editor; re-resolve it by index and retry once (a plain reload would
+			// drop the unsaved edits we're saving).
+			if (!isRetry && err?.exc_type === 'DoesNotExistError') {
+				resolveLessonName().then((name) => {
+					if (name) editCurrentLesson(true)
+					else toast.error(err.messages?.[0] || err.message || err)
+				})
+				return
+			}
 			toast.error(err.messages?.[0] || err.message || err)
 		})
 }
+
+const resolveLessonName = () =>
+	call('lms.lms.utils.get_lesson_creation_details', {
+		course: props.courseName,
+		chapter: props.chapterNumber,
+		lesson: props.lessonNumber,
+	})
+		.then((data) => {
+			const name = data?.lesson?.name
+			if (name) {
+				lessonDetails.data.lesson.name = name
+				contentUploadContext.docname = name
+				instructorUploadContext.docname = name
+			}
+			return name || null
+		})
+		.catch(() => null)
 
 const validateLesson = () => {
 	if (!lesson.title) {

--- a/frontend/src/pages/NotFound.vue
+++ b/frontend/src/pages/NotFound.vue
@@ -1,0 +1,22 @@
+<template>
+	<EmptyStateLayout
+		name="Page"
+		:title="__('Page not found')"
+		:description="
+			__('The page you are looking for does not exist or has moved.')
+		"
+		icon="lucide-compass"
+		width="lg"
+	>
+		<Button
+			:label="__('Back to Home')"
+			@click="router.push({ name: 'Home' })"
+		/>
+	</EmptyStateLayout>
+</template>
+<script setup>
+import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+</script>

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -131,6 +131,7 @@
 			<router-view :profile="profile" :key="profile.data?.name" />
 		</div>
 	</div>
+	<NotFound v-else-if="(profile.fetched || profile.error) && !profile.data" />
 	<EditProfile
 		v-model="showProfileModal"
 		v-model:reloadProfile="profile"
@@ -155,6 +156,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { convertToTitleCase } from '@/utils'
 import UserAvatar from '@/components/UserAvatar.vue'
 import NoPermission from '@/components/NoPermission.vue'
+import NotFound from '@/pages/NotFound.vue'
 import EditProfile from '@/components/Modals/EditProfile.vue'
 import EditCoverImage from '@/components/Modals/EditCoverImage.vue'
 

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -32,12 +32,8 @@
 				<EditCoverImage
 					@select="(imageUrl) => coverImage.submit({ url: imageUrl })"
 				>
-					<template v-slot="{ togglePopover }">
-						<Button
-							v-if="!readOnlyMode"
-							variant="outline"
-							@click="togglePopover()"
-						>
+					<template #default>
+						<Button v-if="!readOnlyMode" variant="outline">
 							<template #prefix>
 								<span class="lucide-edit size-4 text-ink-gray-7" />
 							</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -249,6 +249,11 @@ const routes = [
 		component: () => import('@/pages/DataImport.vue'),
 		props: true,
 	},
+	{
+		path: '/:pathMatch(.*)*',
+		name: 'NotFound',
+		component: () => import('@/pages/NotFound.vue'),
+	},
 ]
 
 let router = createRouter({

--- a/frontend/src/stores/settings.js
+++ b/frontend/src/stores/settings.js
@@ -19,6 +19,13 @@ export const useSettings = defineStore('settings', () => {
 		auto: false,
 	})
 
+	function loadSidebarSettings(force = false) {
+		if (force) return sidebarSettings.reload()
+		if (sidebarSettings.data) return Promise.resolve(sidebarSettings.data)
+		if (sidebarSettings.loading) return sidebarSettings.promise
+		return sidebarSettings.reload()
+	}
+
 	const programs = createResource({
 		url: 'lms.lms.utils.get_programs',
 		auto: false,
@@ -31,5 +38,6 @@ export const useSettings = defineStore('settings', () => {
 		programs,
 		settings,
 		sidebarSettings,
+		loadSidebarSettings,
 	}
 })

--- a/frontend/src/tests/lessonMacros.test.ts
+++ b/frontend/src/tests/lessonMacros.test.ts
@@ -74,6 +74,66 @@ describe('convertBodyToBlocks — malformed macros never crash the editor', () =
 	})
 })
 
+// Bug 3: header detection used `block.includes('#')`, so any prose line
+// containing a '#' anywhere (e.g. "Great for C# developers") became a header
+// with every '#' stripped, mangling the body. Only a leading '#' run is a header.
+describe('convertBodyToBlocks — header detection is leading-only', () => {
+	it('keeps prose with an inline # as a paragraph, verbatim', () => {
+		expect(convertBodyToBlocks({ body: 'Great for C# developers' })).toEqual([
+			{ type: 'paragraph', data: { text: 'Great for C# developers' } },
+		])
+	})
+
+	it('treats a leading # run as a header and strips only that run', () => {
+		expect(convertBodyToBlocks({ body: '## Notes on C# and F#' })).toEqual([
+			{ type: 'header', data: { text: 'Notes on C# and F#', level: 2 } },
+		])
+	})
+
+	it('derives level from the leading run, not the total # count', () => {
+		const [block] = convertBodyToBlocks({ body: '# One # inline' })
+		expect(block).toEqual({
+			type: 'header',
+			data: { text: 'One # inline', level: 1 },
+		})
+	})
+})
+
+// Bug 4: a `youtube` field holding a full "watch?v=ID" URL was reduced with
+// split('/').pop(), yielding "watch?v=ID" and a broken /embed/watch?v=ID src.
+describe('convertBodyToBlocks — youtube field URL forms', () => {
+	it.each([
+		['https://www.youtube.com/watch?v=abc123', 'abc123'],
+		['https://youtu.be/abc123', 'abc123'],
+		['https://www.youtube.com/embed/abc123', 'abc123'],
+		['abc123', 'abc123'],
+	])('embeds %s as the ID %s', (youtube, id) => {
+		const blocks = convertBodyToBlocks({ body: '', youtube })
+		expect(blocks[0]).toEqual({
+			type: 'embed',
+			data: {
+				service: 'youtube',
+				embed: `https://www.youtube.com/embed/${id}`,
+			},
+		})
+	})
+})
+
+// Bug 5: file_type came from url.split('.').pop() without stripping the query
+// string, so "/files/clip.mp4?v=2" produced "mp4?v=2" and failed isVideo().
+describe('convertBodyToBlocks — media file_type ignores query strings', () => {
+	it('strips a query string before deriving the extension', () => {
+		const blocks = convertBodyToBlocks({
+			body: [
+				`{{ Video("/files/clip.mp4?v=2") }}`,
+				`{{ Audio("/files/a.mp3#t=3") }}`,
+			].join('\n'),
+		})
+		expect(blocks[0].data.file_type).toBe('mp4')
+		expect(blocks[1].data.file_type).toBe('mp3')
+	})
+})
+
 // Bug 2: getId() (via getMacroArg) ran `.match(...)[1]` unguarded. A malformed
 // macro made .match() return null, and null[1] threw — taking down the whole
 // lesson render instead of just skipping the bad block.

--- a/frontend/src/utils/lessonMacros.ts
+++ b/frontend/src/utils/lessonMacros.ts
@@ -23,6 +23,27 @@ export function getMacroArg(block: string): string | null {
 }
 
 /**
+ * Extract a YouTube video ID from a stored `youtube` field, which may hold a
+ * bare ID, a `watch?v=ID` URL, a `youtu.be/ID` short link, or an `/embed/ID`
+ * URL. A naive `split('/').pop()` turns `watch?v=ID` into `watch?v=ID` and
+ * produces a broken embed, so pull the `v=` param first.
+ */
+export function extractYoutubeID(url: string): string {
+	const watchMatch = url.match(/[?&]v=([^&]+)/)
+	if (watchMatch) return watchMatch[1]
+	return url.split('/').pop()!.split(/[?#]/)[0]
+}
+
+/**
+ * Derive a file extension from a media URL, stripping any query string or
+ * fragment first: `/files/clip.mp4?v=2` -> `mp4`, not `mp4?v=2` (which would
+ * fail the isVideo/isAudio extension checks in utils/upload.js).
+ */
+export function fileExtension(url: string): string {
+	return url.split(/[?#]/)[0].split('.').pop() ?? ''
+}
+
+/**
  * Convert a lesson's legacy markdown/macro `body` into EditorJS blocks.
  *
  * Moved out of LessonForm.vue so the macro-to-block mapping is unit-testable.
@@ -50,7 +71,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 		})
 	}
 	if (lessonData.youtube) {
-		let youtubeID = lessonData.youtube.split('/').pop()
+		let youtubeID = extractYoutubeID(lessonData.youtube)
 		pushYoutube(`https://www.youtube.com/embed/${youtubeID}`)
 	}
 	lessonData.body.split('\n').forEach((block) => {
@@ -73,7 +94,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				type: 'upload',
 				data: {
 					file_url: video,
-					file_type: video.split('.').pop(),
+					file_type: fileExtension(video),
 				},
 			})
 		} else if (block.includes('{{ Audio')) {
@@ -82,7 +103,7 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 				type: 'upload',
 				data: {
 					file_url: audio,
-					file_type: audio.split('.').pop(),
+					file_type: fileExtension(audio),
 				},
 			})
 		} else if (block.includes('{{ PDF')) {
@@ -112,12 +133,12 @@ export function convertBodyToBlocks(lessonData: LessonBodyData): EditorBlock[] {
 					file_type: 'image',
 				},
 			})
-		} else if (block.includes('#')) {
-			let level = (block.match(/#/g) || []).length
+		} else if (/^#+/.test(block)) {
+			let level = block.match(/^#+/)![0].length
 			blocks.push({
 				type: 'header',
 				data: {
-					text: block.replace(/#/g, '').trim(),
+					text: block.replace(/^#+/, '').trim(),
 					level: level,
 				},
 			})

--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -149,6 +149,7 @@ scheduler_events = {
 		"lms.lms.doctype.lms_batch.lms_batch.send_batch_start_reminder",
 		"lms.lms.doctype.lms_live_class.lms_live_class.send_live_class_reminder",
 		"lms.lms.doctype.lms_course.lms_course.send_notification_for_published_courses",
+		"lms.lms.doctype.course_lesson.course_lesson.rename_settled_untitled_lessons",
 	],
 }
 

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -1978,6 +1978,10 @@ def get_pwa_manifest():
 
 @frappe.whitelist()
 def get_profile_details(username: str):
+	if not has_lms_role():
+		frappe.throw(
+			_("User does not have permission to access this user's profile details."), frappe.PermissionError
+		)
 	details = frappe.db.get_value(
 		"User",
 		{"username": username},
@@ -1999,12 +2003,9 @@ def get_profile_details(username: str):
 		],
 		as_dict=True,
 	)
-	roles = frappe.get_roles(details.name)
-	if not has_lms_role():
-		frappe.throw(
-			_("User does not have permission to access this user's profile details."), frappe.PermissionError
-		)
-	details.roles = roles
+	if not details:
+		frappe.throw(_("User {0} not found").format(username), frappe.DoesNotExistError)
+	details.roles = frappe.get_roles(details.name)
 	return details
 
 

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -9,6 +9,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.realtime import get_website_room
+from frappe.utils import add_to_date, now_datetime
 from frappe.utils.response import send_private_file
 from frappe.utils.telemetry import capture
 
@@ -416,6 +417,69 @@ def get_quiz_progress(lesson):
 		):
 			return False
 	return True
+
+
+UNTITLED_LESSON_TITLE = "Untitled lesson"
+RENAME_BATCH_LIMIT = 500
+
+
+def _untitled_placeholders():
+	"""Placeholder titles in every language a lesson could have been created in."""
+	placeholders = {UNTITLED_LESSON_TITLE}
+	langs = set(frappe.db.get_all("User", pluck="language", distinct=True))
+	langs.add(frappe.db.get_default("lang"))
+	for lang in (lang for lang in langs if lang):
+		translated = frappe.translate.get_all_translations(lang).get(UNTITLED_LESSON_TITLE)
+		if translated:
+			placeholders.add(translated)
+	return list(placeholders)
+
+
+def rename_settled_untitled_lessons():
+	"""Rename settled 'NNNN Untitled lesson' docnames to their real title (daily).
+
+	TODO(docs): document this maintenance job at docs.frappe.io/learning.
+	"""
+	placeholders = _untitled_placeholders()
+	day_ago = add_to_date(now_datetime(), days=-1)
+	lessons = frappe.get_all(
+		"Course Lesson",
+		or_filters=[["name", "like", f"% {p}"] for p in placeholders],
+		filters={"modified": ("<", day_ago)},
+		fields=["name", "title"],
+		order_by="modified asc",
+		limit=RENAME_BATCH_LIMIT,
+	)
+	for lesson in lessons:
+		prefix, _sep, title_part = lesson.name.partition(" ")
+		if title_part not in placeholders:
+			continue
+		new_title = (lesson.title or "").strip()
+		if not new_title or new_title in placeholders:
+			continue
+		new_name = f"{prefix} {new_title}"[:140]
+		if new_name == lesson.name:
+			continue
+		try:
+			frappe.rename_doc(
+				"Course Lesson",
+				lesson.name,
+				new_name,
+				force=True,
+				rebuild_search=False,
+				show_alert=False,
+			)
+			frappe.db.commit()
+		except Exception:
+			frappe.db.rollback()
+			frappe.logger("lms").warning(
+				f"Failed to rename settled untitled lesson {lesson.name}", exc_info=True
+			)
+
+	if len(lessons) == RENAME_BATCH_LIMIT:
+		frappe.logger("lms").info(
+			"rename_settled_untitled_lessons hit the per-run cap; remaining lessons handled next run"
+		)
 
 
 def get_assignment_progress(lesson):

--- a/lms/lms/doctype/course_lesson/test_course_lesson.py
+++ b/lms/lms/doctype/course_lesson/test_course_lesson.py
@@ -3,6 +3,16 @@
 
 import json
 import unittest
+from unittest.mock import patch
+
+import frappe
+from frappe.utils import add_to_date, now_datetime
+
+from lms.lms.doctype.course_lesson.course_lesson import (
+	UNTITLED_LESSON_TITLE,
+	rename_settled_untitled_lessons,
+)
+from lms.lms.test_helpers import BaseTestUtils
 
 # One sample URL per embed service registered in the LMS EditorJS editor.
 # Source of truth: frontend/src/utils/index.js → getEditorTools() → embed.config.services.
@@ -348,3 +358,84 @@ class TestLessonBlockExtraction(unittest.TestCase):
 		# The reported crash case: extraction yields nothing instead of raising.
 		self.assertEqual(self._quiz_ids("https://www.youtube.com/watch?v=htpg8CuD1Ec"), [])
 		self.assertEqual(self._assignment_ids("https://www.youtube.com/watch?v=htpg8CuD1Ec"), [])
+
+
+class TestRenameSettledUntitledLessons(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		# _create_course() defaults instructor="frappe@example.com"; create it so the
+		# course's instructor Link resolves on a fresh DB (mirrors TestLMSCourse.setUp).
+		self.instructor = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"]
+		)
+		self.course = self._create_course(title="Rename Untitled Course")
+		self.chapter = self._create_chapter("Rename Chapter", self.course.name)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def _make_untitled_lesson(self):
+		lesson = self._create_lesson(UNTITLED_LESSON_TITLE, self.chapter.name, self.course.name)
+		self.assertTrue(lesson.name.endswith(f" {UNTITLED_LESSON_TITLE}"))
+		return lesson
+
+	def _retitle(self, lesson, title):
+		frappe.db.set_value("Course Lesson", lesson.name, "title", title, update_modified=False)
+
+	def _age_modified(self, name, days):
+		frappe.db.set_value(
+			"Course Lesson", name, "modified", add_to_date(now_datetime(), days=days), update_modified=False
+		)
+
+	def test_settled_lesson_is_renamed(self):
+		lesson = self._make_untitled_lesson()
+		prefix = lesson.name.split(" ", 1)[0]
+		self._retitle(lesson, "Real Title")
+		self._age_modified(lesson.name, days=-2)
+
+		rename_settled_untitled_lessons()
+
+		expected = f"{prefix} Real Title"
+		self.assertFalse(frappe.db.exists("Course Lesson", lesson.name))
+		self.assertTrue(frappe.db.exists("Course Lesson", expected))
+		self.cleanup_items.append(("Course Lesson", expected))
+
+	def test_recently_modified_lesson_is_not_renamed(self):
+		lesson = self._make_untitled_lesson()
+		self._retitle(lesson, "Fresh Edit")
+
+		rename_settled_untitled_lessons()
+
+		self.assertTrue(frappe.db.exists("Course Lesson", lesson.name))
+
+	def test_still_untitled_lesson_is_not_renamed(self):
+		lesson = self._make_untitled_lesson()
+		self._age_modified(lesson.name, days=-2)
+
+		rename_settled_untitled_lessons()
+
+		self.assertTrue(frappe.db.exists("Course Lesson", lesson.name))
+
+	def test_translated_placeholder_lesson_is_renamed(self):
+		translated = "Titre provisoire"
+		lang = "fr"
+		user = self._create_user("french-author@example.com", "French", "Author", ["LMS Student"])
+		frappe.db.set_value("User", user.name, "language", lang)
+
+		lesson = self._create_lesson(translated, self.chapter.name, self.course.name)
+		self.assertTrue(lesson.name.endswith(f" {translated}"))
+		prefix = lesson.name.split(" ", 1)[0]
+		self._retitle(lesson, "Titre Réel")
+		self._age_modified(lesson.name, days=-2)
+
+		def fake_translations(target_lang):
+			return {UNTITLED_LESSON_TITLE: translated} if target_lang == lang else {}
+
+		with patch("frappe.translate.get_all_translations", side_effect=fake_translations):
+			rename_settled_untitled_lessons()
+
+		expected = f"{prefix} Titre Réel"
+		self.assertFalse(frappe.db.exists("Course Lesson", lesson.name))
+		self.assertTrue(frappe.db.exists("Course Lesson", expected))
+		self.cleanup_items.append(("Course Lesson", expected))

--- a/lms/lms/user.py
+++ b/lms/lms/user.py
@@ -1,3 +1,5 @@
+import time
+
 import frappe
 from frappe import _
 from frappe.model.naming import append_number_if_name_exists
@@ -46,29 +48,40 @@ def sign_up(email: str, full_name: str, verify_terms: bool, user_category: str):
 				http_status_code=429,
 			)
 
-	user = frappe.get_doc(
-		{
-			"doctype": "User",
-			"email": email,
-			"first_name": escape_html(full_name),
-			"verify_terms": verify_terms,
-			"user_category": user_category,
-			"country": "",
-			"enabled": 1,
-			"new_password": random_string(10),
-			"user_type": "Website User",
-		}
-	)
-	user.flags.ignore_permissions = True
-	user.flags.ignore_password_policy = True
-	user.insert()
-
-	# set default signup role as per Portal Settings
 	default_role = frappe.db.get_single_value("Portal Settings", "default_role")
-	if default_role:
-		user.add_roles(default_role)
 
-	user.add_roles("LMS Student")
+	# Concurrent signups deadlock on User insert (Frappe doesn't retry 1213); retry, and append roles pre-insert to keep it to one transaction.
+	for attempt in range(3):
+		try:
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": escape_html(full_name),
+					"verify_terms": verify_terms,
+					"user_category": user_category,
+					"country": "",
+					"enabled": 1,
+					"new_password": random_string(10),
+					"user_type": "Website User",
+				}
+			)
+			user.flags.ignore_permissions = True
+			user.flags.ignore_password_policy = True
+			if default_role:
+				user.append_roles(default_role)
+			user.insert()
+			break
+		except frappe.DuplicateEntryError:
+			# A concurrent signup for the same email won the race; treat as already registered.
+			frappe.db.rollback()
+			return 0, _("Already Registered")
+		except frappe.QueryDeadlockError:
+			frappe.db.rollback()
+			if attempt == 2:
+				raise
+			time.sleep(0.1 * (attempt + 1))
+
 	set_country_from_ip(None, user.name)
 
 	if user.flags.email_sent:


### PR DESCRIPTION
## Summary

- 7 fixes as detailed below with tests:

| # | Fix |
|---|-----|
| **#2579** | Sidebar settings were being fetched 3–4 times on every navigation. Now fetched once on first load and reused after that. |
| **#2589** | Some popovers opened then instantly closed because they were toggled twice. Removed the extra toggle so they open normally. |
| **#2577** | Unknown URLs showed a blank page. Added a proper "Not Found" page with a link back home. |
| **#2576** | Visiting an unknown username returned a 500 error. Now returns a clean 404 instead. |
| — | Lessons created as "Untitled lesson" kept that name in the URL even after being retitled. A daily job now renames them once the title has settled. |
| — | Two people signing up at the same time could fail with a database error. The signup now retries instead of failing. |
| — | Fixed a few cases where old lessons imported wrong: a `#` in a sentence was treated as a heading, some YouTube links broke, and video/audio files with extra bits in the URL weren't recognized. |

## Issues
Closes #2576, #2577, #2579, #2589
