### PR TITLE
fix(a11y): keyboard operability and semantic html across frontend

### DIFF
--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -120,8 +120,10 @@
 									</span>
 								</div>
 							</a>
-							<span
+							<button
 								v-if="canModifyAssignment"
+								type="button"
+								:aria-label="__('Remove submission')"
 								@click="removeSubmission()"
 								class="lucide-x bg-surface-gray-3 rounded-md cursor-pointer w-5 h-5 p-1 ms-4"
 							/>
@@ -132,7 +134,11 @@
 					<div class="text-p-sm-medium text-ink-gray-7 mb-1.5">
 						{{ __('Enter a URL') }}
 					</div>
-					<FormControl v-model="answer" type="text" />
+					<FormControl
+						v-model="answer"
+						type="text"
+						:aria-label="__('Enter a URL')"
+					/>
 				</div>
 				<div v-else>
 					<div class="text-sm mb-2 text-ink-gray-7">

--- a/frontend/src/components/AudioBlock.vue
+++ b/frontend/src/components/AudioBlock.vue
@@ -7,7 +7,11 @@
 			<source :src="encodeURI(file)" type="audio/mp3" />
 		</audio>
 		<div class="flex items-center gap-x-2 shadow rounded-lg p-1 w-1/2">
-			<Button variant="ghost" @click="togglePlay">
+			<Button
+				variant="ghost"
+				:label="isPlaying ? __('Pause') : __('Play')"
+				@click="togglePlay"
+			>
 				<template #icon>
 					<span v-if="!isPlaying" class="lucide-play w-4 h-4 text-ink-gray-9" />
 					<span v-else class="lucide-pause w-4 h-4 text-ink-gray-9" />
@@ -20,12 +24,17 @@
 				step="0.1"
 				v-model="currentTime"
 				@input="changeCurrentTime"
+				:aria-label="__('Seek')"
 				class="duration-slider w-full h-1"
 			/>
 			<span class="text-xs-medium text-ink-gray-9">
 				{{ formatTime(currentTime) }} / {{ formatTime(duration) }}
 			</span>
-			<Button variant="ghost" @click="toggleMute">
+			<Button
+				variant="ghost"
+				:label="isMuted ? __('Unmute') : __('Mute')"
+				@click="toggleMute"
+			>
 				<template #icon>
 					<span
 						v-if="!isMuted"

--- a/frontend/src/components/CommandPalette/CommandPalette.vue
+++ b/frontend/src/components/CommandPalette/CommandPalette.vue
@@ -138,6 +138,9 @@ const addKeyboardShortcuts = () => {
 		} else if (e.key === 'ArrowDown' && show.value) {
 			shortcutForArrowKey(1)
 		} else if (e.key === 'Enter' && show.value) {
+			// A focused result button fires its own click; let that be the
+			// single navigation instead of racing this handler.
+			if ((e.target as HTMLElement)?.closest?.('[data-palette-item]')) return
 			shortcutForEnter()
 		} else if (e.key === 'Escape' && show.value) {
 			show.value = false

--- a/frontend/src/components/CommandPalette/CommandPaletteGroup.vue
+++ b/frontend/src/components/CommandPalette/CommandPaletteGroup.vue
@@ -1,28 +1,31 @@
 <template>
-	<div v-for="result in list" class="px-2.5 space-y-2">
+	<div v-for="result in list" :key="result.title" class="px-2.5 space-y-2">
 		<div class="text-ink-gray-5 px-2">
 			{{ result.title }}
 		</div>
-		<div class="">
-			<div
-				v-for="item in result.items"
-				class="flex items-center justify-between p-2 rounded hover:bg-surface-gray-2 cursor-pointer"
-				:class="{ 'bg-surface-gray-2': item.isActive }"
-				@click="emit('navigateTo', item.route)"
-			>
-				<div class="flex items-center gap-x-3">
-					<component
-						v-if="item.icon"
-						:is="item.icon"
-						class="size-4 stroke-1.5 text-ink-gray-6"
-					/>
-					<div v-html="sanitizeRichHTML(item.title)"></div>
-				</div>
-				<div v-if="item.modified" class="text-ink-gray-5">
-					{{ dayjs.unix(item.modified).fromNow(true) }}
-				</div>
-			</div>
-		</div>
+		<ul class="list-none">
+			<li v-for="(item, index) in result.items" :key="index">
+				<button
+					type="button"
+					data-palette-item
+					class="flex items-center justify-between p-2 rounded hover:bg-surface-gray-2 cursor-pointer w-full text-start"
+					:class="{ 'bg-surface-gray-2': item.isActive }"
+					@click="emit('navigateTo', item.route)"
+				>
+					<div class="flex items-center gap-x-3">
+						<component
+							v-if="item.icon"
+							:is="item.icon"
+							class="size-4 stroke-1.5 text-ink-gray-6"
+						/>
+						<div v-html="sanitizeRichHTML(item.title)"></div>
+					</div>
+					<div v-if="item.modified" class="text-ink-gray-5">
+						{{ dayjs.unix(item.modified).fromNow(true) }}
+					</div>
+				</button>
+			</li>
+		</ul>
 	</div>
 </template>
 <script lang="ts" setup>
@@ -37,6 +40,7 @@ const props = defineProps<{
 		title: string
 		items: Array<{
 			title: string
+			route: { name: string; params?: Record<string, string> }
 			icon?: any
 			isActive?: boolean
 			modified?: string

--- a/frontend/src/components/Controls/ChildTable.vue
+++ b/frontend/src/components/Controls/ChildTable.vue
@@ -26,6 +26,7 @@
 						<input
 							v-if="showKey(key)"
 							v-model="row[key]"
+							:aria-label="columnLabel(key)"
 							class="py-1.5 px-2 w-full border-none bg-transparent text-ink-gray-8 focus:ring-0 focus:border focus:border-outline-gray-3 focus:bg-surface-gray-2 rounded-md text-sm focus:outline-none"
 						/>
 					</template>
@@ -33,6 +34,7 @@
 					<div class="relative">
 						<Button
 							variant="ghost"
+							:label="__('Row actions')"
 							@click="(event: MouseEvent) => toggleMenu(rowIndex, event)"
 						>
 							<template #icon>
@@ -53,6 +55,7 @@
 							"
 						>
 							<button
+								type="button"
 								@click="deleteRow(rowIndex)"
 								class="flex items-center gap-x-2 w-full text-start px-3 py-2 text-sm text-ink-red-6"
 							>
@@ -123,7 +126,7 @@ const addRow = () => {
 	}
 	let newRow: { [key: string]: string } = {}
 	columns.value.forEach((column: any) => {
-		newRow[column.toLowerCase().split(' ').join('_')] = ''
+		newRow[keyFor(column)] = ''
 	})
 	rows.value.push(newRow)
 	focusNewRowInput()
@@ -159,10 +162,13 @@ onClickOutside(menuRef, () => {
 	menuOpenIndex.value = null
 })
 
+const keyFor = (column: string) => column.toLowerCase().split(' ').join('_')
+
 const showKey = (key: string) => {
-	let columnsLower = columns.value.map((col) =>
-		col.toLowerCase().split(' ').join('_')
-	)
-	return columnsLower.includes(key)
+	return columns.value.some((col) => keyFor(col) === key)
+}
+
+const columnLabel = (key: string) => {
+	return __(columns.value.find((col) => keyFor(col) === key) || key)
 }
 </script>

--- a/frontend/src/components/Controls/ColorSwatches.vue
+++ b/frontend/src/components/Controls/ColorSwatches.vue
@@ -31,11 +31,12 @@
 							</div>
 						</template>
 						<template #suffix>
-							<Button variant="ghost">
-								<span
-									class="lucide-x size-3 text-ink-gray-5"
-									@click="emit('update:modelValue', null)"
-								/>
+							<Button
+								variant="ghost"
+								:label="__('Clear color')"
+								@click="emit('update:modelValue', null)"
+							>
+								<span class="lucide-x size-3 text-ink-gray-5" />
 							</Button>
 						</template>
 					</FormControl>
@@ -47,9 +48,11 @@
 						{{ __('Swatches') }}
 					</div>
 					<div class="grid grid-cols-7 gap-2">
-						<div
+						<button
 							v-for="color in colors"
 							:key="color"
+							type="button"
+							:aria-label="color"
 							class="size-5 rounded-full cursor-pointer"
 							:style="{
 								backgroundColor: `var(--${color.toLowerCase()}-400)`,
@@ -61,7 +64,7 @@
 									emit('change', color)
 								}
 							"
-						></div>
+						></button>
 					</div>
 				</div>
 			</template>

--- a/frontend/src/components/Controls/IconPicker.vue
+++ b/frontend/src/components/Controls/IconPicker.vue
@@ -5,6 +5,7 @@
 			<Popover>
 				<template #trigger>
 					<button
+						type="button"
 						class="flex w-full items-center gap-x-2 focus:outline-none transition-colors border border-[--surface-gray-2] bg-surface-gray-2 rounded h-7 py-1.5 px-2 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0"
 					>
 						<component
@@ -31,16 +32,22 @@
 							ref="search"
 							v-model="iconQuery"
 							:placeholder="__('Search for an icon')"
+							:aria-label="__('Search for an icon')"
 							autocomplete="off"
 						/>
 						<div class="grid grid-cols-10 gap-4 mt-4">
-							<div v-for="(iconComponent, iconName) in filteredIcons">
+							<button
+								v-for="(iconComponent, iconName) in filteredIcons"
+								:key="iconName"
+								type="button"
+								:aria-label="iconName"
+								@click="setIcon(iconName, close)"
+							>
 								<component
 									:is="iconComponent"
 									class="h-4 w-4 stroke-1.5 text-ink-gray-7 cursor-pointer"
-									@click="setIcon(iconName, close)"
 								/>
-							</div>
+							</button>
 						</div>
 					</div>
 				</template>

--- a/frontend/src/components/Controls/ImageUploader.vue
+++ b/frontend/src/components/Controls/ImageUploader.vue
@@ -9,7 +9,7 @@
 					:iconLeft="uploading ? 'cloud-upload' : 'lucide-image-up'"
 					:label="
 						uploading
-							? __('Uploading {0}%', [progress])
+							? __('Uploading {0}%').format(progress)
 							: image_url
 							? __('Change')
 							: __('Upload')

--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div :class="attrs.class as any" :style="attrs.style as any">
 		<FormLabel
 			v-if="attrs.label"
 			:label="attrs.label"
@@ -13,6 +13,7 @@
 			:placeholder="attrs.placeholder as string"
 			:disabled="attrs.readonly as boolean"
 			:size="(attrs.size as ComboboxSize) || 'sm'"
+			:aria-label="attrs['aria-label'] as string"
 			:variant="attrs.variant as ComboboxVariant"
 			:loading="options.loading"
 			@update:modelValue="onSelect"
@@ -119,6 +120,8 @@ const emit = defineEmits<{
 	(e: 'update:modelValue', value: string): void
 	(e: 'change', value: string): void
 }>()
+
+defineOptions({ inheritAttrs: false })
 
 const attrs = useAttrs()
 const valuePropPassed = computed<boolean>(() => 'value' in attrs)

--- a/frontend/src/components/Controls/MultiSelect.vue
+++ b/frontend/src/components/Controls/MultiSelect.vue
@@ -21,6 +21,7 @@
 						ref="search"
 						class="flex-1 min-w-[4rem] border-none outline-none bg-transparent p-0 text-base focus:ring-0"
 						type="text"
+						:aria-label="label || __('Search')"
 						:placeholder="!values?.length ? __('Search...') : ''"
 						@change="
 							(e) => {

--- a/frontend/src/components/Controls/Uploader.vue
+++ b/frontend/src/components/Controls/Uploader.vue
@@ -19,6 +19,7 @@
 							<img
 								v-if="type === 'image'"
 								:src="modelValue"
+								:alt="label ? __(label) : __('Uploaded image preview')"
 								class="size-full object-cover"
 							/>
 							<video v-else controls class="size-full object-cover">

--- a/frontend/src/components/Controls/VideoPreviewField.vue
+++ b/frontend/src/components/Controls/VideoPreviewField.vue
@@ -8,6 +8,7 @@
 				<iframe
 					v-if="preview.type === 'youtube'"
 					:src="preview.src"
+					:title="__('Video preview')"
 					class="size-full"
 					frameborder="0"
 					allow="accelerometer; encrypted-media; picture-in-picture"
@@ -33,6 +34,7 @@
 				<button
 					v-if="modelValue && !isUploadedVideo"
 					type="button"
+					:aria-label="__('Remove video')"
 					class="absolute end-1 top-1 grid size-6 place-items-center rounded bg-surface-base/90 shadow"
 					@click="update('')"
 				>
@@ -82,6 +84,7 @@
 				<FormControl
 					type="text"
 					v-model="urlInput"
+					:aria-label="__('YouTube link')"
 					:placeholder="__('Paste a YouTube link')"
 					variant="outline"
 				/>

--- a/frontend/src/components/CourseCard.vue
+++ b/frontend/src/components/CourseCard.vue
@@ -112,6 +112,7 @@
 					>
 						<UserAvatar
 							v-for="instructor in course.instructors"
+							:key="instructor.username || instructor.name"
 							:user="instructor"
 						/>
 					</div>

--- a/frontend/src/components/CourseCreatorCard.vue
+++ b/frontend/src/components/CourseCreatorCard.vue
@@ -54,6 +54,7 @@
 							v-for="(instructor, idx) in visiblePeers"
 							:key="instructor.username || instructor.name || idx"
 							type="button"
+							:aria-label="instructor.full_name"
 							class="rounded-full hover:-translate-y-0.5 transition -ms-1.5 first:ms-0"
 							@click="focusInstructor(instructor)"
 						>
@@ -62,6 +63,7 @@
 						<button
 							v-if="hiddenPeerCount > 0"
 							type="button"
+							:aria-label="__('Show more instructors')"
 							class="-ms-1.5 flex items-center justify-center size-6 rounded-full bg-surface-gray-3 text-xs-medium text-ink-gray-7 hover:bg-surface-gray-4 transition"
 							@click="expanded = true"
 						>

--- a/frontend/src/components/DiscussionReplies.vue
+++ b/frontend/src/components/DiscussionReplies.vue
@@ -1,7 +1,11 @@
 <template>
 	<div class="mt-6">
 		<div v-if="!singleThread" class="flex items-center mb-5 md:hidden">
-			<Button variant="outline" @click="showTopics = true">
+			<Button
+				variant="outline"
+				:label="__('Back to topics')"
+				@click="showTopics = true"
+			>
 				<template #icon>
 					<span class="lucide-chevron-left size-5 text-ink-gray-7" />
 				</template>
@@ -17,66 +21,74 @@
 			{{ topic.title }}
 		</div>
 
-		<div v-for="(reply, index) in replies.data">
-			<div
-				class="py-3"
-				:class="{ 'border-b': index + 1 != replies.data.length }"
-			>
-				<div class="flex items-center justify-between mb-2">
-					<div class="flex items-center text-ink-gray-5">
-						<UserAvatar :user="reply.user" class="me-2" />
-						<span>
-							{{ reply.user.full_name }}
-						</span>
-						<span class="text-sm ms-2">
-							{{ timeAgo(reply.creation) }}
-						</span>
+		<ul class="list-none">
+			<li v-for="(reply, index) in replies.data" :key="reply.name">
+				<div
+					class="py-3"
+					:class="{ 'border-b': index + 1 != replies.data.length }"
+				>
+					<div class="flex items-center justify-between mb-2">
+						<div class="flex items-center text-ink-gray-5">
+							<UserAvatar :user="reply.user" class="me-2" />
+							<span>
+								{{ reply.user.full_name }}
+							</span>
+							<span class="text-sm ms-2">
+								{{ timeAgo(reply.creation) }}
+							</span>
+						</div>
+						<Dropdown
+							v-if="
+								user.data.name == reply.owner &&
+								!reply.editable &&
+								!readOnlyMode
+							"
+							:options="[
+								{
+									label: __('Edit'),
+									onClick() {
+										reply.editable = true
+									},
+								},
+								{
+									label: __('Delete'),
+									onClick() {
+										deleteReply(reply)
+									},
+								},
+							]"
+						>
+							<template #default>
+								<Button variant="ghost" :label="__('Reply actions')">
+									<template #icon>
+										<span class="lucide-more-horizontal size-4" />
+									</template>
+								</Button>
+							</template>
+						</Dropdown>
+						<div v-if="reply.editable">
+							<Button variant="ghost" @click="postEdited(reply)">
+								{{ __('Post') }}
+							</Button>
+							<Button variant="ghost" @click="reply.editable = false">
+								{{ __('Discard') }}
+							</Button>
+						</div>
 					</div>
-					<Dropdown
-						v-if="
-							user.data.name == reply.owner && !reply.editable && !readOnlyMode
+					<RichTextEditor
+						:content="reply.reply"
+						@change="(val) => (reply.reply = val)"
+						:editable="reply.editable || false"
+						:fixedMenu="reply.editable || false"
+						:editorClass="
+							reply.editable
+								? 'ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none'
+								: 'prose-sm'
 						"
-						:options="[
-							{
-								label: __('Edit'),
-								onClick() {
-									reply.editable = true
-								},
-							},
-							{
-								label: __('Delete'),
-								onClick() {
-									deleteReply(reply)
-								},
-							},
-						]"
-					>
-						<template v-slot="{ open }">
-							<span class="lucide-more-horizontal size-4 cursor-pointer" />
-						</template>
-					</Dropdown>
-					<div v-if="reply.editable">
-						<Button variant="ghost" @click="postEdited(reply)">
-							{{ __('Post') }}
-						</Button>
-						<Button variant="ghost" @click="reply.editable = false">
-							{{ __('Discard') }}
-						</Button>
-					</div>
+					/>
 				</div>
-				<RichTextEditor
-					:content="reply.reply"
-					@change="(val) => (reply.reply = val)"
-					:editable="reply.editable || false"
-					:fixedMenu="reply.editable || false"
-					:editorClass="
-						reply.editable
-							? 'ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none'
-							: 'prose-sm'
-					"
-				/>
-			</div>
-		</div>
+			</li>
+		</ul>
 
 		<RichTextEditor
 			v-if="renderEditor && !readOnlyMode"

--- a/frontend/src/components/Discussions.vue
+++ b/frontend/src/components/Discussions.vue
@@ -20,43 +20,44 @@
 	>
 		<!-- Master: topic list (always visible at md+; hidden on mobile while a
 		     topic thread is open) -->
-		<div
-			class="md:w-2/5 md:shrink-0 md:max-h-[60vh] md:overflow-y-auto md:border-e md:pe-5"
+		<ul
+			class="md:w-2/5 md:shrink-0 md:max-h-[60vh] md:overflow-y-auto md:border-e md:pe-5 list-none"
 			:class="{ 'hidden md:block': currentTopic }"
 		>
-			<div
-				v-for="(topic, index) in topics.data"
-				:key="topic.name"
-				data-testid="topic-row"
-				@click="showReplies(topic)"
-				class="flex items-center cursor-pointer py-4 px-2 rounded-md w-full"
-				:class="[
-					{ 'border-b': index + 1 != topics.data.length },
-					currentTopic?.name === topic.name ? 'bg-surface-gray-2' : '',
-				]"
-			>
-				<UserAvatar :user="topic.user" size="xl" class="me-3" />
-				<div class="min-w-0">
-					<div class="text-base-semibold mb-1 text-ink-gray-7 truncate">
-						{{ topic.title }}
+			<li v-for="(topic, index) in topics.data" :key="topic.name">
+				<button
+					type="button"
+					data-testid="topic-row"
+					@click="showReplies(topic)"
+					class="flex items-center cursor-pointer py-4 px-2 rounded-md w-full text-start"
+					:class="[
+						{ 'border-b': index + 1 != topics.data.length },
+						currentTopic?.name === topic.name ? 'bg-surface-gray-2' : '',
+					]"
+				>
+					<UserAvatar :user="topic.user" size="xl" class="me-3" />
+					<div class="min-w-0">
+						<div class="text-base-semibold mb-1 text-ink-gray-7 truncate">
+							{{ topic.title }}
+						</div>
+						<div class="flex items-center text-ink-gray-5">
+							<span class="text-sm">
+								{{ timeAgo(topic.creation) }}
+							</span>
+							<span class="flex items-center gap-1 text-sm ms-3">
+								<span class="lucide-message-square size-3.5" />
+								{{
+									(topic.reply_count === 1
+										? __('{0} reply')
+										: __('{0} replies')
+									).format(topic.reply_count || 0)
+								}}
+							</span>
+						</div>
 					</div>
-					<div class="flex items-center text-ink-gray-5">
-						<span class="text-sm">
-							{{ timeAgo(topic.creation) }}
-						</span>
-						<span class="flex items-center gap-1 text-sm ms-3">
-							<span class="lucide-message-square size-3.5" />
-							{{
-								(topic.reply_count === 1
-									? __('{0} reply')
-									: __('{0} replies')
-								).format(topic.reply_count || 0)
-							}}
-						</span>
-					</div>
-				</div>
-			</div>
-		</div>
+				</button>
+			</li>
+		</ul>
 		<!-- Detail: selected topic's thread -->
 		<div class="flex-1 min-w-0">
 			<DiscussionReplies

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -32,7 +32,9 @@
 						{{ __('Install Frappe Learning') }}
 					</span>
 					<span class="inline-flex items-baseline">
-						<span
+						<button
+							type="button"
+							:aria-label="__('Close')"
 							class="lucide-x ms-auto size-4 text-ink-gray-7"
 							@click="iosInstallMessage = false"
 						/>

--- a/frontend/src/components/Layouts/DesktopLayout.vue
+++ b/frontend/src/components/Layouts/DesktopLayout.vue
@@ -1,13 +1,25 @@
 <template>
 	<div class="flex h-screen w-screen">
+		<a
+			href="#main-content"
+			@click.prevent="skipToContent('main-content')"
+			class="sr-only focus:not-sr-only focus:absolute focus:start-4 focus:top-4 focus:z-50 focus:rounded focus:bg-surface-base focus:px-4 focus:py-2 focus:text-ink-gray-9 focus:shadow-md focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+		>
+			{{ __('Skip to main content') }}
+		</a>
 		<div class="h-full border-e bg-surface-sidebar">
 			<AppSidebar />
 		</div>
-		<div class="flex-1 flex flex-col h-full overflow-auto bg-surface-base">
+		<main
+			id="main-content"
+			tabindex="-1"
+			class="flex-1 flex flex-col h-full overflow-auto bg-surface-base focus:outline-none"
+		>
 			<slot />
-		</div>
+		</main>
 	</div>
 </template>
 <script setup>
+import { skipToContent } from '@/utils/a11y'
 import AppSidebar from '@/components/Sidebar/AppSidebar.vue'
 </script>

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -20,7 +20,7 @@
 			<div
 				id="mobileMoreMenu"
 				class="fixed bottom-16 end-2 w-[80%] space-y-4 rounded-md bg-surface-base p-5 text-base shadow-md"
-				v-if="showMenu"
+				v-show="showMenu"
 				ref="menu"
 			>
 				<button

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -1,23 +1,33 @@
 <template>
 	<div class="relative flex h-screen flex-col">
-		<div
-			class="flex flex-1 flex-col overflow-y-auto pb-10"
+		<a
+			href="#scrollContainer"
+			@click.prevent="skipToContent('scrollContainer')"
+			class="sr-only focus:not-sr-only focus:absolute focus:start-4 focus:top-4 focus:z-50 focus:rounded focus:bg-surface-base focus:px-4 focus:py-2 focus:text-ink-gray-9 focus:shadow-md focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+		>
+			{{ __('Skip to main content') }}
+		</a>
+		<main
+			class="flex flex-1 flex-col overflow-y-auto pb-10 focus:outline-none"
 			id="scrollContainer"
+			tabindex="-1"
 		>
 			<slot />
-		</div>
+		</main>
 
 		<div class="relative z-20">
 			<!-- Dropdown menu -->
 			<div
+				id="mobileMoreMenu"
 				class="fixed bottom-16 end-2 w-[80%] space-y-4 rounded-md bg-surface-base p-5 text-base shadow-md"
 				v-if="showMenu"
 				ref="menu"
 			>
-				<div
+				<button
 					v-for="link in otherLinks"
 					:key="link.label"
-					class="flex cursor-pointer items-center gap-x-2"
+					type="button"
+					class="flex w-full cursor-pointer items-center gap-x-2"
 					@click="handleClick(link)"
 				>
 					<component
@@ -25,17 +35,21 @@
 						class="h-4 w-4 stroke-1.5 text-ink-gray-5"
 					/>
 					<div>{{ link.label }}</div>
-				</div>
+				</button>
 			</div>
 
 			<!-- Fixed menu -->
-			<div
+			<nav
 				v-if="sidebarSettings.data"
+				:aria-label="__('Primary')"
 				class="standalone:pb-4 fixed bottom-0 start-0 z-10 flex w-full items-center justify-around border-t border-outline-gray-2 bg-surface-base"
 			>
 				<button
 					v-for="tab in sidebarLinks"
 					:key="tab.label"
+					type="button"
+					:aria-label="__(tab.label)"
+					:aria-current="isActive(tab) ? 'page' : undefined"
 					:class="isVisible(tab) ? 'block' : 'hidden'"
 					class="flex flex-col items-center justify-center py-3 transition active:scale-95"
 					@click="handleClick(tab)"
@@ -46,17 +60,24 @@
 						:class="[isActive(tab) ? 'text-ink-gray-9' : 'text-ink-gray-5']"
 					/>
 				</button>
-				<button @click="toggleMenu">
+				<button
+					type="button"
+					:aria-label="__('More')"
+					:aria-expanded="showMenu"
+					aria-controls="mobileMoreMenu"
+					@click="toggleMenu"
+				>
 					<component
 						:is="icons['List']"
 						class="h-6 w-6 stroke-1.5 text-ink-gray-5"
 					/>
 				</button>
-			</div>
+			</nav>
 		</div>
 	</div>
 </template>
 <script setup>
+import { skipToContent } from '@/utils/a11y'
 import { getSidebarLinks } from '@/utils'
 import { useRouter } from 'vue-router'
 import { call } from 'frappe-ui'

--- a/frontend/src/components/Layouts/NoSidebarLayout.vue
+++ b/frontend/src/components/Layouts/NoSidebarLayout.vue
@@ -1,11 +1,25 @@
 <template>
 	<div class="relative flex h-full flex-col">
+		<a
+			href="#scrollContainer"
+			@click.prevent="skipToContent('scrollContainer')"
+			class="sr-only focus:not-sr-only focus:absolute focus:start-4 focus:top-4 focus:z-50 focus:rounded focus:bg-surface-base focus:px-4 focus:py-2 focus:text-ink-gray-9 focus:shadow-md focus:outline-none focus:ring-2 focus:ring-outline-gray-3"
+		>
+			{{ __('Skip to main content') }}
+		</a>
 		<div class="h-full flex-1">
 			<div class="flex h-screen text-base bg-surface-base">
-				<div class="w-full overflow-auto" id="scrollContainer">
+				<main
+					class="w-full overflow-auto focus:outline-none"
+					id="scrollContainer"
+					tabindex="-1"
+				>
 					<slot />
-				</div>
+				</main>
 			</div>
 		</div>
 	</div>
 </template>
+<script setup lang="ts">
+import { skipToContent } from '@/utils/a11y'
+</script>

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -3,17 +3,19 @@
 		<iframe
 			class="youtube-video"
 			:src="getYouTubeVideoSource(youtube.split('/').pop())"
+			:title="__('YouTube video')"
 			width="100%"
 			:height="screenSize.width < 640 ? 200 : 400"
 			frameborder="0"
 			allowfullscreen
 		></iframe>
 	</div>
-	<div v-for="block in content?.split('\n\n')">
+	<div v-for="(block, index) in content?.split('\n\n')" :key="index">
 		<div v-if="block.includes('{{ YouTubeVideo')">
 			<iframe
 				class="youtube-video"
 				:src="getYouTubeVideoSource(block)"
+				:title="__('YouTube video')"
 				width="100%"
 				:height="screenSize.width < 640 ? 200 : 400"
 				frameborder="0"
@@ -46,6 +48,7 @@
 				width="100%"
 				height="400"
 				:src="getId(block)"
+				:title="__('Embedded content')"
 				frameborder="0"
 				allowfullscreen
 			>

--- a/frontend/src/components/Modals/ChapterModal.vue
+++ b/frontend/src/components/Modals/ChapterModal.vue
@@ -63,7 +63,9 @@
 									{{ getFileSize(chapter.scorm_package.file_size) }}
 								</span>
 							</div>
-							<span
+							<button
+								type="button"
+								:aria-label="__('Remove file')"
 								@click="() => (chapter.scorm_package = null)"
 								class="lucide-x bg-surface-gray-3 rounded-md cursor-pointer w-5 h-5 p-1 ms-4 shrink-0"
 							/>

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -14,6 +14,7 @@
 						<TextInput
 							type="text"
 							placeholder="search by keyword"
+							:aria-label="__('Search images by keyword')"
 							v-model="search"
 							:debounce="300"
 							class="flex-1"
@@ -48,6 +49,7 @@
 									image.urls.raw +
 									'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
 								"
+								:alt="__('Cover image option')"
 							/>
 						</button>
 					</div>

--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -24,7 +24,7 @@
 						{{ __('Available Slots') }}
 					</div>
 					<div class="space-y-5">
-						<div v-for="row in slots.data" class="space-y-2">
+						<div v-for="row in slots.data" :key="row.date" class="space-y-2">
 							<div class="flex items-center text-ink-gray-7 gap-x-2">
 								<span class="lucide-calendar size-3" />
 								<div class="text-ink-gray-9">
@@ -36,8 +36,10 @@
 								</div>
 							</div>
 							<div class="grid grid-cols-3 gap-2">
-								<div
+								<button
 									v-for="slot in row.slots"
+									:key="slot.start_time"
+									type="button"
 									class="text-base text-center border rounded-md text-ink-gray-8 p-2 cursor-pointer text-ink-gray-7 hover:bg-surface-gray-2 hover:border-outline-gray-3"
 									@click="saveSlot(slot, row)"
 									:class="{
@@ -48,7 +50,7 @@
 								>
 									{{ formatTime(slot.start_time) }} -
 									{{ formatTime(slot.end_time) }}
-								</div>
+								</button>
 							</div>
 						</div>
 					</div>

--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -17,26 +17,30 @@
 							</div>
 						</Tooltip>
 						<Tooltip :text="__('Course')">
-							<div
+							<a
+								:href="`/lms/courses/${event.course}`"
+								target="_blank"
+								rel="noopener noreferrer"
 								class="flex gap-x-2 w-fit cursor-pointer"
-								@click="openLink('course', event.course)"
 							>
 								<span class="lucide-book-open h-4 w-4" />
 								<span>
 									{{ event.course_title }}
 								</span>
-							</div>
+							</a>
 						</Tooltip>
 						<Tooltip v-if="event.batch_title" :text="__('Batch')">
-							<div
+							<a
+								:href="`/lms/batches/${event.batch_name}#students`"
+								target="_blank"
+								rel="noopener noreferrer"
 								class="flex gap-x-2 w-fit cursor-pointer"
-								@click="openLink('batch', event.batch_name)"
 							>
 								<span class="lucide-users h-4 w-4" />
 								<span>
 									{{ event.batch_title }}
 								</span>
-							</div>
+							</a>
 						</Tooltip>
 						<Tooltip :text="__('Date')">
 							<div class="flex items-center gap-x-2 w-fit">
@@ -367,16 +371,6 @@ const openCertificate = (certificate) => {
 			certificate.name
 		}&format=${encodeURIComponent(certificate.template)}`
 	)
-}
-
-const openLink = (type, name) => {
-	let url = ''
-	if (type === 'course') {
-		url = `/lms/courses/${name}`
-	} else if (type === 'batch') {
-		url = `/lms/batches/${name}#students`
-	}
-	window.open(url, '_blank')
 }
 
 const statusOptions = computed(() => {

--- a/frontend/src/components/Modals/LiveClassAttendance.vue
+++ b/frontend/src/components/Modals/LiveClassAttendance.vue
@@ -24,9 +24,11 @@
 				</div>
 			</div>
 			<div class="divide-y text-base">
-				<div
+				<component
+					:is="participant.member_username ? 'router-link' : 'div'"
 					v-for="participant in participants.data"
-					@click="redirectToProfile(participant.member_username)"
+					:key="participant.name"
+					:to="profileRoute(participant.member_username)"
 					class="grid grid-cols-2 items-center w-full text-base w-fit py-2"
 				>
 					<div class="flex items-center gap-x-2">
@@ -54,18 +56,17 @@
 						</div>
 						<div>{{ participant.duration }} {{ __('minutes') }}</div>
 					</div>
-				</div>
+				</component>
 			</div>
 		</template>
 	</Dialog>
 </template>
 <script setup lang="ts">
 import { Avatar, createListResource, Dialog, Tooltip } from 'frappe-ui'
-import { useRouter } from 'vue-router'
 import { inject } from 'vue'
+import { profileRoute } from '@/utils/routes'
 
 const show = defineModel()
-const router = useRouter()
 const dayjs = inject('$dayjs')
 
 interface LiveClass {
@@ -94,11 +95,4 @@ const participants = createListResource({
 	],
 	auto: true,
 })
-
-const redirectToProfile = (username: string) => {
-	router.push({
-		name: 'Profile',
-		params: { username },
-	})
-}
 </script>

--- a/frontend/src/components/Modals/Question.vue
+++ b/frontend/src/components/Modals/Question.vue
@@ -70,6 +70,7 @@
 									v-if="visibleOptionCount > 2"
 									variant="ghost"
 									size="sm"
+									:label="__('Remove option')"
 									@click="removeOption(n)"
 								>
 									<span class="lucide-trash-2 size-4" />
@@ -118,6 +119,7 @@
 								<Button
 									v-if="visiblePossibilityCount > 1"
 									variant="ghost"
+									:label="__('Remove possibility')"
 									@click="removePossibility(n)"
 								>
 									<span class="lucide-trash-2 size-4" />

--- a/frontend/src/components/Modals/QuizInVideo.vue
+++ b/frontend/src/components/Modals/QuizInVideo.vue
@@ -74,6 +74,7 @@
 								<div class="flex gap-2">
 									<Button
 										variant="ghost"
+										:label="__('Remove quiz')"
 										@click="removeQuiz(selections, unselectAll)"
 									>
 										<span class="lucide-trash-2 h-4 w-4" />

--- a/frontend/src/components/Modals/VideoStatistics.vue
+++ b/frontend/src/components/Modals/VideoStatistics.vue
@@ -35,6 +35,7 @@
 							</div>
 							<div
 								v-for="row in currentTabData"
+								:key="row.name"
 								class="hover:bg-surface-gray-1 cursor-pointer rounded-md py-1 px-2"
 							>
 								<router-link

--- a/frontend/src/components/NoPermission.vue
+++ b/frontend/src/components/NoPermission.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="bg-surface-base w-full h-full">
 		<div class="w-fit mx-auto mt-56 text-center p-4">
-			<div class="text-4xl-semibold text-ink-gray-5 pb-4 mb-2 border-b">
+			<h1 class="text-4xl-semibold text-ink-gray-5 pb-4 mb-2 border-b">
 				{{ __('Not Permitted') }}
-			</div>
+			</h1>
 			<div v-if="user.data" class="px-5 py-3">
 				<div class="text-ink-gray-5">
 					{{ __('You do not have permission to access this page.') }}

--- a/frontend/src/components/Notes/InlineLessonMenu.vue
+++ b/frontend/src/components/Notes/InlineLessonMenu.vue
@@ -12,9 +12,11 @@
 				{{ __('Highlight') }}
 			</div>
 			<div class="">
-				<div
+				<button
 					v-for="color in colors"
-					class="flex items-center gap-x-2 px-3 py-2 cursor-pointer hover:bg-surface-gray-2"
+					:key="color"
+					type="button"
+					class="w-full flex items-center gap-x-2 px-3 py-2 cursor-pointer hover:bg-surface-gray-2"
 					@click="saveHighLight(color)"
 				>
 					<span
@@ -26,29 +28,31 @@
 					<span>
 						{{ __(color) }}
 					</span>
-				</div>
+				</button>
 			</div>
 		</div>
 		<div class="border-t">
-			<div
+			<button
+				type="button"
 				@click="addToNotes()"
-				class="flex items-center gap-x-2 hover:bg-surface-gray-2 cursor-pointer rounded-b-md py-2 px-3"
+				class="w-full flex items-center gap-x-2 hover:bg-surface-gray-2 cursor-pointer rounded-b-md py-2 px-3"
 			>
 				<span class="lucide-notepad-text size-3" />
 				<span>
 					{{ __('Add to Notes') }}
 				</span>
-			</div>
-			<div
+			</button>
+			<button
 				v-if="highlightExists()"
+				type="button"
 				@click="deleteHighlight"
-				class="flex items-center gap-x-2 hover:bg-surface-gray-2 cursor-pointer rounded-b-md py-2 px-3"
+				class="w-full flex items-center gap-x-2 hover:bg-surface-gray-2 cursor-pointer rounded-b-md py-2 px-3"
 			>
 				<span class="lucide-trash-2 size-3" />
 				<span>
 					{{ __('Remove Highlight') }}
 				</span>
-			</div>
+			</button>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -133,7 +133,7 @@
 			</div>
 		</div>
 		<div v-else-if="!quizSubmission.data">
-			<div v-for="(question, qtidx) in questions">
+			<div v-for="(question, qtidx) in questions" :key="question.name">
 				<div
 					v-if="qtidx == activeQuestion - 1 && questionDetails.data"
 					class="border rounded-lg p-5"
@@ -155,6 +155,7 @@
 					<div
 						v-if="questionDetails.data.type == 'Choices'"
 						v-for="index in MAX_OPTIONS"
+						:key="index"
 					>
 						<label
 							v-if="questionDetails.data[`option_${index}`]"
@@ -180,6 +181,7 @@
 							<div
 								v-else-if="quiz.data.show_answers"
 								v-for="(answer, idx) in showAnswers"
+								:key="idx"
 							>
 								<div v-if="index - 1 == idx">
 									<span
@@ -257,6 +259,7 @@
 							class="flex items-center gap-x-2"
 						>
 							<Button
+								:label="__('Previous question')"
 								@click="switchQuestion(activeQuestion - 1)"
 								:disabled="activeQuestion == 1"
 								class="rounded-full"
@@ -265,9 +268,11 @@
 									<span class="lucide-chevron-left size-4" />
 								</template>
 							</Button>
-							<span
-								v-for="item in paginationWindow"
-								:key="item"
+							<component
+								:is="item === '...' ? 'span' : 'button'"
+								v-for="(item, pidx) in paginationWindow"
+								:key="pidx"
+								:type="item === '...' ? null : 'button'"
 								class="w-6 h-6 rounded-full flex items-center justify-center text-sm"
 								:class="{
 									'cursor-pointer': item !== '...',
@@ -284,9 +289,10 @@
 								@click="item !== '...' && switchQuestion(item)"
 							>
 								{{ item }}
-							</span>
+							</component>
 
 							<Button
+								:label="__('Next question')"
 								@click="switchQuestion(activeQuestion + 1)"
 								:disabled="activeQuestion == questions.length"
 								class="rounded-full"
@@ -338,13 +344,15 @@
 					{{ __('Questions marked for review') }}
 				</div>
 				<div class="flex items-center gap-x-2 mt-2">
-					<div
+					<button
 						v-for="index in reviewQuestions"
+						:key="index"
+						type="button"
 						@click="switchQuestion(index)"
 						class="w-6 h-6 rounded-full flex items-center justify-center text-sm cursor-pointer bg-surface-gray-3"
 					>
 						{{ index }}
-					</div>
+					</button>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/components/Settings/BrandSettings.vue
+++ b/frontend/src/components/Settings/BrandSettings.vue
@@ -29,6 +29,7 @@
 					<FormControl
 						type="text"
 						size="md"
+						:aria-label="__('Brand Name')"
 						:placeholder="__('Enter Brand Name')"
 						:modelValue="branding.data.app_name"
 						@input="

--- a/frontend/src/components/Settings/Categories.vue
+++ b/frontend/src/components/Settings/Categories.vue
@@ -31,15 +31,16 @@
 			</div>
 		</template>
 
-		<div
-			class="divide-y divide-outline-elevation-2"
+		<ul
+			class="divide-y divide-outline-elevation-2 list-none"
 			v-if="categories.data?.length"
 		>
-			<div v-for="(cat, index) in categories.data" :key="cat.name">
+			<li v-for="(cat, index) in categories.data" :key="cat.name">
 				<div
 					v-if="editing?.name !== cat.name"
 					class="group flex min-h-11 items-center justify-between gap-2 py-2"
 				>
+					<!-- TODO(a11y): double-click-to-edit is not keyboard-accessible; needs a focusable edit affordance without changing the current layout. -->
 					<div
 						class="text-p-base text-ink-gray-8"
 						@dblclick="allowEdit(cat, index)"
@@ -49,6 +50,7 @@
 					<Button
 						variant="ghost"
 						theme="red"
+						:label="__('Delete category')"
 						class="invisible group-hover:visible"
 						@click="deleteCategory(cat.name)"
 					>
@@ -66,8 +68,8 @@
 						@keyup.enter="saveChanges(cat.name, editedValue)"
 					/>
 				</div>
-			</div>
-		</div>
+			</li>
+		</ul>
 		<EmptyStateLayout
 			v-else
 			name="Categories"

--- a/frontend/src/components/Settings/Coupons/CouponDetails.vue
+++ b/frontend/src/components/Settings/Coupons/CouponDetails.vue
@@ -75,9 +75,9 @@
 				/>
 			</div>
 			<div class="pt-4">
-				<div class="font-semibold text-ink-gray-9 mb-3">
+				<h2 class="font-semibold text-ink-gray-9 mb-3">
 					{{ __('Applicable For') }}
-				</div>
+				</h2>
 				<CouponItems :items="doc.applicable_items" />
 			</div>
 		</div>

--- a/frontend/src/components/Settings/Coupons/CouponItems.vue
+++ b/frontend/src/components/Settings/Coupons/CouponItems.vue
@@ -7,6 +7,7 @@
 				<thead
 					class="text-xs text-ink-gray-7 uppercase bg-surface-gray-2 border-b border-outline-gray-2"
 				>
+					<!-- TODO(a11y): header cells use <td>; switching to <th scope="col"> would add UA bold/center styling (visual change), so deferred. -->
 					<tr>
 						<td scope="col" class="px-6 py-2">
 							{{ __('Document Type') }}

--- a/frontend/src/components/Settings/Coupons/CouponList.vue
+++ b/frontend/src/components/Settings/Coupons/CouponList.vue
@@ -58,7 +58,11 @@
 									onClick: () => confirmDeletion(row.name),
 								},
 							]"
-							:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+							:button="{
+								icon: 'lucide-more-horizontal',
+								variant: 'ghost',
+								label: __('Coupon actions'),
+							}"
 							placement="right"
 						/>
 					</ListCell>

--- a/frontend/src/components/Settings/EmailAccount/EmailAccountList.vue
+++ b/frontend/src/components/Settings/EmailAccount/EmailAccountList.vue
@@ -19,8 +19,11 @@
 			</Button>
 		</template>
 
-		<div v-if="!emailAccounts.loading && emailAccounts.data?.length">
-			<div v-for="(account, i) in emailAccounts.data" :key="account.name">
+		<ul
+			v-if="!emailAccounts.loading && emailAccounts.data?.length"
+			class="list-none"
+		>
+			<li v-for="(account, i) in emailAccounts.data" :key="account.name">
 				<EmailAccountCard
 					:email-account="account"
 					@click="emit('update:step', 'email-edit', { ...account })"
@@ -29,8 +32,8 @@
 					v-if="emailAccounts.data.length !== i + 1"
 					class="mx-2 h-px border-t border-outline-elevation-2"
 				/>
-			</div>
-		</div>
+			</li>
+		</ul>
 
 		<EmptyStateLayout
 			v-else

--- a/frontend/src/components/Settings/EmailAccount/EmailAdd.vue
+++ b/frontend/src/components/Settings/EmailAccount/EmailAdd.vue
@@ -18,9 +18,11 @@
 		<div class="flex flex-col gap-4">
 			<!-- email service provider selection -->
 			<div class="flex flex-wrap items-center gap-4">
-				<div
+				<button
 					v-for="s in services"
 					:key="s.name"
+					type="button"
+					:aria-pressed="selectedService?.name === s?.name"
 					class="flex w-[70px] flex-col items-center gap-1"
 					@click="handleSelect(s)"
 				>
@@ -29,7 +31,7 @@
 						:logo="s.icon"
 						:selected="selectedService?.name === s?.name"
 					/>
-				</div>
+				</button>
 			</div>
 			<div v-if="selectedService" class="flex flex-col gap-4">
 				<!-- email service provider info -->
@@ -39,9 +41,12 @@
 					<CircleAlert class="size-5 shrink-0" />
 					<div class="text-wrap text-p-xs">
 						{{ selectedService.info }}
-						<a :href="selectedService.link" target="_blank" class="underline">{{
-							__('here')
-						}}</a
+						<a
+							:href="selectedService.link"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="underline"
+							>{{ __('here') }}</a
 						>.
 					</div>
 				</div>

--- a/frontend/src/components/Settings/EmailAccount/EmailProviderIcon.vue
+++ b/frontend/src/components/Settings/EmailAccount/EmailProviderIcon.vue
@@ -3,7 +3,12 @@
 		class="flex size-8 cursor-pointer items-center justify-center rounded-xl bg-surface-gray-2 hover:bg-surface-gray-3"
 		:class="{ 'ring-2 ring-outline-gray-4': selected }"
 	>
-		<img v-if="logo" :src="logo" class="size-4" />
+		<img
+			v-if="logo"
+			:src="logo"
+			:alt="__('{0} icon').format(serviceName || __('Email provider'))"
+			class="size-4"
+		/>
 		<LucideMail v-else class="size-4 text-ink-gray-7" />
 	</div>
 	<p v-if="serviceName" class="mt-2 text-center text-xs text-ink-gray-6">

--- a/frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue
+++ b/frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue
@@ -24,6 +24,7 @@
 					type="text"
 					:debounce="300"
 					class="w-1/3"
+					:aria-label="__('Search Template')"
 					:placeholder="__('Search Template')"
 				>
 					<template #prefix>
@@ -65,7 +66,11 @@
 					<ListCell class="justify-end" @click.stop>
 						<Dropdown
 							:options="getMoreOptions(row)"
-							:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+							:button="{
+								icon: 'lucide-more-horizontal',
+								variant: 'ghost',
+								label: __('Template actions'),
+							}"
 							placement="right"
 						/>
 					</ListCell>

--- a/frontend/src/components/Settings/GoogleMeetSettings.vue
+++ b/frontend/src/components/Settings/GoogleMeetSettings.vue
@@ -55,7 +55,11 @@
 										onClick: () => removeAccount(row.name),
 									},
 								]"
-								:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+								:button="{
+									icon: 'lucide-more-horizontal',
+									variant: 'ghost',
+									label: __('Account actions'),
+								}"
 								placement="right"
 							/>
 						</ListCell>

--- a/frontend/src/components/Settings/Members.vue
+++ b/frontend/src/components/Settings/Members.vue
@@ -13,6 +13,7 @@
 				<FormControl
 					v-model="search"
 					:placeholder="__('Search')"
+					:aria-label="__('Search members')"
 					type="text"
 					:debounce="300"
 					class="w-1/3"
@@ -21,7 +22,12 @@
 						<span class="lucide-search size-4 text-ink-gray-5" />
 					</template>
 				</FormControl>
-				<Select v-model="currentRole" class="w-40" :options="roleOptions" />
+				<Select
+					v-model="currentRole"
+					class="w-40"
+					:aria-label="__('Filter by role')"
+					:options="roleOptions"
+				/>
 			</div>
 		</template>
 		<div v-if="displayedMembers.length">
@@ -63,7 +69,11 @@
 							</span>
 							<Dropdown
 								:options="getMemberMenuOptions(member)"
-								:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+								:button="{
+									icon: 'lucide-more-horizontal',
+									variant: 'ghost',
+									label: __('Member actions'),
+								}"
 								placement="right"
 							/>
 						</ListCell>

--- a/frontend/src/components/Settings/PaymentGateways.vue
+++ b/frontend/src/components/Settings/PaymentGateways.vue
@@ -47,7 +47,11 @@
 									onClick: () => removeAccount(row.name),
 								},
 							]"
-							:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+							:button="{
+								icon: 'lucide-more-horizontal',
+								variant: 'ghost',
+								label: __('More options'),
+							}"
 							placement="right"
 						/>
 					</ListCell>

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -65,7 +65,9 @@
 										{{ fileName(data[field.name]) }}
 									</span>
 								</div>
-								<span
+								<button
+									type="button"
+									:aria-label="__('Remove image')"
 									@click="data[field.name] = null"
 									class="lucide-x border text-ink-gray-7 border-outline-elevation-2 rounded-md cursor-pointer w-5 h-5 p-1 ms-4"
 								/>
@@ -102,6 +104,7 @@
 							:rows="field.rows || 3"
 							v-model="data[field.name]"
 							:required="field.reqd"
+							:aria-label="__(field.label)"
 							:placeholder="field.placeholder || __(field.label)"
 						/>
 					</div>
@@ -126,12 +129,14 @@
 								v-model="data[field.name]"
 								:doctype="field.doctype"
 								:required="field.reqd"
+								:aria-label="__(field.label)"
 								class="w-48"
 							/>
 							<Select
 								v-else-if="field.type == 'select'"
 								v-model="data[field.name]"
 								:options="field.options"
+								:aria-label="__(field.label)"
 								class="w-48"
 							/>
 							<FormControl
@@ -144,6 +149,7 @@
 								:required="field.reqd"
 								:min="field.min"
 								class="w-48"
+								:aria-label="__(field.label)"
 								:placeholder="field.placeholder || __(field.label)"
 							/>
 						</div>

--- a/frontend/src/components/Settings/Transactions/TransactionList.vue
+++ b/frontend/src/components/Settings/Transactions/TransactionList.vue
@@ -16,6 +16,7 @@
 					type="text"
 					:debounce="300"
 					class="w-1/3"
+					:aria-label="__('Search')"
 					:placeholder="__('Search')"
 				>
 					<template #prefix>

--- a/frontend/src/components/Settings/ZoomSettings.vue
+++ b/frontend/src/components/Settings/ZoomSettings.vue
@@ -58,7 +58,11 @@
 									onClick: () => removeAccount(row.name),
 								},
 							]"
-							:button="{ icon: 'lucide-more-horizontal', variant: 'ghost' }"
+							:button="{
+								icon: 'lucide-more-horizontal',
+								variant: 'ghost',
+								label: __('More options'),
+							}"
 							placement="right"
 						/>
 					</ListCell>

--- a/frontend/src/components/StudentLessonSidebar.vue
+++ b/frontend/src/components/StudentLessonSidebar.vue
@@ -18,78 +18,84 @@
 			</div>
 		</div>
 
-		<div class="flex-1 overflow-y-auto px-2 py-3">
-			<Disclosure
-				v-for="chapter in outline.data || []"
-				:key="chapter.name"
-				v-slot="{ open }"
-				:defaultOpen="chapterDefaultOpen(chapter)"
-			>
-				<DisclosureButton
-					class="w-full flex items-center justify-between rounded px-3 py-2 hover:bg-surface-gray-2 text-left"
+		<ul class="flex-1 overflow-y-auto px-2 py-3 list-none">
+			<li v-for="chapter in outline.data || []" :key="chapter.name">
+				<Disclosure
+					v-slot="{ open }"
+					:defaultOpen="chapterDefaultOpen(chapter)"
 				>
-					<div
-						class="flex items-center gap-2 text-base-medium leading-5 text-ink-gray-9 min-w-0"
+					<DisclosureButton
+						class="w-full flex items-center justify-between rounded px-3 py-2 hover:bg-surface-gray-2 text-start"
 					>
-						<ChevronDown
-							class="size-4 stroke-1.5 shrink-0 transition-transform"
-							:class="{ '-rotate-90': !open }"
-						/>
-						<span class="truncate">{{ chapter.title }}</span>
-					</div>
-					<span
-						v-if="chapter.lessons?.length"
-						class="text-sm text-ink-gray-5 shrink-0"
-					>
-						{{ chapter.lessons.length }}
-					</span>
-				</DisclosureButton>
-				<DisclosurePanel>
-					<component
-						:is="inlineSelect ? 'div' : 'router-link'"
-						v-for="lesson in chapter.lessons || []"
-						:key="lesson.name"
-						:to="
-							inlineSelect
-								? undefined
-								: {
-										name: 'Lesson',
-										params: {
-											courseName,
-											chapterNumber: lesson.number.split('-')[0],
-											lessonNumber: lesson.number.split('-')[1],
-										},
-								  }
-						"
-						class="flex items-center gap-3 rounded ps-9 pe-3 py-2 text-sm leading-5 text-ink-gray-8 hover:bg-surface-gray-2"
-						:class="[
-							inlineSelect ? 'cursor-pointer' : '',
-							isActive(lesson.number)
-								? 'bg-surface-gray-2 text-ink-gray-9'
-								: '',
-						]"
-						@click="
-							inlineSelect &&
-								emit('select-lesson', {
-									chapterNumber: lesson.number.split('-')[0],
-									lessonNumber: lesson.number.split('-')[1],
-								})
-						"
-					>
-						<component
-							:is="iconFor(lesson.icon)"
-							class="size-4 stroke-1.5 shrink-0 text-ink-gray-7"
-						/>
-						<span class="truncate flex-1">{{ lesson.title }}</span>
-						<CircleCheck
-							v-if="lesson.is_complete"
-							class="size-4 stroke-1.5 shrink-0 text-green-700 fill-none"
-						/>
-						<Circle v-else class="size-4 stroke-1.5 shrink-0 text-ink-gray-4" />
-					</component>
-				</DisclosurePanel>
-			</Disclosure>
-		</div>
+						<div
+							class="flex items-center gap-2 text-base-medium leading-5 text-ink-gray-9 min-w-0"
+						>
+							<ChevronDown
+								class="size-4 stroke-1.5 shrink-0 transition-transform"
+								:class="{ '-rotate-90': !open }"
+							/>
+							<span class="truncate">{{ chapter.title }}</span>
+						</div>
+						<span
+							v-if="chapter.lessons?.length"
+							class="text-sm text-ink-gray-5 shrink-0"
+						>
+							{{ chapter.lessons.length }}
+						</span>
+					</DisclosureButton>
+					<DisclosurePanel>
+						<ul class="list-none">
+							<li v-for="lesson in chapter.lessons || []" :key="lesson.name">
+								<component
+									:is="inlineSelect ? 'button' : 'router-link'"
+									:type="inlineSelect ? 'button' : undefined"
+									:to="
+										inlineSelect
+											? undefined
+											: {
+													name: 'Lesson',
+													params: {
+														courseName,
+														chapterNumber: lesson.number.split('-')[0],
+														lessonNumber: lesson.number.split('-')[1],
+													},
+											  }
+									"
+									class="flex w-full items-center gap-3 rounded ps-9 pe-3 py-2 text-start text-sm leading-5 text-ink-gray-8 hover:bg-surface-gray-2"
+									:class="[
+										inlineSelect ? 'cursor-pointer' : '',
+										isActive(lesson.number)
+											? 'bg-surface-gray-2 text-ink-gray-9'
+											: '',
+									]"
+									@click="
+										inlineSelect &&
+											emit('select-lesson', {
+												chapterNumber: lesson.number.split('-')[0],
+												lessonNumber: lesson.number.split('-')[1],
+											})
+									"
+								>
+									<component
+										:is="iconFor(lesson.icon)"
+										class="size-4 stroke-1.5 shrink-0 text-ink-gray-7"
+									/>
+									<span class="truncate flex-1">{{ lesson.title }}</span>
+									<CircleCheck
+										v-if="lesson.is_complete"
+										class="size-4 stroke-1.5 shrink-0 text-green-700 fill-none"
+									/>
+									<Circle
+										v-else
+										class="size-4 stroke-1.5 shrink-0 text-ink-gray-4"
+									/>
+								</component>
+							</li>
+						</ul>
+					</DisclosurePanel>
+				</Disclosure>
+			</li>
+		</ul>
 	</div>
 </template>
 

--- a/frontend/src/components/Tags.vue
+++ b/frontend/src/components/Tags.vue
@@ -7,15 +7,22 @@
 			{{ tags }}
 			<div
 				v-for="tag in tags?.split(', ')"
+				:key="tag"
 				class="flex items-center bg-surface-gray-2 p-2 rounded-md me-2"
 			>
 				{{ tag }}
-				<span
+				<button
+					type="button"
+					:aria-label="__('Remove tag')"
 					class="lucide-x w-3 h-3 ms-2 cursor-pointer"
 					@click="removeTag(tag)"
 				/>
 			</div>
-			<FormControl v-model="newTag" @keyup.enter="updateTags()" />
+			<FormControl
+				v-model="newTag"
+				:aria-label="__('Add tag')"
+				@keyup.enter="updateTags()"
+			/>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -15,6 +15,7 @@
 							<TextInput
 								type="text"
 								placeholder="search by keyword"
+								:aria-label="__('Search by keyword')"
 								v-model="search"
 								:debounce="300"
 							/>
@@ -45,6 +46,7 @@
 									image.urls.raw +
 									'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
 								"
+								:alt="__('Unsplash photo')"
 							/>
 						</Button>
 					</div>

--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -33,7 +33,7 @@
 				class="grid gap-4"
 				:class="forHome ? 'grid-cols-1 md:grid-cols-4' : 'grid-cols-1'"
 			>
-				<div v-for="evl in upcoming_evals.data">
+				<div v-for="evl in upcoming_evals.data" :key="evl.name">
 					<div
 						class="border hover:border-outline-gray-3 text-ink-gray-7 rounded-md p-3"
 					>
@@ -56,7 +56,7 @@
 								side="left"
 							>
 								<template v-slot="{ open }">
-									<Button variant="ghost">
+									<Button variant="ghost" :label="__('Options')">
 										<template #icon>
 											<span class="lucide-ellipsis-vertical w-4 h-4" />
 										</template>

--- a/frontend/src/components/VideoBlock.vue
+++ b/frontend/src/components/VideoBlock.vue
@@ -8,7 +8,11 @@
 				)
 			}}
 
-			<div v-for="(quiz, index) in quizzes" class="ps-3 mt-1">
+			<div
+				v-for="(quiz, index) in quizzes"
+				:key="`${quiz.quiz}-${index}`"
+				class="ps-3 mt-1"
+			>
 				<span>
 					{{ index + 1 }}. <span class="font-semibold"> {{ quiz.quiz }} </span>
 				</span>
@@ -30,8 +34,10 @@
 				:src="fileURL"
 				:type="type"
 			></video>
-			<div
+			<button
+				type="button"
 				v-if="!playing"
+				:aria-label="__('Play video')"
 				class="absolute inset-0 flex items-center justify-center cursor-pointer"
 				@click="playVideo"
 			>
@@ -47,25 +53,22 @@
 				>
 					<Play />
 				</div>
-			</div>
+			</button>
 			<div
 				class="flex items-center gap-x-2 py-2 px-1 text-ink-base bg-gradient-to-b from-transparent to-black/75 absolute bottom-0 start-0 end-0 mx-auto rounded-md"
 				:class="{
 					'invisible group-hover:visible': playing,
 				}"
 			>
-				<Button variant="ghost" class="hover:bg-transparent">
+				<Button
+					variant="ghost"
+					class="hover:bg-transparent"
+					:label="playing ? __('Pause') : __('Play')"
+					@click="togglePlay"
+				>
 					<template #icon>
-						<Play
-							v-if="!playing"
-							@click="playVideo"
-							class="size-4 text-ink-gray-9"
-						/>
-						<span
-							class="lucide-pause size-5 text-ink-base"
-							v-else
-							@click="pauseVideo"
-						/>
+						<Play v-if="!playing" class="size-4 text-ink-gray-9" />
+						<span v-else class="lucide-pause size-5 text-ink-base" />
 					</template>
 				</Button>
 
@@ -77,6 +80,7 @@
 						step="0.1"
 						v-model="currentTime"
 						@input="changeCurrentTime"
+						:aria-label="__('Seek')"
 						class="duration-slider h-1"
 					/>
 					<!-- QUIZ MARKERS -->
@@ -101,6 +105,7 @@
 				<Button
 					variant="ghost"
 					@click="toggleMute"
+					:label="muted ? __('Unmute') : __('Mute')"
 					class="hover:bg-transparent"
 				>
 					<template #icon>
@@ -111,6 +116,7 @@
 				<Button
 					variant="ghost"
 					@click="toggleFullscreen"
+					:label="__('Toggle fullscreen')"
 					class="hover:bg-transparent"
 				>
 					<template #icon>
@@ -125,8 +131,8 @@
 			:inVideo="true"
 			:backToVideo="resumeVideo"
 		/>
-		<div v-if="!readOnly" @click="showQuizModal = true">
-			<Button>
+		<div v-if="!readOnly">
+			<Button @click="showQuizModal = true">
 				{{ __('Add Quiz to Video') }}
 			</Button>
 		</div>

--- a/frontend/src/components/VideoPreview.vue
+++ b/frontend/src/components/VideoPreview.vue
@@ -2,6 +2,7 @@
 	<iframe
 		v-if="videoPreview.type === 'youtube'"
 		:src="videoPreview.src"
+		:title="__('Video preview')"
 		class="min-h-56 w-full rounded-t-md"
 		allowfullscreen
 	/>
@@ -15,6 +16,7 @@
 	<img
 		v-else-if="videoPreview.type === 'file' && videoError && fallbackImage"
 		:src="fallbackImage"
+		:alt="__('Video preview')"
 		class="min-h-56 w-full rounded-t-md object-cover"
 	/>
 </template>

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,20 +1,20 @@
 export {}
 
 declare module '*.svg?raw' {
-  const content: string
-  export default content
+	const content: string
+	export default content
 }
 
 declare global {
-  function __(text: string): string
+	function __(text: string): string
 
-  interface String {
-    format(...args: any[]): string
-  }
+	interface String {
+		format(...args: any[]): string
+	}
 }
 
 declare module 'vue' {
-  interface ComponentCustomProperties {
-    __: (text: string) => string
-  }
+	interface ComponentCustomProperties {
+		__: (text: string) => string
+	}
 }

--- a/frontend/src/pages/AssignmentSubmissionList.vue
+++ b/frontend/src/pages/AssignmentSubmissionList.vue
@@ -17,6 +17,7 @@
 				type="select"
 				:options="statusOptions"
 				:placeholder="__('Status')"
+				:aria-label="__('Status')"
 			/>
 		</div>
 		<ListView
@@ -28,11 +29,16 @@
 			<ListHeader
 				class="mb-2 grid items-center gap-x-4 rounded bg-surface-gray-2 p-2"
 			>
-				<ListHeaderItem :item="item" v-for="item in submissionColumns" />
+				<ListHeaderItem
+					:item="item"
+					v-for="item in submissionColumns"
+					:key="item.key"
+				/>
 			</ListHeader>
 			<ListRows>
 				<router-link
 					v-for="row in submissions.data"
+					:key="row.name"
 					:to="{
 						name: 'AssignmentSubmission',
 						params: {

--- a/frontend/src/pages/Assignments.vue
+++ b/frontend/src/pages/Assignments.vue
@@ -26,14 +26,15 @@
 		<div
 			class="mx-5 mb-5 flex flex-col justify-between gap-y-4 sm:flex-row sm:items-center"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('{0} Assignments').format(totalAssignments.data || 0) }}
-			</div>
+			</h1>
 			<div class="flex flex-col gap-3 sm:flex-row md:gap-5">
 				<FormControl
 					type="text"
 					v-model="titleFilter"
 					:placeholder="__('Search')"
+					:aria-label="__('Search')"
 				>
 					<template #prefix>
 						<span class="lucide-search size-4 text-ink-gray-5" />
@@ -69,7 +70,11 @@
 			class="flex-1 px-5"
 		>
 			<ListHeader class="mb-2 grid items-center rounded bg-surface-gray-2 p-2">
-				<ListHeaderItem :item="item" v-for="item in assignmentColumns">
+				<ListHeaderItem
+					:item="item"
+					v-for="item in assignmentColumns"
+					:key="item.key"
+				>
 					<template #prefix="{ item }">
 						<span :class="[item.icon, 'h-4 w-4']" aria-hidden="true" />
 					</template>
@@ -78,6 +83,7 @@
 			<ListRows>
 				<ListRow
 					v-for="row in assignments.data"
+					:key="row.name"
 					:row="row"
 					class="hover:bg-surface-gray-2"
 				>
@@ -104,6 +110,7 @@
 					<div class="flex gap-2">
 						<Button
 							variant="ghost"
+							:label="__('Delete')"
 							@click="deleteAssignment(selections, unselectAll)"
 						>
 							<span class="lucide-trash-2 h-4 w-4" />

--- a/frontend/src/pages/Batches/BatchDetail.vue
+++ b/frontend/src/pages/Batches/BatchDetail.vue
@@ -14,7 +14,7 @@
 					<Badge v-if="childRef?.isDirty" theme="orange">
 						{{ __('Not Saved') }}
 					</Badge>
-					<Button @click="childRef.deleteBatch()">
+					<Button :label="__('Delete batch')" @click="childRef.deleteBatch()">
 						<template #icon>
 							<span class="lucide-trash-2 w-4 h-4" />
 						</template>
@@ -32,7 +32,11 @@
 					side="left"
 				>
 					<template v-slot="{ open }">
-						<Button variant="ghost">
+						<Button
+							variant="ghost"
+							:label="__('Batch options')"
+							:aria-expanded="open"
+						>
 							<template #icon>
 								<span class="lucide-ellipsis-vertical w-4 h-4" />
 							</template>

--- a/frontend/src/pages/Batches/BatchForm.vue
+++ b/frontend/src/pages/Batches/BatchForm.vue
@@ -3,9 +3,9 @@
 		<div class="grid grid-cols-1 lg:grid-cols-[3fr,2fr]">
 			<div v-if="batchDetail.doc" class="py-5 lg:h-[88vh] lg:overflow-y-auto">
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-base-semibold text-ink-gray-9">
+					<h2 class="text-base-semibold text-ink-gray-9">
 						{{ __('Details') }}
-					</div>
+					</h2>
 
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<FormControl
@@ -79,9 +79,9 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-base-semibold text-ink-gray-9">
+					<h2 class="text-base-semibold text-ink-gray-9">
 						{{ __('Enrollment & Certification') }}
-					</div>
+					</h2>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5 items-start">
 						<BooleanSwitch
 							size="sm"
@@ -142,9 +142,9 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-base-semibold text-ink-gray-9">
+					<h2 class="text-base-semibold text-ink-gray-9">
 						{{ __('Batch overview') }}
-					</div>
+					</h2>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<MultiLink
 							v-model="instructors"
@@ -213,9 +213,9 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5 border-b mb-5">
-					<div class="text-base-semibold text-ink-gray-9">
+					<h2 class="text-base-semibold text-ink-gray-9">
 						{{ __('Conferencing') }}
-					</div>
+					</h2>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<Select
 							v-model="batchDetail.doc.conferencing_provider"
@@ -252,9 +252,9 @@
 				</div>
 
 				<div class="px-5 pb-5 space-y-5">
-					<div class="text-base-semibold text-ink-gray-9">
+					<h2 class="text-base-semibold text-ink-gray-9">
 						{{ __('Meta Tags') }}
-					</div>
+					</h2>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<FormControl
 							v-model="meta.description"

--- a/frontend/src/pages/Batches/BatchOverview.vue
+++ b/frontend/src/pages/Batches/BatchOverview.vue
@@ -2,9 +2,9 @@
 	<div class="m-5 pb-10">
 		<div class="flex justify-between w-full">
 			<div class="md:w-2/3">
-				<div class="text-4xl-semibold text-ink-gray-9">
+				<h1 class="text-4xl-semibold text-ink-gray-9">
 					{{ batch.data.title }}
-				</div>
+				</h1>
 				<div class="my-3 leading-6 text-ink-gray-7">
 					{{ batch.data.description }}
 				</div>
@@ -17,6 +17,7 @@
 					>
 						<UserAvatar
 							v-for="instructor in batch.data.instructors"
+							:key="instructor.name"
 							:user="instructor"
 						/>
 					</div>
@@ -34,9 +35,9 @@
 		</div>
 		<div v-if="courses.data?.length">
 			<div class="flex items-center mt-10">
-				<div class="text-3xl-semibold text-ink-gray-9">
+				<h2 class="text-3xl-semibold text-ink-gray-9">
 					{{ __('Courses') }}
-				</div>
+				</h2>
 			</div>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-5">
 				<div

--- a/frontend/src/pages/Batches/Batches.vue
+++ b/frontend/src/pages/Batches/Batches.vue
@@ -49,9 +49,9 @@
 		<div
 			class="mb-5 flex flex-col justify-between space-y-4 lg:flex-row lg:items-center lg:space-y-0"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('All Batches') }}
-			</div>
+			</h1>
 			<div
 				class="flex flex-col space-y-3 lg:flex-row lg:items-center lg:gap-x-4 lg:space-y-0"
 			>
@@ -65,6 +65,7 @@
 					<FormControl
 						v-model="title"
 						:placeholder="__('Search')"
+						:aria-label="__('Search')"
 						type="text"
 						class="min-w-40"
 						@input="updateBatches()"
@@ -102,6 +103,7 @@
 		>
 			<router-link
 				v-for="batch in batches.data"
+				:key="batch.name"
 				:to="{ name: 'BatchDetail', params: { batchName: batch.name } }"
 			>
 				<BatchCard :batch="batch" />

--- a/frontend/src/pages/Batches/components/AdminBatchDashboard.vue
+++ b/frontend/src/pages/Batches/components/AdminBatchDashboard.vue
@@ -42,13 +42,14 @@
 		>
 			<div class="border rounded-lg py-3 px-4 order-2 lg:order-1">
 				<div class="flex items-center justify-between gap-x-2 mb-3">
-					<div class="text-lg-semibold text-ink-gray-9">
+					<h2 class="text-lg-semibold text-ink-gray-9">
 						{{ __('Students') }}
-					</div>
+					</h2>
 					<div class="flex items-center gap-x-2">
 						<FormControl
 							v-model="searchFilter"
 							:placeholder="__('Search')"
+							:aria-label="__('Search')"
 							type="text"
 						>
 							<template #prefix>

--- a/frontend/src/pages/Batches/components/Announcements.vue
+++ b/frontend/src/pages/Batches/components/Announcements.vue
@@ -1,10 +1,10 @@
 <template>
 	<div class="w-[90%] lg:w-[75%] mx-auto mt-5">
-		<div class="text-ink-gray-9 text-lg-semibold mb-5">
+		<h2 class="text-ink-gray-9 text-lg-semibold mb-5">
 			{{ __('Announcements') }}
-		</div>
-		<div v-if="communications.data?.length">
-			<div v-for="comm in communications.data">
+		</h2>
+		<ul v-if="communications.data?.length" class="list-none">
+			<li v-for="comm in communications.data" :key="comm.name">
 				<div class="mb-8">
 					<div class="flex items-center justify-between mb-2">
 						<div class="flex items-center">
@@ -22,8 +22,8 @@
 						v-html="sanitizeRichHTML(comm.content)"
 					></div>
 				</div>
-			</div>
-		</div>
+			</li>
+		</ul>
 		<div v-else class="text-ink-gray-7 leading-5">
 			{{ __('No announcements have been made yet for this batch') }}
 		</div>

--- a/frontend/src/pages/Batches/components/Assessments.vue
+++ b/frontend/src/pages/Batches/components/Assessments.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
 		<div class="flex items-center justify-between mb-4">
-			<div class="text-ink-gray-9 font-semibold">
+			<h2 class="text-ink-gray-9 font-semibold">
 				{{ __('Assessments') }}
-			</div>
+			</h2>
 			<Button v-if="canAddAssessments()" @click="showModal = true">
 				<template #prefix>
 					<span class="lucide-plus h-4 w-4" />
@@ -26,13 +26,18 @@
 				<ListHeader
 					class="mb-2 grid items-center gap-x-4 rounded-t-lg bg-surface-gray-2 p-2"
 				>
-					<ListHeaderItem :item="item" v-for="item in getAssessmentColumns()">
+					<ListHeaderItem
+						:item="item"
+						v-for="item in getAssessmentColumns()"
+						:key="item.key"
+					>
 					</ListHeaderItem>
 				</ListHeader>
 				<ListRows>
 					<ListRow
 						:row="row"
 						v-for="row in assessments.data"
+						:key="row.name"
 						class="!rounded-none last:!rounded-b-lg"
 					>
 						<template #default="{ column, item }">
@@ -60,6 +65,7 @@
 						<div class="flex gap-2">
 							<Button
 								variant="ghost"
+								:label="__('Delete')"
 								@click="removeAssessments(selections, unselectAll)"
 							>
 								<span class="lucide-trash-2 h-4 w-4" />

--- a/frontend/src/pages/Batches/components/BatchCard.vue
+++ b/frontend/src/pages/Batches/components/BatchCard.vue
@@ -64,6 +64,7 @@
 			>
 				<UserAvatar
 					v-for="instructor in batch.instructors"
+					:key="instructor.name"
 					:user="instructor"
 				/>
 			</div>

--- a/frontend/src/pages/Batches/components/BatchCourses.vue
+++ b/frontend/src/pages/Batches/components/BatchCourses.vue
@@ -29,13 +29,18 @@
 				<ListHeader
 					class="mb-2 grid items-center gap-x-4 rounded-t-lg bg-surface-gray-2 p-2"
 				>
-					<ListHeaderItem :item="item" v-for="item in getCoursesColumns()">
+					<ListHeaderItem
+						:item="item"
+						v-for="item in getCoursesColumns()"
+						:key="item.key"
+					>
 					</ListHeaderItem>
 				</ListHeader>
 				<ListRows>
 					<ListRow
 						:row="row"
 						v-for="row in courses.data"
+						:key="row.name"
 						class="!rounded-none last:!rounded-b-lg"
 					>
 						<template #default="{ column, item }">
@@ -52,6 +57,7 @@
 						<div class="flex gap-2">
 							<Button
 								variant="ghost"
+								:label="__('Delete selected courses')"
 								@click="removeCourses(selections, unselectAll)"
 							>
 								<span class="lucide-trash-2 h-4 w-4" />

--- a/frontend/src/pages/Batches/components/BatchDashboard.vue
+++ b/frontend/src/pages/Batches/components/BatchDashboard.vue
@@ -42,6 +42,7 @@
 								<ListRow
 									:row="row"
 									v-for="row in batch.data?.courses"
+									:key="row.name"
 									class="!rounded-none last:!rounded-b-lg text-sm"
 								>
 									<template #default="{ column, item }">

--- a/frontend/src/pages/Batches/components/BatchFeedback.vue
+++ b/frontend/src/pages/Batches/components/BatchFeedback.vue
@@ -25,11 +25,14 @@
 				<div class="leading-5 mb-4 text-ink-gray-7">
 					<div v-if="readOnly">
 						{{ __('Thank you for providing your feedback.') }}
-						<span
+						<button
+							type="button"
 							@click="showFeedbackForm = !showFeedbackForm"
+							:aria-expanded="showFeedbackForm"
 							class="underline cursor-pointer"
-							>{{ __('Click here') }}</span
 						>
+							{{ __('Click here') }}
+						</button>
 						{{ __('to view your feedback.') }}
 					</div>
 					<div v-else>
@@ -40,6 +43,7 @@
 					<div class="space-y-4">
 						<Rating
 							v-for="key in ratingKeys"
+							:key="key"
 							v-model="feedback[key]"
 							:label="__(convertToTitleCase(key))"
 							:disabled="readOnly"
@@ -63,6 +67,7 @@
 			<div class="space-y-4">
 				<Rating
 					v-for="key in ratingKeys"
+					:key="key"
 					v-model="average[key]"
 					:label="__(convertToTitleCase(key))"
 					:disabled="true"

--- a/frontend/src/pages/Batches/components/BatchStudentProgress.vue
+++ b/frontend/src/pages/Batches/components/BatchStudentProgress.vue
@@ -55,7 +55,10 @@
 							class="mb-2 grid items-center gap-x-4 rounded-t-lg bg-surface-gray-2 p-2"
 						>
 						</ListHeader>
-						<ListRows v-for="row in studentDetails.data.assessments">
+						<ListRows
+							v-for="(row, index) in studentDetails.data.assessments"
+							:key="index"
+						>
 							<ListRow :row="row" class="!rounded-none last:!rounded-b-lg">
 								<template #default="{ column, item }">
 									<ListRowItem
@@ -97,7 +100,10 @@
 							class="mb-2 grid items-center gap-x-4 rounded-t-lg bg-surface-gray-2 p-2"
 						>
 						</ListHeader>
-						<ListRows v-for="row in studentDetails.data.courses">
+						<ListRows
+							v-for="row in studentDetails.data.courses"
+							:key="row.course"
+						>
 							<ListRow :row="row" class="!rounded-none last:!rounded-b-lg">
 								<template #default="{ column, item }">
 									<ListRowItem

--- a/frontend/src/pages/Batches/components/LiveClass.vue
+++ b/frontend/src/pages/Batches/components/LiveClass.vue
@@ -31,8 +31,13 @@
 			v-if="liveClasses.data?.length"
 			class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 mt-5"
 		>
+			<!-- TODO(a11y): this card is click-activated (opens attendance modal)
+			     but contains nested Start/Join anchors, so it can't become a
+			     <button>. Needs a redesign (dedicated action button) to be
+			     keyboard-accessible; left as-is to avoid invalid nesting. -->
 			<div
 				v-for="cls in liveClasses.data"
+				:key="cls.name"
 				class="flex flex-col border rounded-md h-full text-ink-gray-7 hover:border-outline-gray-3 p-3"
 				:class="{
 					'cursor-pointer': isAdmin() && cls.attendees > 0,

--- a/frontend/src/pages/Billing.vue
+++ b/frontend/src/pages/Billing.vue
@@ -67,6 +67,7 @@
 							<FormControl
 								v-model="appliedCoupon"
 								:disabled="orderSummary.data.discount_amount > 0"
+								:aria-label="__('Coupon Code')"
 								@input="appliedCoupon = $event.target.value.toUpperCase()"
 								@keydown.enter="applyCouponCode"
 								placeholder="COUPON2025"
@@ -82,6 +83,7 @@
 							</Button>
 							<Button
 								v-if="orderSummary.data.discount_amount"
+								:label="__('Remove coupon')"
 								@click="removeCoupon"
 								variant="outline"
 							>
@@ -105,9 +107,9 @@
 
 				<div class="flex-1 lg:me-10">
 					<div class="mb-5">
-						<div class="text-lg-semibold text-ink-gray-9">
+						<h2 class="text-lg-semibold text-ink-gray-9">
 							{{ __('Address') }}
-						</div>
+						</h2>
 					</div>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<div class="space-y-4">

--- a/frontend/src/pages/CertifiedParticipants.vue
+++ b/frontend/src/pages/CertifiedParticipants.vue
@@ -16,9 +16,9 @@
 	</LayoutHeader>
 	<div class="mx-auto flex min-h-0 w-full flex-1 flex-col">
 		<div class="mb-5 flex flex-col justify-between px-5 pt-5 md:flex-row">
-			<div class="mb-4 text-lg-semibold text-ink-gray-9 md:mb-0">
+			<h1 class="mb-4 text-lg-semibold text-ink-gray-9 md:mb-0">
 				{{ memberCount }} {{ __('Certified Members') }}
-			</div>
+			</h1>
 			<div
 				class="flex flex-col space-y-4 md:flex-row md:items-center md:gap-x-4 md:space-y-0"
 			>
@@ -26,6 +26,7 @@
 					<FormControl
 						v-model="nameFilter"
 						:placeholder="__('Search')"
+						:aria-label="__('Search')"
 						type="text"
 						class="min-w-40 lg:w-32 lg:min-w-0 xl:w-40"
 						@input="updateParticipants()"
@@ -67,14 +68,16 @@
 			class="flex-1 overflow-y-auto px-5 pb-5"
 		>
 			<div class="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4">
-				<div
-					v-for="participant in participants.data"
-					class="flex cursor-pointer flex-col rounded-lg border p-3 text-ink-gray-9 hover:border-outline-gray-3"
-					@click="
-						router.push({
-							name: 'ProfileAbout',
-							params: { username: participant.username },
-						})
+				<component
+					:is="participant.username ? 'router-link' : 'div'"
+					v-for="(participant, index) in participants.data"
+					:key="participant.username || index"
+					:to="profileRoute(participant.username, 'ProfileAbout')"
+					class="flex flex-col rounded-lg border p-3 text-ink-gray-9"
+					:class="
+						participant.username
+							? 'cursor-pointer hover:border-outline-gray-3'
+							: ''
 					"
 				>
 					<div class="flex items-center gap-x-4">
@@ -110,7 +113,7 @@
 							}}</span>
 						</div>
 					</div>
-				</div>
+				</component>
 			</div>
 		</div>
 		<div v-else class="flex-1">
@@ -162,6 +165,7 @@ import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import LayoutHeader from '@/components/Layouts/LayoutHeader.vue'
+import { profileRoute } from '@/utils/routes'
 
 const filters = ref({})
 const currentCategory = ref('')

--- a/frontend/src/pages/Courses/CourseCertification.vue
+++ b/frontend/src/pages/Courses/CourseCertification.vue
@@ -6,9 +6,9 @@
 	</header>
 	<div class="p-5">
 		<div v-if="certificate.data && Object.keys(certificate.data).length">
-			<div class="text-lg-semibold text-ink-gray-9 mb-1">
+			<h1 class="text-lg-semibold text-ink-gray-9 mb-1">
 				{{ __('Certification') }}
-			</div>
+			</h1>
 			<div class="text-ink-gray-9 text-sm">
 				{{
 					__(
@@ -16,8 +16,9 @@
 					)
 				}}
 			</div>
-			<div
-				class="border p-3 w-fit min-w-60 rounded-md space-y-2 hover:bg-surface-gray-1 cursor-pointer mt-5"
+			<button
+				type="button"
+				class="border p-3 w-fit min-w-60 rounded-md space-y-2 hover:bg-surface-gray-1 cursor-pointer mt-5 text-start block"
 				@click="openCertificate(certificate.data)"
 			>
 				<div class="text-ink-gray-9 font-semibold">
@@ -27,7 +28,7 @@
 					{{ __('Issued On') }}:
 					{{ dayjs(certificate.data.issue_date).format('DD MMM YYYY') }}
 				</div>
-			</div>
+			</button>
 		</div>
 		<div v-else>
 			<UpcomingEvaluations v-if="courses.length" :courses="courses" />

--- a/frontend/src/pages/Courses/CourseDashboard.vue
+++ b/frontend/src/pages/Courses/CourseDashboard.vue
@@ -43,6 +43,7 @@
 						<FormControl
 							v-model="searchFilter"
 							:placeholder="__('Search')"
+							:aria-label="__('Search students')"
 							type="text"
 						>
 							<template #prefix>
@@ -152,10 +153,11 @@
 					<div
 						class="grid grid-cols-[2fr_1fr] items-center justify-between text-ink-gray-9"
 					>
-						<div class="flex flex-col space-y-4 flex-1 text-sm">
-							<div
+						<ul class="flex flex-col space-y-4 flex-1 text-sm list-none">
+							<li
 								class="flex items-center text-ink-gray-7"
 								v-for="row in chartDetails.data?.progress_distribution"
+								:key="row.name"
 							>
 								<div
 									class="size-2 rounded"
@@ -187,8 +189,8 @@
 										}}%
 									</div>
 								</Tooltip>
-							</div>
-						</div>
+							</li>
+						</ul>
 						<ECharts
 							class="w-40 h-20"
 							:options="{
@@ -238,11 +240,12 @@
 							class="!w-32"
 						/>
 					</div>
-					<div
-						class="divide-y max-h-[40vh] divide-outline-elevation-2 text-ink-gray-7 overflow-y-auto"
+					<ul
+						class="divide-y max-h-[40vh] divide-outline-elevation-2 text-ink-gray-7 overflow-y-auto list-none"
 					>
-						<div
+						<li
 							v-for="progress in lessonProgress.data"
+							:key="`${progress.chapter_idx}-${progress.idx}`"
 							class="flex justify-between text-sm py-2 my-1 text-ink-gray-9"
 						>
 							<div class="">
@@ -266,8 +269,8 @@
 									}}%
 								</div>
 							</Tooltip>
-						</div>
-					</div>
+						</li>
+					</ul>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -14,7 +14,11 @@
 					</Badge>
 					<Dropdown
 						:options="courseFormRef.courseMenu"
-						:button="{ icon: 'lucide-ellipsis', variant: 'ghost' }"
+						:button="{
+							icon: 'lucide-ellipsis',
+							variant: 'ghost',
+							label: __('Course options'),
+						}"
 						side="bottom"
 						align="end"
 					/>
@@ -40,7 +44,11 @@
 						v-if="courseEditorRef?.lessonHasVideo && editorMode !== 'preview'"
 						:text="__('Video Statistics')"
 					>
-						<Button variant="ghost" @click="courseEditorRef?.openVideoStats()">
+						<Button
+							variant="ghost"
+							:label="__('Video Statistics')"
+							@click="courseEditorRef?.openVideoStats()"
+						>
 							<template #icon>
 								<span class="lucide-trending-up size-4" />
 							</template>
@@ -50,7 +58,11 @@
 						v-if="editorMode !== 'preview'"
 						:text="__('How to edit a lesson')"
 					>
-						<Button variant="ghost" @click="showLessonHelp = true">
+						<Button
+							variant="ghost"
+							:label="__('How to edit a lesson')"
+							@click="showLessonHelp = true"
+						>
 							<template #icon>
 								<span class="lucide-info size-4" />
 							</template>

--- a/frontend/src/pages/Courses/CourseDetailsSection.vue
+++ b/frontend/src/pages/Courses/CourseDetailsSection.vue
@@ -38,8 +38,9 @@
 					<template #trigger="{ open, toggleOpen, selectedOptions }">
 						<button
 							type="button"
+							:aria-expanded="open"
 							:class="[
-								'relative inline-flex w-full min-h-7 items-center gap-2 rounded border border-outline-gray-2 bg-surface-base px-2 text-left text-base text-ink-gray-8 outline-none transition-colors hover:border-outline-gray-3 hover:shadow-sm focus:border-outline-gray-4 focus:shadow-sm',
+								'relative inline-flex w-full min-h-7 items-center gap-2 rounded border border-outline-gray-2 bg-surface-base px-2 text-start text-base text-ink-gray-8 outline-none transition-colors hover:border-outline-gray-3 hover:shadow-sm focus:border-outline-gray-4 focus:shadow-sm',
 								open && 'border-outline-gray-4 shadow-sm',
 							]"
 							@click="toggleOpen"

--- a/frontend/src/pages/Courses/CourseImportModal.vue
+++ b/frontend/src/pages/Courses/CourseImportModal.vue
@@ -21,12 +21,13 @@
 						/>
 						<div class="leading-5 text-ink-gray-9">
 							{{ __('Drag and drop a ZIP file, or upload from your') }}
-							<span
+							<button
+								type="button"
 								@click="openFileSelector"
 								class="cursor-pointer font-semibold hover:underline"
 							>
 								{{ __('Device') }}
-							</span>
+							</button>
 						</div>
 					</div>
 					<div
@@ -64,8 +65,10 @@
 								{{ convertToMB(zip.file_size) }}
 							</div>
 						</div>
-						<span
+						<button
+							type="button"
 							class="lucide-trash-2 size-4 text-ink-red-6 cursor-pointer"
+							:aria-label="__('Remove file')"
 							@click="deleteFile"
 						/>
 					</div>

--- a/frontend/src/pages/Courses/Courses.vue
+++ b/frontend/src/pages/Courses/Courses.vue
@@ -33,9 +33,9 @@
 		<div
 			class="mb-5 flex flex-col justify-between space-y-4 lg:flex-row lg:items-center lg:space-y-0"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('All Courses') }}
-			</div>
+			</h1>
 			<div
 				class="flex flex-col space-y-4 lg:flex-row lg:items-center lg:gap-x-4 lg:space-y-0"
 			>
@@ -83,6 +83,7 @@
 		>
 			<router-link
 				v-for="course in courses.data"
+				:key="course.name"
 				:to="{ name: 'CourseDetail', params: { courseName: course.name } }"
 			>
 				<CourseCard :course="course" />

--- a/frontend/src/pages/Courses/StudentCourseProgress.vue
+++ b/frontend/src/pages/Courses/StudentCourseProgress.vue
@@ -41,31 +41,34 @@
 						<div class="sticky top-0 z-10 bg-surface-base py-3 text-ink-gray-5">
 							{{ __('Lesson Progress') }}
 						</div>
-						<div
-							v-for="progress in lessons.data"
-							class="flex justify-between text-sm py-2 my-1"
-						>
-							<div class="">
-								<span class="me-3 text-xs">
-									{{ progress.chapter_idx }}.{{ progress.idx }}
-								</span>
-								<span>
-									{{ progress.title }}
-								</span>
-							</div>
-							<Tooltip
-								v-if="getLessonStatus(progress) == 'Complete'"
-								:text="__('Complete')"
+						<ul class="list-none">
+							<li
+								v-for="progress in lessons.data"
+								:key="progress.lesson_name"
+								class="flex justify-between text-sm py-2 my-1"
 							>
-								<span class="lucide-check text-ink-green-6 size-4" />
-							</Tooltip>
-							<Tooltip v-else :text="__('Pending')">
-								<span class="lucide-minus text-ink-amber-5 size-4" />
-							</Tooltip>
-							<!-- <Badge :theme="getLessonStatusTheme(progress)">
-								{{ getLessonStatus(progress) }}
-							</Badge> -->
-						</div>
+								<div class="">
+									<span class="me-3 text-xs">
+										{{ progress.chapter_idx }}.{{ progress.idx }}
+									</span>
+									<span>
+										{{ progress.title }}
+									</span>
+								</div>
+								<Tooltip
+									v-if="getLessonStatus(progress) == 'Complete'"
+									:text="__('Complete')"
+								>
+									<span class="lucide-check text-ink-green-6 size-4" />
+								</Tooltip>
+								<Tooltip v-else :text="__('Pending')">
+									<span class="lucide-minus text-ink-amber-5 size-4" />
+								</Tooltip>
+								<!-- <Badge :theme="getLessonStatusTheme(progress)">
+									{{ getLessonStatus(progress) }}
+								</Badge> -->
+							</li>
+						</ul>
 					</div>
 
 					<div class="space-y-3">
@@ -85,7 +88,8 @@
 								</div>
 							</div>
 							<div
-								v-for="quiz in assessmentProgress.data.quizzes"
+								v-for="(quiz, index) in assessmentProgress.data.quizzes"
+								:key="`${quiz.quiz}-${index}`"
 								class="grid grid-cols-4 gap-15 text-sm py-1 my-1"
 							>
 								<div class="col-span-2 leading-5">
@@ -107,17 +111,21 @@
 									{{ __('Assignment Progress') }}
 								</div>
 							</div>
-							<div
-								v-for="assignment in assessmentProgress.data.assignments"
-								class="flex justify-between text-sm py-2 my-1"
-							>
-								<div>
-									{{ assignment.assignment_title }}
-								</div>
-								<Badge :theme="getAssessmentStatusTheme(assignment.status)">
-									{{ assignment.status }}
-								</Badge>
-							</div>
+							<ul class="list-none">
+								<li
+									v-for="(assignment, index) in assessmentProgress.data
+										.assignments"
+									:key="`${assignment.assignment}-${index}`"
+									class="flex justify-between text-sm py-2 my-1"
+								>
+									<div>
+										{{ assignment.assignment_title }}
+									</div>
+									<Badge :theme="getAssessmentStatusTheme(assignment.status)">
+										{{ assignment.status }}
+									</Badge>
+								</li>
+							</ul>
 						</div>
 
 						<div
@@ -129,17 +137,20 @@
 									{{ __('Programming Exercise Progress') }}
 								</div>
 							</div>
-							<div
-								v-for="exercise in assessmentProgress.data.exercises"
-								class="flex justify-between text-sm py-2 my-1"
-							>
-								<div>
-									{{ exercise.exercise_title }}
-								</div>
-								<Badge :theme="getAssessmentStatusTheme(exercise.status)">
-									{{ exercise.status }}
-								</Badge>
-							</div>
+							<ul class="list-none">
+								<li
+									v-for="(exercise, index) in assessmentProgress.data.exercises"
+									:key="`${exercise.exercise}-${index}`"
+									class="flex justify-between text-sm py-2 my-1"
+								>
+									<div>
+										{{ exercise.exercise_title }}
+									</div>
+									<Badge :theme="getAssessmentStatusTheme(exercise.status)">
+										{{ exercise.status }}
+									</Badge>
+								</li>
+							</ul>
 						</div>
 					</div>
 				</div>

--- a/frontend/src/pages/Home/AdminHome.vue
+++ b/frontend/src/pages/Home/AdminHome.vue
@@ -6,10 +6,17 @@
 					{{ __('Upcoming Evaluations') }}
 				</div>
 				<div class="grid grid-cols-1 md:grid-cols-4 gap-5">
-					<div
+					<component
+						:is="user.data?.username ? 'router-link' : 'div'"
 						v-for="evaluation in evals?.data"
-						class="border hover:border-outline-gray-3 rounded-md p-3 flex flex-col h-full cursor-pointer"
-						@click="redirectToProfile()"
+						:key="evaluation.name"
+						:to="profileRoute(user.data?.username, 'ProfileEvaluationSchedule')"
+						class="border rounded-md p-3 flex flex-col h-full"
+						:class="
+							user.data?.username
+								? 'cursor-pointer hover:border-outline-gray-3'
+								: ''
+						"
 					>
 						<div class="text-ink-gray-9 text-lg-semibold leading-5 mb-3">
 							{{ evaluation.course_title }}
@@ -34,7 +41,7 @@
 								</span>
 							</div>
 						</div>
-					</div>
+					</component>
 				</div>
 			</div>
 			<div v-if="liveClasses?.data?.length">
@@ -44,6 +51,7 @@
 				<div class="grid grid-cols-1 md:grid-cols-4 gap-5">
 					<div
 						v-for="cls in liveClasses?.data"
+						:key="cls.name"
 						class="border hover:border-outline-gray-3 rounded-md p-3"
 					>
 						<div class="text-ink-gray-9 text-lg-semibold leading-5 mb-1">
@@ -128,6 +136,7 @@
 			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
 				<router-link
 					v-for="course in createdCourses.data"
+					:key="course.name"
 					:to="{ name: 'CourseDetail', params: { courseName: course.name } }"
 				>
 					<CourseCard :course="course" />
@@ -156,6 +165,7 @@
 			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
 				<router-link
 					v-for="batch in createdBatches.data"
+					:key="batch.name"
 					:to="{ name: 'BatchDetail', params: { batchName: batch.name } }"
 				>
 					<BatchCard :batch="batch" />
@@ -197,14 +207,13 @@
 <script setup lang="ts">
 import { Button, createResource, Tooltip } from 'frappe-ui'
 import { inject } from 'vue'
-import { useRouter } from 'vue-router'
 import { formatTime } from '@/utils'
+import { profileRoute } from '@/utils/routes'
 import CourseCard from '@/components/CourseCard.vue'
 import BatchCard from '@/pages/Batches/components/BatchCard.vue'
 
 const user = inject<any>('$user')
 const dayjs = inject<any>('$dayjs')
-const router = useRouter()
 
 const props = defineProps<{
 	liveClasses?: { data?: any[] }
@@ -245,12 +254,5 @@ const hasClassEnded = (cls: {
 	const classEnd = getClassEnd(cls)
 	const now = new Date()
 	return now > classEnd
-}
-
-const redirectToProfile = () => {
-	router.push({
-		name: 'ProfileEvaluationSchedule',
-		params: { username: user.data?.username },
-	})
 }
 </script>

--- a/frontend/src/pages/Home/Home.vue
+++ b/frontend/src/pages/Home/Home.vue
@@ -2,20 +2,26 @@
 	<div class="w-full px-5 pt-5 pb-10">
 		<div class="space-y-2">
 			<div class="flex items-center justify-between">
-				<div class="text-2xl-bold text-ink-gray-9">
+				<h1 class="text-2xl-bold text-ink-gray-9">
 					{{ __('Hey') }}, {{ user.data?.full_name }} 👋
-				</div>
+				</h1>
 				<div>
-					<div
+					<button
 						v-if="!isAdmin"
+						type="button"
 						@click="showStreakModal = true"
+						:aria-label="
+							__('View learning streak: {0} days').format(
+								streakInfo.data?.current_streak || 0
+							)
+						"
 						class="bg-surface-amber-2 px-2 py-1 rounded-md cursor-pointer"
 					>
 						<span> 🔥 </span>
 						<span class="text-ink-gray-9">
 							{{ streakInfo.data?.current_streak }}
 						</span>
-					</div>
+					</button>
 				</div>
 			</div>
 

--- a/frontend/src/pages/Home/StudentHome.vue
+++ b/frontend/src/pages/Home/StudentHome.vue
@@ -3,12 +3,13 @@
 		<div class="mt-10 space-y-10">
 			<UpcomingEvaluations :forHome="true" />
 			<div v-if="myLiveClasses.data?.length">
-				<div class="font-semibold text-md mb-3 text-ink-gray-9">
+				<h2 class="font-semibold text-md mb-3 text-ink-gray-9">
 					{{ __('Upcoming Live Classes') }}
-				</div>
+				</h2>
 				<div class="grid grid-cols-1 md:grid-cols-4 gap-5">
 					<div
 						v-for="cls in myLiveClasses.data"
+						:key="cls.name"
 						class="border rounded-md hover:border-outline-gray-3 p-3"
 					>
 						<div class="font-semibold text-ink-gray-9 leading-5 mb-1">
@@ -74,13 +75,13 @@
 
 		<div v-if="myCourses.data?.length" class="mt-10">
 			<div class="flex items-center justify-between mb-3">
-				<span class="font-semibold text-md text-ink-gray-9">
+				<h2 class="font-semibold text-md text-ink-gray-9">
 					{{
 						myCourses.data[0].membership
 							? __('My Courses')
 							: __('Our Popular Courses')
 					}}
-				</span>
+				</h2>
 				<router-link
 					:to="{
 						name: 'Courses',
@@ -97,6 +98,7 @@
 			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
 				<router-link
 					v-for="course in myCourses.data"
+					:key="course.name"
 					:to="{ name: 'CourseDetail', params: { courseName: course.name } }"
 				>
 					<CourseCard :course="course" />
@@ -106,13 +108,13 @@
 
 		<div v-if="myBatches.data?.length" class="mt-10">
 			<div class="flex items-center justify-between mb-3">
-				<span class="font-semibold text-md text-ink-gray-9">
+				<h2 class="font-semibold text-md text-ink-gray-9">
 					{{
 						myBatches.data?.[0].students?.includes(user.data?.name)
 							? __('My Batches')
 							: __('Our Upcoming Batches')
 					}}
-				</span>
+				</h2>
 				<router-link
 					:to="{
 						name: 'Batches',
@@ -129,6 +131,7 @@
 			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
 				<router-link
 					v-for="batch in myBatches.data"
+					:key="batch.name"
 					:to="{ name: 'BatchDetail', params: { batchName: batch.name } }"
 				>
 					<BatchCard :batch="batch" />

--- a/frontend/src/pages/JobApplications.vue
+++ b/frontend/src/pages/JobApplications.vue
@@ -17,15 +17,20 @@
 		</LayoutHeader>
 		<div class="mx-auto pt-5 p-4">
 			<div class="flex items-center justify-between mb-5">
-				<div class="text-md font-semibold text-ink-gray-9 mb-4 md:mb-0">
+				<h1 class="text-md font-semibold text-ink-gray-9 mb-4 md:mb-0">
 					{{ totalApplications.data }}
 					{{
 						totalApplications.data === 1
 							? __('Application')
 							: __('Applications')
 					}}
-				</div>
-				<FormControl v-model="search" type="text" placeholder="Search">
+				</h1>
+				<FormControl
+					v-model="search"
+					type="text"
+					placeholder="Search"
+					:aria-label="__('Search applications')"
+				>
 					<template #prefix>
 						<span class="lucide-search size-4 text-ink-gray-5" />
 					</template>
@@ -65,6 +70,7 @@
 							:row="row"
 							v-slot="{ column, item }"
 							v-for="row in applicantRows"
+							:key="row.name"
 							class="cursor-pointer"
 						>
 							<ListRowItem :item="item">
@@ -82,7 +88,7 @@
 								</div>
 								<div v-else-if="column.key === 'actions'">
 									<Dropdown :options="getActionOptions(row)">
-										<Button variant="ghost">
+										<Button variant="ghost" :label="__('More actions')">
 											<span class="lucide-more-horizontal size-4" />
 										</Button>
 									</Dropdown>

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -80,16 +80,22 @@
 			<div class="p-4">
 				<div class="space-y-5 mb-12">
 					<div class="flex">
-						<img
-							:src="job.data.company_logo"
-							class="size-10 rounded-lg object-contain cursor-pointer me-4"
-							:alt="job.data.company_name"
-							@click="redirectToWebsite(job.data.company_website)"
-						/>
+						<a
+							:href="job.data.company_website"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="me-4"
+						>
+							<img
+								:src="job.data.company_logo"
+								class="size-10 rounded-lg object-contain cursor-pointer"
+								:alt="job.data.company_name"
+							/>
+						</a>
 						<div class="">
-							<div class="text-xl text-ink-gray-9 font-semibold mb-1">
+							<h1 class="text-xl text-ink-gray-9 font-semibold mb-1">
 								{{ job.data.job_title }}
-							</div>
+							</h1>
 							<div class="text-sm text-ink-gray-5 font-semibold">
 								{{ job.data.company_name }} - {{ job.data.location }},
 								{{ job.data.country }}

--- a/frontend/src/pages/JobForm.vue
+++ b/frontend/src/pages/JobForm.vue
@@ -18,9 +18,9 @@
 		<div class="">
 			<div class="grid grid-cols-[70%,30%] gap-5 px-5">
 				<div class="space-y-5 pt-5">
-					<div class="text-ink-gray-9 font-semibold">
+					<h2 class="text-ink-gray-9 font-semibold">
 						{{ __('Job Details') }}
-					</div>
+					</h2>
 					<div class="grid grid-cols-3 gap-5">
 						<FormControl
 							v-model="job.job_title"
@@ -67,9 +67,9 @@
 						/>
 					</div>
 					<div class="p-5 space-y-5 border-b">
-						<div class="text-ink-gray-9 font-semibold">
+						<h2 class="text-ink-gray-9 font-semibold">
 							{{ __('Location') }}
-						</div>
+						</h2>
 						<FormControl
 							v-model="job.location"
 							:label="__('City')"
@@ -83,9 +83,9 @@
 						/>
 					</div>
 					<div class="p-5 space-y-5">
-						<div class="text-ink-gray-9 font-semibold">
+						<h2 class="text-ink-gray-9 font-semibold">
 							{{ __('Company Details') }}
-						</div>
+						</h2>
 						<FormControl
 							v-model="job.company_name"
 							:label="__('Company Name')"

--- a/frontend/src/pages/Jobs.vue
+++ b/frontend/src/pages/Jobs.vue
@@ -32,9 +32,9 @@
 			class="mx-auto mb-2 flex w-full flex-col justify-between space-y-4 p-5 lg:flex-row lg:items-center lg:space-y-0"
 		>
 			<div class="flex items-center justify-between">
-				<div class="text-md font-semibold text-ink-gray-9 md:mb-0">
+				<h1 class="text-md font-semibold text-ink-gray-9 md:mb-0">
 					{{ __('{0} {1} Jobs').format(jobCount.data ?? 0, activeTab) }}
-				</div>
+				</h1>
 				<TabButtons
 					v-if="tabs.length > 1"
 					v-model="activeTab"
@@ -58,6 +58,7 @@
 					<FormControl
 						type="text"
 						:placeholder="__('Search')"
+						:aria-label="__('Search jobs')"
 						v-model="searchQuery"
 						class="w-full"
 						@input="updateJobs"

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -7,7 +7,7 @@
 			<Breadcrumbs class="h-7" :items="breadcrumbs" />
 			<div class="flex items-center gap-x-2">
 				<Tooltip v-if="canGoZen() && isAdmin" :text="__('Zen Mode')">
-					<Button @click="goFullScreen()">
+					<Button @click="goFullScreen()" :label="__('Zen Mode')">
 						<template #icon>
 							<span class="lucide-focus size-4" />
 						</template>
@@ -80,9 +80,9 @@
 							class="flex flex-col space-y-3 md:space-y-0 md:flex-row md:items-center justify-between"
 						>
 							<div class="flex flex-col">
-								<div class="text-4xl-semibold text-ink-gray-9">
+								<h1 class="text-4xl-semibold text-ink-gray-9">
 									{{ lesson.data.title }}
-								</div>
+								</h1>
 
 								<div
 									v-if="zenModeEnabled"
@@ -126,7 +126,7 @@
 									</Button>
 								</router-link>
 								<Tooltip v-else-if="canGoZen()" :text="__('Zen Mode')">
-									<Button @click="goFullScreen()">
+									<Button @click="goFullScreen()" :label="__('Zen Mode')">
 										<template #icon>
 											<span class="lucide-focus size-4" />
 										</template>
@@ -159,7 +159,10 @@
 								v-if="zenModeEnabled"
 								class="flex items-center gap-x-2 mt-2 md:mt-0"
 							>
-								<Button @click="showDiscussionsInZenMode()">
+								<Button
+									@click="showDiscussionsInZenMode()"
+									:label="__('Toggle discussions')"
+								>
 									<template #icon>
 										<span class="lucide-message-circle-question size-4" />
 									</template>
@@ -205,6 +208,7 @@
 							>
 								<UserAvatar
 									v-for="instructor in lesson.data.instructors"
+									:key="instructor.name ?? instructor"
 									:user="instructor"
 								/>
 							</span>
@@ -223,9 +227,9 @@
 							"
 							class="bg-surface-gray-2 p-3 rounded-md mt-6"
 						>
-							<div class="text-ink-gray-5 font-medium">
+							<h2 class="text-ink-gray-5 font-medium">
 								{{ __('Instructor Notes') }}
-							</div>
+							</h2>
 							<div
 								id="instructor-content"
 								class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal"

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -27,6 +27,7 @@
 				ref="titleRef"
 				v-model="lesson.title"
 				:placeholder="__('Lesson title')"
+				:aria-label="__('Lesson title')"
 				rows="1"
 				class="lesson-title w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-2xl font-bold leading-tight text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 				@input="onTitleInput"

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -5,12 +5,14 @@
 			class="sticky group top-0 z-10 flex flex-col md:flex-row md:items-center justify-between border-b bg-surface-base px-3 py-2.5 sm:px-5"
 		>
 			<Breadcrumbs class="h-7" :items="breadcrumbs" />
-			<Button v-if="isSessionUser()" class="invisible group-hover:visible">
+			<Button
+				v-if="isSessionUser()"
+				class="invisible group-hover:visible"
+				:label="__('Refresh session')"
+				@click="reloadUser()"
+			>
 				<template #icon>
-					<span
-						class="lucide-refresh-ccw size-4 text-ink-gray-7"
-						@click="reloadUser()"
-					/>
+					<span class="lucide-refresh-ccw size-4 text-ink-gray-7" />
 				</template>
 			</Button>
 		</header>
@@ -18,6 +20,7 @@
 			<img
 				v-if="profile.data.cover_image"
 				:src="profile.data.cover_image"
+				alt=""
 				class="h-[130px] w-full object-cover object-center"
 			/>
 			<div
@@ -50,6 +53,7 @@
 						<img
 							v-if="profile.data.user_image"
 							:src="profile.data.user_image"
+							:alt="profile.data.full_name"
 							class="object-cover h-[100px] w-[100px] rounded-full border-4 border-white object-cover"
 						/>
 						<div
@@ -85,28 +89,40 @@
 					</div>
 				</div>
 				<div class="ms-6 mt-5">
-					<h2 class="text-4xl-semibold text-ink-gray-9">
+					<h1 class="text-4xl-semibold text-ink-gray-9">
 						{{ profile.data.full_name }}
-					</h2>
+					</h1>
 					<div class="text-base text-ink-gray-7 mt-1">
 						{{ profile.data.headline }}
 					</div>
 					<div class="flex items-center gap-x-4 mt-2">
-						<Twitter
+						<a
 							v-if="profile.data.twitter"
-							class="size-4 text-ink-gray-5 cursor-pointer"
-							@click="navigateTo(profile.data.twitter)"
-						/>
-						<Linkedin
+							:href="profile.data.twitter"
+							target="_blank"
+							rel="noopener noreferrer"
+							:aria-label="__('Twitter')"
+						>
+							<Twitter class="size-4 text-ink-gray-5 cursor-pointer" />
+						</a>
+						<a
 							v-if="profile.data.linkedin"
-							class="size-4 text-ink-gray-5 cursor-pointer"
-							@click="navigateTo(profile.data.linkedin)"
-						/>
-						<Github
+							:href="profile.data.linkedin"
+							target="_blank"
+							rel="noopener noreferrer"
+							:aria-label="__('LinkedIn')"
+						>
+							<Linkedin class="size-4 text-ink-gray-5 cursor-pointer" />
+						</a>
+						<a
 							v-if="profile.data.github"
-							class="size-4 text-ink-gray-5 cursor-pointer"
-							@click="navigateTo(profile.data.github)"
-						/>
+							:href="profile.data.github"
+							target="_blank"
+							rel="noopener noreferrer"
+							:aria-label="__('GitHub')"
+						>
+							<Github class="size-4 text-ink-gray-5 cursor-pointer" />
+						</a>
 					</div>
 				</div>
 				<Button

--- a/frontend/src/pages/ProfileAbout.vue
+++ b/frontend/src/pages/ProfileAbout.vue
@@ -34,7 +34,7 @@
 			{{ __('Achievements') }}
 		</h2>
 		<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-			<div v-for="badge in badges.data">
+			<div v-for="badge in badges.data" :key="badge.badge">
 				<HoverCard :leave-delay="0.01">
 					<template #trigger>
 						<div class="relative">

--- a/frontend/src/pages/ProfileCertificates.vue
+++ b/frontend/src/pages/ProfileCertificates.vue
@@ -7,11 +7,13 @@
 			v-if="certificates.data?.length"
 			class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
 		>
-			<div
+			<a
 				v-for="certificate in certificates.data"
 				:key="certificate.name"
+				:href="certificateUrl(certificate)"
+				target="_blank"
+				rel="noopener noreferrer"
 				class="flex flex-col bg-surface-base border rounded-lg p-3 cursor-pointer hover:bg-surface-sidebar"
-				@click="openCertificate(certificate)"
 			>
 				<div class="font-medium leading-5 mb-2 text-ink-gray-9">
 					{{ certificate.course_title || certificate.batch_title }}
@@ -20,7 +22,7 @@
 					<span> {{ __('Issued on') }}: </span>
 					{{ dayjs(certificate.issue_date).format('DD MMM YYYY') }}
 				</div>
-			</div>
+			</a>
 		</div>
 		<div v-else class="text-sm italic text-ink-gray-5">
 			{{ __('You have not received any certificates yet.') }}
@@ -54,11 +56,8 @@ const certificates = createListResource({
 	cache: ['certificates', props.profile.data?.name],
 })
 
-const openCertificate = (certificate) => {
-	window.open(
-		`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
-			certificate.name
-		}&format=${encodeURIComponent(certificate.template)}`
-	)
-}
+const certificateUrl = (certificate) =>
+	`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
+		certificate.name
+	}&format=${encodeURIComponent(certificate.template)}`
 </script>

--- a/frontend/src/pages/ProfileEvaluationSchedule.vue
+++ b/frontend/src/pages/ProfileEvaluationSchedule.vue
@@ -23,12 +23,14 @@
 								variant="ghost"
 								class="h-4 w-4"
 								icon="lucide-chevron-left"
+								:label="__('Previous')"
 							/>
 							<Button
 								@click="increment()"
 								variant="ghost"
 								class="h-4 w-4"
 								icon="lucide-chevron-right"
+								:label="__('Next')"
 							/>
 						</div>
 					</div>

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -36,30 +36,42 @@
 				<div
 					v-if="evaluator.data"
 					v-for="slot in evaluator.data.slots.schedule"
+					:key="slot.name"
 					class="grid grid-cols-3 md:grid-cols-4 gap-4 mb-4 group"
 				>
 					<FormControl
 						type="select"
 						:options="days"
 						v-model="slot.day"
+						:aria-label="__('Day')"
 						@update:modelValue="update(slot.name, 'day', $event)"
 						:disabled="!isSessionUser()"
 					/>
+					<label :for="`start-time-${slot.name}`" class="sr-only">
+						{{ __('Start Time') }}
+					</label>
 					<FormControl
 						type="time"
+						:id="`start-time-${slot.name}`"
 						v-model="slot.start_time"
 						@update:modelValue="update(slot.name, 'start_time', $event)"
 						:disabled="!isSessionUser()"
 					/>
+					<label :for="`end-time-${slot.name}`" class="sr-only">
+						{{ __('End Time') }}
+					</label>
 					<FormControl
 						type="time"
+						:id="`end-time-${slot.name}`"
 						v-model="slot.end_time"
 						@update:modelValue="update(slot.name, 'end_time', $event)"
 						:disabled="!isSessionUser()"
 					/>
-					<span
+					<button
 						v-if="isSessionUser()"
-						class="lucide-x size-6 text-red-900 rounded-md cursor-pointer p-1 bg-surface-red-2 hidden group-hover:block"
+						type="button"
+						:aria-label="__('Delete slot')"
+						class="lucide-x size-6 text-red-900 rounded-md cursor-pointer p-1 bg-surface-red-2 sr-only group-hover:not-sr-only focus:not-sr-only"
 						@click="deleteRow(slot.name)"
 					/>
 				</div>
@@ -72,17 +84,26 @@
 						type="select"
 						:options="days"
 						v-model="newSlot.day"
+						:aria-label="__('Day')"
 						@update:modelValue="add()"
 						:disabled="!isSessionUser()"
 					/>
+					<label for="new-slot-start-time" class="sr-only">
+						{{ __('Start Time') }}
+					</label>
 					<FormControl
 						type="time"
+						id="new-slot-start-time"
 						v-model="newSlot.start_time"
 						@update:modelValue="add()"
 						:disabled="!isSessionUser()"
 					/>
+					<label for="new-slot-end-time" class="sr-only">
+						{{ __('End Time') }}
+					</label>
 					<FormControl
 						type="time"
+						id="new-slot-end-time"
 						v-model="newSlot.end_time"
 						@update:modelValue="add()"
 						:disabled="!isSessionUser()"

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
@@ -21,9 +21,9 @@
 	</div>
 	<div class="grid grid-cols-2 h-[calc(100vh_-_3rem)]">
 		<div class="border-e py-5 px-8 h-full">
-			<div class="font-semibold mb-2 text-ink-gray-9">
+			<h2 class="font-semibold mb-2 text-ink-gray-9">
 				{{ __('Problem Statement') }}
-			</div>
+			</h2>
 			<div
 				v-html="sanitizeRichHTML(exercise.doc?.problem_statement)"
 				class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal"
@@ -74,6 +74,7 @@
 					<textarea
 						v-if="error"
 						v-model="errorMessage"
+						:aria-label="__('Compiler Message')"
 						class="font-mono text-ink-red-3 bg-surface-gray-1 border-none text-sm h-32 leading-6"
 						readonly
 					/>
@@ -82,9 +83,9 @@
 			</div>
 
 			<div ref="testCaseSection" class="p-5">
-				<span class="text-md font-semibold text-ink-gray-9">
+				<h2 class="text-md font-semibold text-ink-gray-9">
 					{{ __('Test Cases') }}
-				</span>
+				</h2>
 				<div v-if="testCases.length" class="divide-y mt-5">
 					<div
 						v-for="(testCase, index) in testCases"

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue
@@ -6,13 +6,13 @@
 	</LayoutHeader>
 	<div class="p-6">
 		<div class="flex items-center justify-between gap-x-32 mb-5">
-			<div class="text-md font-semibold text-ink-gray-9">
+			<h1 class="text-md font-semibold text-ink-gray-9">
 				{{
 					submissions.data?.length
 						? __('{0} Submissions').format(submissions.data.length)
 						: __('No Submissions')
 				}}
-			</div>
+			</h1>
 			<div
 				v-if="submissions.data?.length || filters"
 				class="grid grid-cols-3 gap-5"
@@ -69,6 +69,7 @@
 			<ListRows>
 				<router-link
 					v-for="row in submissions.data"
+					:key="row.name"
 					:to="{
 						name: 'ProgrammingExerciseSubmission',
 						params: {
@@ -116,6 +117,7 @@
 					<div class="flex gap-2">
 						<Button
 							variant="ghost"
+							:label="__('Delete')"
 							@click="deleteExercises(selections, unselectAll)"
 						>
 							<span class="lucide-trash-2 size-4" />

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue
@@ -39,9 +39,9 @@
 		<div
 			class="mb-5 flex flex-col justify-between gap-y-4 px-5 sm:flex-row sm:items-center"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('{0} Exercises').format(totalExercises.data || 0) }}
-			</div>
+			</h1>
 			<div class="flex flex-col gap-3 sm:gap-5 md:flex-row">
 				<FormControl
 					v-model="titleFilter"
@@ -84,7 +84,7 @@
 			class="flex-1 overflow-y-auto px-5"
 		>
 			<ListHeader class="mb-2 grid items-center rounded bg-surface-gray-2 p-2">
-				<ListHeaderItem :item="item" v-for="item in columns">
+				<ListHeaderItem :item="item" v-for="item in columns" :key="item.key">
 					<template #prefix="{ item }">
 						<span :class="[item.icon, 'h-4 w-4']" aria-hidden="true" />
 					</template>
@@ -94,6 +94,7 @@
 				<ListRow
 					:row="row"
 					v-for="row in exercises.data"
+					:key="row.name"
 					class="hover:bg-surface-gray-1"
 				>
 					<template #default="{ column, item }">
@@ -116,6 +117,7 @@
 					<div class="flex gap-2">
 						<Button
 							variant="ghost"
+							:label="__('Delete')"
 							@click="showDeleteConfirmation(selections, unselectAll)"
 						>
 							<span class="lucide-trash-2 size-4" />

--- a/frontend/src/pages/Programs/ProgramDetail.vue
+++ b/frontend/src/pages/Programs/ProgramDetail.vue
@@ -6,9 +6,9 @@
 	</header>
 	<div v-if="program.data" class="pt-5 px-5 pb-10 mx-auto">
 		<div class="flex items-center gap-x-2 mb-5">
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ program.data.name }}
-			</div>
+			</h1>
 
 			<Badge :theme="program.data.progress < 100 ? 'orange' : 'green'">
 				{{ program.data.progress }}% {{ __('completed') }}

--- a/frontend/src/pages/Programs/ProgramEnrollment.vue
+++ b/frontend/src/pages/Programs/ProgramEnrollment.vue
@@ -41,6 +41,7 @@
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
 						<div
 							v-for="course in program.data.courses"
+							:key="course.name"
 							class="flex flex-col border border-outline-gray-2 p-2 rounded-md h-full"
 						>
 							<div class="font-semibold text-ink-gray-9 leading-5 mb-2">

--- a/frontend/src/pages/Programs/ProgramForm.vue
+++ b/frontend/src/pages/Programs/ProgramForm.vue
@@ -66,7 +66,11 @@
 						<ListHeader
 							class="mb-2 grid items-center gap-x-4 rounded bg-surface-gray-2 p-2"
 						>
-							<ListHeaderItem :item="item" v-for="item in courseColumns" />
+							<ListHeaderItem
+								:item="item"
+								v-for="item in courseColumns"
+								:key="item.key"
+							/>
 						</ListHeader>
 						<ListRows>
 							<Draggable
@@ -86,6 +90,7 @@
 								<div class="flex gap-2">
 									<Button
 										variant="ghost"
+										:label="__('Delete')"
 										@click="remove(selections, unselectAll, 'courses')"
 									>
 										<span class="lucide-trash-2 size-4" />
@@ -140,16 +145,25 @@
 						<ListHeader
 							class="mb-2 grid items-center gap-x-4 rounded bg-surface-gray-2 p-2"
 						>
-							<ListHeaderItem :item="item" v-for="item in memberColumns" />
+							<ListHeaderItem
+								:item="item"
+								v-for="item in memberColumns"
+								:key="item.key"
+							/>
 						</ListHeader>
 						<ListRows>
-							<ListRow :row="row" v-for="row in program.program_members" />
+							<ListRow
+								:row="row"
+								v-for="row in program.program_members"
+								:key="row.member"
+							/>
 						</ListRows>
 						<ListSelectBanner>
 							<template #actions="{ unselectAll, selections }">
 								<div class="flex gap-2">
 									<Button
 										variant="ghost"
+										:label="__('Delete')"
 										@click="remove(selections, unselectAll, 'members')"
 									>
 										<span class="lucide-trash-2 size-4" />

--- a/frontend/src/pages/Programs/Programs.vue
+++ b/frontend/src/pages/Programs/Programs.vue
@@ -21,9 +21,9 @@
 		<div
 			class="mb-5 flex flex-col justify-between space-y-4 lg:flex-row lg:items-center lg:space-y-0"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('All Programs') }}
-			</div>
+			</h1>
 			<div
 				class="flex flex-col space-y-3 lg:flex-row lg:items-center lg:gap-x-4 lg:space-y-0"
 			>
@@ -51,10 +51,12 @@
 			v-else-if="programs.data?.length"
 			class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5"
 		>
-			<div
+			<button
+				type="button"
 				v-for="program in programs.data"
+				:key="program.name"
 				@click="openForm(program.name)"
-				class="border rounded-md p-3 hover:border-outline-gray-3 cursor-pointer space-y-2"
+				class="block w-full border rounded-md p-3 hover:border-outline-gray-3 cursor-pointer space-y-2 text-start"
 			>
 				<div class="text-lg-semibold text-ink-gray-9">
 					{{ program.name }}
@@ -73,7 +75,7 @@
 						{{ program.member_count == 1 ? __('member') : __('members') }}
 					</span>
 				</div>
-			</div>
+			</button>
 		</div>
 		<div v-else class="flex-1">
 			<EmptyStateLayout name="Programs" icon="lucide-graduation-cap" />

--- a/frontend/src/pages/Programs/StudentPrograms.vue
+++ b/frontend/src/pages/Programs/StudentPrograms.vue
@@ -1,21 +1,23 @@
 <template>
 	<div class="py-5 px-5 w-full lg:w-3/4 lg:px-0 mx-auto">
 		<div class="flex items-center justify-between mb-5">
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('All Programs') }}
-			</div>
+			</h1>
 			<TabButtons v-model="currentTab" :options="tabs" class="w-fit" />
 		</div>
-		<div v-for="(data, category) in programs.data">
+		<div v-for="(data, category) in programs.data" :key="category">
 			<div v-if="category == currentTab">
 				<div
 					v-if="data.length > 0"
 					class="grid grid-cols-1 lg:grid-cols-3 gap-5"
 				>
-					<div
+					<button
+						type="button"
 						v-for="program in data"
+						:key="program.name"
 						@click="openDetails(program.name, category)"
-						class="border rounded-md p-3 hover:border-outline-gray-3 cursor-pointer"
+						class="block w-full border rounded-md p-3 hover:border-outline-gray-3 cursor-pointer text-start"
 					>
 						<div class="text-lg-semibold text-ink-gray-9 mb-2">
 							{{ program.name }}
@@ -44,7 +46,7 @@
 								{{ Math.ceil(program.progress) }}% {{ __('completed') }}
 							</div>
 						</div>
-					</div>
+					</button>
 				</div>
 				<div v-else class="flex-1">
 					<EmptyStateLayout

--- a/frontend/src/pages/QuizForm.vue
+++ b/frontend/src/pages/QuizForm.vue
@@ -63,9 +63,9 @@
 		<!-- LEFT: Questions -->
 		<div class="flex min-h-0 flex-col">
 			<div class="flex items-center justify-between px-5 pt-5 mb-4">
-				<div class="text-lg-semibold text-ink-gray-9">
+				<h2 class="text-lg-semibold text-ink-gray-9">
 					{{ __('Questions') }}
-				</div>
+				</h2>
 				<Button v-if="!readOnlyMode" @click="openQuestionModal()">
 					<template #prefix>
 						<span class="lucide-plus size-4" />
@@ -86,13 +86,18 @@
 				<ListHeader
 					class="mb-2 grid items-center gap-x-4 rounded bg-surface-gray-2 p-2"
 				>
-					<ListHeaderItem :item="item" v-for="item in questionColumns" />
+					<ListHeaderItem
+						:item="item"
+						v-for="item in questionColumns"
+						:key="item.key"
+					/>
 				</ListHeader>
 				<ListRows>
 					<ListRow
 						:row="row"
 						v-slot="{ idx, column, item }"
 						v-for="row in questions"
+						:key="row.name"
 						@click="openQuestionModal(row)"
 						class="cursor-pointer"
 					>
@@ -113,6 +118,7 @@
 						<div class="flex gap-2">
 							<Button
 								variant="ghost"
+								:label="__('Delete')"
 								@click="deleteQuestions(selections, unselectAll)"
 							>
 								<span class="lucide-trash-2 size-4" />
@@ -150,7 +156,7 @@
 		<!-- RIGHT: Details + Settings -->
 		<div class="space-y-8 overflow-y-auto border-l p-5">
 			<div class="space-y-5">
-				<div class="text-ink-gray-9 font-semibold">{{ __('Details') }}</div>
+				<h2 class="text-ink-gray-9 font-semibold">{{ __('Details') }}</h2>
 				<FormControl
 					v-model="quizDetails.doc.title"
 					:label="__('Title')"
@@ -198,7 +204,7 @@
 				/>
 			</div>
 			<div class="space-y-5">
-				<div class="text-ink-gray-9 font-semibold">{{ __('Settings') }}</div>
+				<h2 class="text-ink-gray-9 font-semibold">{{ __('Settings') }}</h2>
 				<BooleanSwitch
 					v-model="quizDetails.doc.show_answers"
 					size="sm"

--- a/frontend/src/pages/QuizSubmission.vue
+++ b/frontend/src/pages/QuizSubmission.vue
@@ -18,9 +18,9 @@
 		</div>
 	</header>
 	<div v-if="submissionDetails.doc" class="w-2/3 border-x mx-auto py-5">
-		<div class="text-2xl-semibold px-10 text-ink-gray-9 mb-5">
+		<h1 class="text-2xl-semibold px-10 text-ink-gray-9 mb-5">
 			{{ submissionDetails.doc.member_name }}
-		</div>
+		</h1>
 		<div class="space-y-4 border-b pb-5 px-10">
 			<div class="grid grid-cols-2 gap-5">
 				<FormControl
@@ -52,6 +52,7 @@
 		<div class="divide-y">
 			<div
 				v-for="(row, index) in submissionDetails.doc.result"
+				:key="row.name"
 				class="py-5 px-10 space-y-4"
 			>
 				<div class="text-ink-gray-9">

--- a/frontend/src/pages/QuizSubmissionList.vue
+++ b/frontend/src/pages/QuizSubmissionList.vue
@@ -5,9 +5,9 @@
 		</template>
 	</LayoutHeader>
 	<div v-if="submissions.data?.length" class="md:w-3/4 md:mx-auto py-5 mx-5">
-		<div class="text-2xl-semibold mb-5 text-ink-gray-9">
+		<h1 class="text-2xl-semibold mb-5 text-ink-gray-9">
 			{{ submissions.data[0].quiz_title }}
-		</div>
+		</h1>
 		<ListView
 			:columns="quizColumns"
 			:rows="submissions.data"
@@ -17,12 +17,17 @@
 			<ListHeader
 				class="mb-2 grid items-center gap-x-4 rounded bg-surface-gray-2 p-2"
 			>
-				<ListHeaderItem :item="item" v-for="item in quizColumns">
+				<ListHeaderItem
+					:item="item"
+					v-for="item in quizColumns"
+					:key="item.key"
+				>
 				</ListHeaderItem>
 			</ListHeader>
 			<ListRows>
 				<router-link
 					v-for="row in submissions.data"
+					:key="row.name"
 					:to="{
 						name: 'QuizSubmission',
 						params: {

--- a/frontend/src/pages/Quizzes.vue
+++ b/frontend/src/pages/Quizzes.vue
@@ -17,10 +17,15 @@
 		<div
 			class="mx-5 mb-5 flex flex-col justify-between gap-y-4 sm:flex-row sm:items-center"
 		>
-			<div class="text-lg-semibold text-ink-gray-9">
+			<h1 class="text-lg-semibold text-ink-gray-9">
 				{{ __('{0} Quizzes').format(totalQuizzes.data || 0) }}
-			</div>
-			<FormControl v-model="search" type="text" placeholder="Search">
+			</h1>
+			<FormControl
+				v-model="search"
+				type="text"
+				placeholder="Search"
+				:aria-label="__('Search')"
+			>
 				<template #prefix>
 					<span class="lucide-search size-4 text-ink-gray-5" />
 				</template>
@@ -41,7 +46,11 @@
 			class="flex-1 overflow-y-auto px-5"
 		>
 			<ListHeader class="mb-2 grid items-center rounded bg-surface-gray-2 p-2">
-				<ListHeaderItem :item="item" v-for="item in quizColumns">
+				<ListHeaderItem
+					:item="item"
+					v-for="item in quizColumns"
+					:key="item.key"
+				>
 					<template #prefix="{ item }">
 						<span :class="[item.icon, 'h-4 w-4']" aria-hidden="true" />
 					</template>
@@ -50,6 +59,7 @@
 			<ListRows>
 				<router-link
 					v-for="row in quizzes.data"
+					:key="row.name"
 					:to="{
 						name: 'QuizForm',
 						params: {
@@ -82,6 +92,7 @@
 					<div class="flex gap-2">
 						<Button
 							variant="ghost"
+							:label="__('Delete')"
 							@click="deleteQuiz(selections, unselectAll)"
 						>
 							<span class="lucide-trash-2 size-4" />
@@ -241,7 +252,7 @@ const createQuiz = () => {
 				})
 			},
 			onError(error) {
-				toast.error(__('Error creating quiz: {0}', error.message))
+				toast.error(__('Error creating quiz: {0}').format(error.message))
 			},
 		}
 	)

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -14,6 +14,7 @@
 	>
 		<iframe
 			:src="chapter.doc.launch_file"
+			:title="chapter.doc?.title || __('Lesson content')"
 			class="w-full h-[calc(100vh-3.00rem)]"
 		/>
 	</div>

--- a/frontend/src/tests/VideoPreview.test.ts
+++ b/frontend/src/tests/VideoPreview.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import VideoPreview from '@/components/VideoPreview.vue'
 
+const global = { mocks: { __: (s: string) => s } }
+
 describe('VideoPreview', () => {
 	it('renders a YouTube iframe (not a <video>) for a youtube link', () => {
 		const w = mount(VideoPreview, {
 			props: { videoLink: 'https://youtu.be/O7FIiYsVy3U?si=22FPigXQedh7jAlz' },
+			global,
 		})
 		const iframe = w.find('iframe')
 		expect(iframe.exists()).toBe(true)
@@ -16,7 +19,10 @@ describe('VideoPreview', () => {
 	})
 
 	it('renders a <video> for an uploaded file path', () => {
-		const w = mount(VideoPreview, { props: { videoLink: '/files/intro.mp4' } })
+		const w = mount(VideoPreview, {
+			props: { videoLink: '/files/intro.mp4' },
+			global,
+		})
 		const video = w.find('video')
 		expect(video.exists()).toBe(true)
 		expect(video.attributes('src')).toBe('/files/intro.mp4')
@@ -25,7 +31,11 @@ describe('VideoPreview', () => {
 
 	it('falls back to the image when the file video errors', async () => {
 		const w = mount(VideoPreview, {
-			props: { videoLink: '/files/intro.mov', fallbackImage: '/files/thumb.jpg' },
+			props: {
+				videoLink: '/files/intro.mov',
+				fallbackImage: '/files/thumb.jpg',
+			},
+			global,
 		})
 		await w.find('video').trigger('error')
 		expect(w.find('video').exists()).toBe(false)
@@ -35,7 +45,10 @@ describe('VideoPreview', () => {
 	})
 
 	it('renders nothing without a link', () => {
-		const w = mount(VideoPreview, { props: { videoLink: null } })
+		const w = mount(VideoPreview, {
+			props: { videoLink: null },
+			global,
+		})
 		expect(w.find('iframe').exists()).toBe(false)
 		expect(w.find('video').exists()).toBe(false)
 		expect(w.find('img').exists()).toBe(false)

--- a/frontend/src/utils/a11y.ts
+++ b/frontend/src/utils/a11y.ts
@@ -1,0 +1,6 @@
+/* Moves focus to the skip-link target without a native fragment navigation,
+   which would overwrite the hash that pages like CourseDetail use for tab
+   state. The target carries tabindex="-1" so it can take focus. */
+export function skipToContent(id: string) {
+	document.getElementById(id)?.focus()
+}

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -1,0 +1,11 @@
+import type { RouteLocationRaw } from 'vue-router'
+
+/* Returns null when the username is missing, since /user/:username is a
+   required param and router-link resolves `to` while rendering. */
+export function profileRoute(
+	username?: string | null,
+	name = 'Profile'
+): RouteLocationRaw | null {
+	if (!username) return null
+	return { name, params: { username } }
+}


### PR DESCRIPTION
## Summary
- Makes the LMS frontend keyboard-operable and screen-reader-navigable — no visual redesign, no new patterns. 108 files, two commits.

## Changes
- Added `<main>` + "Skip to main content" link in the three layouts; the link moves focus via JS, not a fragment nav, so it doesn't clobber the URL hash CourseDetail/CourseEditor use for tab state.
- Turned the mobile tab bar into a labelled `<nav>`.
- 31 `<div @click>` → real `<button>`/`<router-link>` (tabbable, Enter/Space).
- 17 hand-rolled lists → `<ul>`/`<li>`; 44 real heading levels.
- Accessible names for icon-only controls; alt text on 8 images.
- 78 `:key` bindings fixed (missing, non-unique, nullable, or object-bound).