### PR TITLE
fix: count a coupon redemption once per payment that was actually paid

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -77,6 +77,7 @@ before_uninstall = "lms.install.before_uninstall"
 setup_wizard_complete = "lms.demo.demo_data.create_demo_data"
 after_migrate = [
 	"lms.sqlite.build_index_in_background",
+	"lms.lms.doctype.lms_payment.lms_payment.add_unique_payment_id_constraint",
 ]
 
 # Desk Notifications

--- a/lms/lms/doctype/lms_payment/lms_payment.json
+++ b/lms/lms/doctype/lms_payment/lms_payment.json
@@ -203,7 +203,7 @@
    "link_fieldname": "payment"
   }
  ],
- "modified": "2026-03-06 17:38:02.235044",
+ "modified": "2026-07-28 12:30:00.000000",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Payment",

--- a/lms/lms/doctype/lms_payment/lms_payment.py
+++ b/lms/lms/doctype/lms_payment/lms_payment.py
@@ -6,12 +6,67 @@ from frappe import _
 from frappe.email.doctype.email_template.email_template import get_email_template
 from frappe.model.document import Document
 from frappe.utils import add_days, flt, nowdate
+from pypika import functions as fn
 
 from lms.lms.utils import get_lms_route
 
 
 class LMSPayment(Document):
 	pass
+
+
+UNIQUE_PAYMENT_ID = "unique_payment_id"
+
+
+def on_doctype_update():
+	add_unique_payment_id_constraint()
+
+
+def add_unique_payment_id_constraint():
+	"""One gateway payment belongs to one LMS Payment. Two callbacks for the same
+	payment id can be resolved to different rows, which do not lock each other,
+	so the constraint is what stops both being credited.
+
+	A site that already carries duplicates — the very bug this prevents — keeps
+	its rows and is told, rather than having a migration decide which payment was
+	really charged. It gets a plain index for the duplicate lookup, and
+	update_payment_record falls back to serializing callbacks until the
+	constraint can be added. Runs on every migrate, so cleaning the duplicates up
+	is all an operator has to do."""
+	if has_unique_payment_id():
+		return
+
+	duplicates = get_duplicate_payment_ids()
+
+	if duplicates:
+		frappe.log_error(
+			title="Duplicate payment ids block a unique constraint on LMS Payment",
+			message="More than one LMS Payment row shares a payment id: "
+			+ ", ".join(duplicates)
+			+ ".\nUntil the duplicates are removed, every payment callback for a course or batch "
+			"is serialized to keep one gateway payment from crediting two of them. Keep the "
+			"payment that was really charged and the next migrate will add the constraint.",
+			defer_insert=True,
+		)
+		frappe.db.add_index("LMS Payment", ["payment_id"])
+		return
+
+	frappe.db.add_unique("LMS Payment", ["payment_id"])
+
+
+def has_unique_payment_id() -> bool:
+	return bool(frappe.db.has_index("tabLMS Payment", UNIQUE_PAYMENT_ID))
+
+
+def get_duplicate_payment_ids() -> list[str]:
+	payment = frappe.qb.DocType("LMS Payment")
+	return (
+		frappe.qb.from_(payment)
+		.select(payment.payment_id)
+		.where(payment.payment_id.notnull() & (payment.payment_id != ""))
+		.groupby(payment.payment_id)
+		.having(fn.Count(payment.name) > 1)
+	).run(pluck=True)
 
 
 def send_payment_reminder():

--- a/lms/lms/payments.py
+++ b/lms/lms/payments.py
@@ -69,6 +69,14 @@ def get_payment_link(
 	coupon = details.get("coupon")
 	total_amount = amount_with_gst if amount_with_gst else amount
 
+	# Checkout is reachable from a stale tab or the back button. Paying again for
+	# access the learner already has would charge them twice, count another
+	# coupon redemption, and grant nothing. The billing details they typed are
+	# still worth keeping.
+	if already_has_access(doctype, docname, payment_for_certificate):
+		save_address(address)
+		return redirect_to
+
 	# Resolve the controller before writing anything: get_controller validates the
 	# gateway and fails with an actionable message, so a misconfigured gateway
 	# doesn't leave an orphan Address / LMS Payment row behind.
@@ -111,6 +119,22 @@ def get_payment_link(
 	url = controller.get_payment_url(**payment_details)
 
 	return url
+
+
+def already_has_access(doctype: str, docname: str, payment_for_certificate: int) -> bool:
+	member = frappe.session.user
+
+	if int(payment_for_certificate):
+		return bool(
+			frappe.db.get_value(
+				"LMS Enrollment", {"member": member, "course": docname}, "purchased_certificate"
+			)
+		)
+
+	if doctype == "LMS Course":
+		return bool(frappe.db.exists("LMS Enrollment", {"member": member, "course": docname}))
+
+	return bool(frappe.db.exists("LMS Batch Enrollment", {"member": member, "batch": docname}))
 
 
 def create_order(payment_gateway: str, payment_details: dict, controller: object):

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -2138,19 +2138,100 @@ def publish_notifications(doc: Document, method: str):
 
 
 def update_payment_record(doctype: str, docname: str):
+	data = get_payment_callback_data(doctype, docname)
+
+	if not data or not data.get("payment"):
+		return
+
+	serialize_callbacks_without_the_constraint()
+
+	if payment_already_recorded(data):
+		return
+
+	try:
+		update_payment_details(data)
+	except Exception as e:
+		if not frappe.db.is_unique_key_violation(e):
+			raise
+		# Another callback for the same gateway payment reached this first and is
+		# crediting a different LMS Payment row. LMS Payment.payment_id is unique
+		# precisely so that only one of them can.
+		return
+
+	complete_enrollment(data.payment, doctype, docname)
+
+
+def get_payment_callback_data(doctype: str, docname: str) -> dict | None:
+	"""The payload of the callback being handled, which is the only thing that
+	says which payment the money arrived for.
+
+	Only some gateways publish it, so fall back to the document's latest request.
+	That fallback picks the wrong payment when a learner has an unpaid checkout
+	open, which is why payment_already_recorded double-checks the gateway's own
+	payment id before anything is credited."""
+	data = frappe.flags.data
+
+	if data and data.get("payment"):
+		return frappe._dict(data)
+
 	request = get_integration_requests(doctype, docname)
 
-	if len(request):
-		data = request[0].data
-		data = frappe._dict(json.loads(data))
+	if not request:
+		return None
 
-		update_payment_details(data)
-		complete_enrollment(data.payment, doctype, docname)
+	return frappe._dict(json.loads(request[0].data))
+
+
+def serialize_callbacks_without_the_constraint():
+	"""A site carrying duplicate payment ids cannot take the unique constraint on
+	LMS Payment.payment_id, and without it two callbacks for one gateway payment
+	can be credited to different rows, which never lock each other.
+
+	Take one lock every callback contends for instead. The DocType row of the
+	table missing its constraint is an arbitrary choice, but it always exists and
+	nothing else writes it outside a migrate. Payment callbacks then queue
+	site-wide, which is coarse — and is why it only happens while the constraint
+	is missing — but it puts them back in line, so the second one sees the first
+	payment recorded."""
+	# Imported here: lms_payment imports get_lms_route from this module.
+	from lms.lms.doctype.lms_payment.lms_payment import has_unique_payment_id
+
+	if has_unique_payment_id():
+		return
+
+	frappe.db.get_value("DocType", "LMS Payment", "name", for_update=True)
+
+
+def payment_already_recorded(data: dict) -> bool:
+	"""A gateway retries a callback it never got an answer to. The money arrived
+	once, so the enrollment and the coupon redemption stay as they are.
+
+	for_update holds the payment row until this transaction ends, so two retries
+	arriving together cannot both read it as unrecorded and both credit it."""
+	if frappe.db.get_value("LMS Payment", data.payment, "payment_received", for_update=True):
+		return True
+
+	payment_id = data.get(get_payment_id(data))
+
+	if not payment_id:
+		return False
+
+	# Only sees callbacks that have already committed. Two arriving together are
+	# kept apart by the unique constraint on payment_id, which is what makes
+	# update_payment_details fail for whichever one loses.
+	return bool(frappe.db.exists("LMS Payment", {"payment_id": payment_id}))
 
 
 def complete_enrollment(payment_name: str, doctype: str, docname: str):
 	payment_doc = get_payment_doc(payment_name)
-	update_coupon_redemption(payment_doc)
+
+	if not payment_doc:
+		frappe.log_error(
+			title="Payment record missing while completing enrollment",
+			message=f"LMS Payment {payment_name} was not found for {doctype} {docname}.",
+			defer_insert=True,
+		)
+		frappe.throw(_("We could not find your payment record. Please contact the administrator."))
 
 	if payment_doc.payment_for_certificate:
 		update_certificate_purchase(docname, payment_name)
@@ -2158,6 +2239,10 @@ def complete_enrollment(payment_name: str, doctype: str, docname: str):
 		enroll_in_course(docname, payment_name)
 	else:
 		enroll_in_batch(docname, payment_name)
+
+	# Counted last: it locks the coupon row until the request commits, and
+	# enrolling is the slower half of this transaction.
+	update_coupon_redemption(payment_doc)
 
 
 def get_integration_requests(doctype: str, docname: str):
@@ -2176,7 +2261,10 @@ def get_integration_requests(doctype: str, docname: str):
 
 def get_payment_doc(payment_name: str) -> dict:
 	return frappe.db.get_value(
-		"LMS Payment", payment_name, ["name", "coupon", "payment_for_certificate"], as_dict=True
+		"LMS Payment",
+		payment_name,
+		["name", "coupon", "payment_for_certificate", "amount", "amount_with_gst"],
+		as_dict=True,
 	)
 
 
@@ -2206,15 +2294,57 @@ def get_payment_id(data: dict) -> str:
 
 
 def update_coupon_redemption(payment_doc: dict):
-	if payment_doc.coupon:
-		redemption_count = frappe.db.get_value("LMS Coupon", payment_doc.coupon, "redemption_count") or 0
+	"""Count one redemption against the coupon a completed payment used.
 
-		frappe.db.set_value(
-			"LMS Coupon",
-			payment_doc.coupon,
-			"redemption_count",
-			redemption_count + 1,
-		)
+	Reached once per payment: payment_already_recorded turns a replayed callback
+	away before it gets here."""
+	if not payment_doc or not payment_doc.coupon:
+		return
+
+	# for_update locks the coupon row until this transaction ends, so the read
+	# below and the write that follows cannot interleave with another redemption
+	# and lose one of the two increments.
+	coupon = frappe.db.get_value(
+		"LMS Coupon",
+		payment_doc.coupon,
+		["usage_limit", "redemption_count"],
+		as_dict=True,
+		for_update=True,
+	)
+
+	if not coupon:
+		return
+
+	redemption_count = cint(coupon.redemption_count) + 1
+	usage_limit = cint(coupon.usage_limit)
+
+	if usage_limit and redemption_count > usage_limit:
+		handle_usage_limit_overshoot(payment_doc, redemption_count, usage_limit)
+
+	frappe.db.set_value("LMS Coupon", payment_doc.coupon, "redemption_count", redemption_count)
+
+
+def handle_usage_limit_overshoot(payment_doc: dict, redemption_count: int, usage_limit: int):
+	"""The usage limit is enforced before payment, so reaching it here means a
+	redemption slipped through the window between that check and this payment
+	completing. A fully discounted order has taken no money yet, so the limit is
+	still enforceable there. Otherwise the learner has already paid: record the
+	redemption regardless and surface the overshoot to the operator."""
+	if not get_payment_total(payment_doc):
+		frappe.throw(_("This coupon has reached its maximum usage limit."))
+
+	# defer_insert keeps the Error Log write out of this transaction, so a
+	# failure to log cannot roll back an enrollment the learner paid for.
+	frappe.log_error(
+		title="Coupon redeemed beyond its usage limit",
+		message=f"Coupon {payment_doc.coupon} has {redemption_count} redemptions "
+		f"against a usage limit of {usage_limit}.",
+		defer_insert=True,
+	)
+
+
+def get_payment_total(payment_doc: dict) -> float:
+	return flt(payment_doc.amount_with_gst) or flt(payment_doc.amount)
 
 
 def enroll_in_course(course: str, payment_name: str):
@@ -2270,6 +2400,11 @@ def create_enrollment(batch: str, payment_doc: dict = None):
 
 
 def update_certificate_purchase(course: str, payment_name: str):
+	# The purchase is recorded on the enrollment, so a learner who bought
+	# certification without enrolling first would otherwise pay for nothing:
+	# set_value with filters updates no rows and reports no error.
+	enroll_in_course(course, payment_name)
+
 	frappe.db.set_value(
 		"LMS Enrollment",
 		{"member": frappe.session.user, "course": course},

--- a/lms/tests/test_coupon_redemption.py
+++ b/lms/tests/test_coupon_redemption.py
@@ -1,0 +1,442 @@
+# Copyright (c) 2026, FOSS United and Contributors
+# See license.txt
+
+import threading
+from unittest.mock import patch
+
+import frappe
+
+from lms.lms.doctype.lms_payment.lms_payment import (
+	UNIQUE_PAYMENT_ID,
+	add_unique_payment_id_constraint,
+)
+from lms.lms.payments import get_payment_link
+from lms.lms.test_helpers import BaseTestUtils
+from lms.lms.utils import complete_enrollment, update_coupon_redemption, update_payment_record
+
+# A worker that never reaches the barrier must not hang the whole suite.
+THREAD_TIMEOUT = 30
+
+BILLING_ADDRESS = {
+	"billing_name": "Coupon Tester",
+	"address_line1": "1 Test Street",
+	"city": "Mumbai",
+	"country": "India",
+	"source": "Website",
+	"member_consent": 1,
+}
+
+
+class TestCouponRedemption(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"cinstr-{hash}@example.com", "Ida", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.course = self._create_course(
+			title=f"Coupon Redemption Course {hash}", instructor=self.instructor.email
+		)
+		self.course.db_set({"paid_course": 1, "course_price": 1000, "currency": "INR"})
+		self.extra_courses = []
+
+	def tearDown(self):
+		self._delete_course_records()
+		super().tearDown()
+
+	def _delete_course_records(self):
+		"""Some tests commit, so the framework's rollback cannot undo them."""
+		courses = [self.course.name] + [course.name for course in self.extra_courses]
+		for doctype, field in (("LMS Enrollment", "course"), ("LMS Payment", "payment_for_document")):
+			for name in frappe.get_all(doctype, {field: ("in", courses)}, pluck="name"):
+				frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+		frappe.db.commit()  # nosemgrep
+
+	def _create_coupon(self, redemption_count=0, usage_limit=None, percentage_discount=10):
+		coupon = frappe.new_doc("LMS Coupon")
+		coupon.update(
+			{
+				"code": f"RACE{frappe.generate_hash(length=8)}",
+				"discount_type": "Percentage",
+				"percentage_discount": percentage_discount,
+				"usage_limit": usage_limit,
+				"enabled": 1,
+				"applicable_items": [{"reference_doctype": "LMS Course", "reference_name": self.course.name}],
+			}
+		)
+		coupon.save(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Coupon", coupon.name))
+
+		if redemption_count:
+			frappe.db.set_value("LMS Coupon", coupon.name, "redemption_count", redemption_count)
+
+		return coupon
+
+	def _create_address(self):
+		address = frappe.new_doc("Address")
+		address.update(
+			{
+				"address_title": f"Coupon Tester {frappe.generate_hash(length=8)}",
+				"address_type": "Billing",
+				"address_line1": "1 Test Street",
+				"city": "Mumbai",
+				"country": "India",
+				"email_id": frappe.session.user,
+			}
+		)
+		address.save(ignore_permissions=True)
+		self.cleanup_items.append(("Address", address.name))
+		return address
+
+	def _create_source(self):
+		if not frappe.db.exists("LMS Source", "Website"):
+			frappe.get_doc({"doctype": "LMS Source", "source": "Website"}).insert(ignore_permissions=True)
+		return "Website"
+
+	def _create_payment(self, coupon=None, amount=1000, payment_for_certificate=0, course=None):
+		payment = frappe.new_doc("LMS Payment")
+		payment.update(
+			{
+				"member": frappe.session.user,
+				"billing_name": "Coupon Tester",
+				"address": self._create_address().name,
+				"source": self._create_source(),
+				"amount": amount,
+				"currency": "INR",
+				"payment_for_document_type": "LMS Course",
+				"payment_for_document": course or self.course.name,
+				"payment_for_certificate": payment_for_certificate,
+				"coupon": coupon.name if coupon else None,
+			}
+		)
+		payment.save(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Payment", payment.name))
+		return payment
+
+	def _payment_doc(self, payment, coupon, amount=1000):
+		return frappe._dict(coupon=coupon.name if coupon else None, name=payment.name, amount=amount)
+
+	def _count(self, coupon):
+		return frappe.db.get_value("LMS Coupon", coupon.name, "redemption_count")
+
+	def _callback(self, payment, razorpay_payment_id, course=None):
+		"""What the gateway controller does before handing over: publish the
+		payload of the callback it is handling."""
+		frappe.flags.data = {
+			"payment": payment.name,
+			"payment_gateway": "Razorpay",
+			"razorpay_payment_id": razorpay_payment_id,
+		}
+		try:
+			update_payment_record("LMS Course", course or self.course.name)
+		finally:
+			frappe.flags.data = None
+
+	def _checkout(self, coupon, address=None):
+		return get_payment_link(
+			doctype="LMS Course",
+			docname=self.course.name,
+			address=address or BILLING_ADDRESS,
+			payment_for_certificate=0,
+			coupon_code=coupon.code,
+		)
+
+	def _drop_unique_payment_id(self):
+		# Constant identifier, and the test puts the constraint back.
+		frappe.db.sql_ddl(f"alter table `tabLMS Payment` drop index `{UNIQUE_PAYMENT_ID}`")
+
+	def _is_enrolled(self):
+		return bool(
+			frappe.db.exists("LMS Enrollment", {"member": frappe.session.user, "course": self.course.name})
+		)
+
+	# Counting
+
+	def test_increments_redemption_count(self):
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+
+		update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_no_coupon_is_a_noop(self):
+		coupon = self._create_coupon()
+		payment = self._create_payment()
+
+		update_coupon_redemption(self._payment_doc(payment, coupon=None))
+
+		self.assertEqual(self._count(coupon), 0)
+
+	def test_separate_payments_each_count(self):
+		coupon = self._create_coupon()
+
+		for _ in range(5):
+			payment = self._create_payment(coupon)
+			update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertEqual(self._count(coupon), 5)
+
+	def test_redemption_keeps_the_coupon_timestamp_current(self):
+		"""The count is edited from the desk form too, which relies on `modified`
+		to detect that it went stale."""
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+		modified_before = frappe.db.get_value("LMS Coupon", coupon.name, "modified")
+
+		update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertNotEqual(frappe.db.get_value("LMS Coupon", coupon.name, "modified"), modified_before)
+
+	def test_parallel_redemptions_are_not_lost(self):
+		"""Two redemptions committing at the same time must both be counted, on
+		real threads with their own database connections."""
+		workers = 8
+		coupon = self._create_coupon()
+		payments = [self._create_payment(coupon) for _ in range(workers)]
+
+		def redeem(payment):
+			update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertEqual(self._in_parallel(coupon, redeem, payments), workers)
+
+	# Usage limit
+
+	def test_paid_redemption_past_the_usage_limit_is_still_recorded(self):
+		coupon = self._create_coupon(redemption_count=1, usage_limit=1)
+		payment = self._create_payment(coupon)
+
+		with patch.object(frappe, "log_error") as log_error:
+			update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		# The payment already went through, so the redemption is still recorded.
+		self.assertEqual(self._count(coupon), 2)
+		log_error.assert_called_once()
+		self.assertIn(coupon.name, str(log_error.call_args))
+
+	def test_free_redemption_past_the_usage_limit_is_rejected(self):
+		"""Nothing has been paid on a fully discounted order, so the limit can
+		still be enforced instead of merely logged."""
+		coupon = self._create_coupon(redemption_count=1, usage_limit=1)
+		payment = self._create_payment(coupon, amount=0)
+
+		with self.assertRaises(frappe.ValidationError):
+			update_coupon_redemption(self._payment_doc(payment, coupon, amount=0))
+
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_does_not_log_within_usage_limit(self):
+		coupon = self._create_coupon(redemption_count=0, usage_limit=5)
+		payment = self._create_payment(coupon)
+
+		with patch.object(frappe, "log_error") as log_error:
+			update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertEqual(self._count(coupon), 1)
+		log_error.assert_not_called()
+
+	def test_does_not_log_when_no_usage_limit_set(self):
+		coupon = self._create_coupon(redemption_count=99, usage_limit=0)
+		payment = self._create_payment(coupon)
+
+		with patch.object(frappe, "log_error") as log_error:
+			update_coupon_redemption(self._payment_doc(payment, coupon))
+
+		self.assertEqual(self._count(coupon), 100)
+		log_error.assert_not_called()
+
+	# Gateway callbacks
+
+	def test_gateway_callback_enrolls_and_counts_one_redemption(self):
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+
+		self._callback(payment, "pay_first")
+
+		self.assertEqual(frappe.db.get_value("LMS Payment", payment.name, "payment_received"), 1)
+		self.assertTrue(self._is_enrolled())
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_replayed_callback_does_not_credit_a_second_payment(self):
+		"""A gateway retry can be resolved against a newer unpaid checkout. That
+		payment must not be marked received, and the coupon must not be counted
+		twice for money that arrived once."""
+		coupon = self._create_coupon()
+		paid = self._create_payment(coupon)
+		self._callback(paid, "pay_first")
+
+		open_checkout = self._create_payment(coupon)
+		self._callback(open_checkout, "pay_first")
+
+		self.assertEqual(frappe.db.get_value("LMS Payment", open_checkout.name, "payment_received"), 0)
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_parallel_callbacks_for_one_payment_count_once(self):
+		"""Two gateway retries for the same payment can arrive at once. Only one
+		of them may count a redemption."""
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+
+		def deliver(_):
+			self._callback(payment, "pay_first")
+
+		self.assertEqual(self._in_parallel(coupon, deliver, [payment] * 4), 1)
+
+	def test_parallel_callbacks_for_one_gateway_payment_credit_one_payment(self):
+		"""Retries for one gateway payment can be resolved to different LMS
+		Payment rows, which do not contend with each other. One transaction, one
+		credited payment."""
+		coupon = self._create_coupon()
+		payments = [self._create_payment(coupon) for _ in range(2)]
+
+		def deliver(payment):
+			self._callback(payment, "pay_shared")
+
+		self.assertEqual(self._in_parallel(coupon, deliver, payments), 1)
+
+	def test_parallel_callbacks_are_serialized_without_the_constraint(self):
+		"""A site carrying duplicate payment ids cannot take the constraint, and
+		the two callbacks need not even be for the same course. It must still not
+		credit two payments for one gateway payment."""
+		coupon = self._create_coupon()
+		other_course = self._create_second_course()
+		payments = [
+			self._create_payment(coupon),
+			self._create_payment(coupon, course=other_course.name),
+		]
+		self._drop_unique_payment_id()
+
+		def deliver(payment):
+			self._callback(payment, "pay_shared", course=payment.payment_for_document)
+
+		try:
+			self.assertEqual(self._in_parallel(coupon, deliver, payments), 1)
+		finally:
+			add_unique_payment_id_constraint()
+
+	def _create_second_course(self):
+		course = self._create_course(
+			title=f"Coupon Redemption Course {frappe.generate_hash(length=6)}",
+			instructor=self.instructor.email,
+		)
+		course.db_set({"paid_course": 1, "course_price": 1000, "currency": "INR"})
+		self.extra_courses.append(course)
+		return course
+
+	def test_missing_payment_record_fails_with_a_readable_error(self):
+		with patch.object(frappe, "log_error"), self.assertRaises(frappe.ValidationError) as caught:
+			complete_enrollment("LMS-PAY-does-not-exist", "LMS Course", self.course.name)
+
+		self.assertIn("payment record", str(caught.exception))
+
+	def test_certificate_purchase_enrolls_a_learner_who_is_not_enrolled(self):
+		"""The purchase is recorded on the enrollment, so without one the learner
+		pays and gets nothing — and never stops paying, because the checkout
+		guard reads the same flag."""
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon, payment_for_certificate=1)
+
+		complete_enrollment(payment.name, "LMS Course", self.course.name)
+
+		enrollment = frappe.db.get_value(
+			"LMS Enrollment",
+			{"member": frappe.session.user, "course": self.course.name},
+			["name", "purchased_certificate"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(enrollment)
+		self.assertEqual(enrollment.purchased_certificate, 1)
+
+	# Checkout
+
+	def test_fully_discounted_checkout_enrolls_and_counts_one_redemption(self):
+		coupon = self._create_coupon(percentage_discount=100)
+
+		self._checkout(coupon)
+
+		self.assertTrue(self._is_enrolled())
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_repeat_free_checkout_does_not_burn_another_redemption(self):
+		"""Nothing stops a learner calling checkout again on a course they are
+		already enrolled in; it must not eat into the coupon's usage limit."""
+		coupon = self._create_coupon(percentage_discount=100)
+		self._checkout(coupon)
+
+		for _ in range(3):
+			self._checkout(coupon)
+
+		self.assertEqual(self._count(coupon), 1)
+		self.assertEqual(frappe.db.count("LMS Payment", {"coupon": coupon.name}), 1)
+
+	def test_repeat_paid_checkout_does_not_create_a_second_payment(self):
+		"""A stale tab or the back button must not charge a learner again for a
+		course they already have."""
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+		self._callback(payment, "pay_first")
+
+		self._checkout(coupon)
+
+		self.assertEqual(frappe.db.count("LMS Payment", {"payment_for_document": self.course.name}), 1)
+		self.assertEqual(self._count(coupon), 1)
+
+	def test_repeat_checkout_still_saves_edited_billing_details(self):
+		coupon = self._create_coupon()
+		payment = self._create_payment(coupon)
+		self._callback(payment, "pay_first")
+
+		self._checkout(coupon, address={**BILLING_ADDRESS, "address_line1": "42 New Street"})
+
+		address = frappe.get_last_doc("Address", filters={"email_id": frappe.session.user})
+		self.assertEqual(address.address_line1, "42 New Street")
+
+	# Threading
+
+	def _in_parallel(self, coupon, work, items) -> int:
+		"""Run work(item) once per item, each on its own connection, all at the
+		same moment. Returns the resulting redemption count, read before the
+		committed fixtures are cleaned up."""
+		site = frappe.local.site
+		# The workers run on their own connections, so the fixtures have to be
+		# visible outside this test's transaction.
+		frappe.db.commit()  # nosemgrep
+		barrier = threading.Barrier(len(items))
+		errors = []
+
+		def run(item):
+			try:
+				frappe.init(site=site)
+				frappe.connect()
+				try:
+					barrier.wait(timeout=THREAD_TIMEOUT)  # maximise overlap between the workers
+					work(item)
+					frappe.db.commit()  # nosemgrep
+				finally:
+					frappe.destroy()
+			except Exception as e:  # surfaced in the assertion below
+				errors.append(e)
+				barrier.abort()  # don't strand the workers still waiting
+
+		threads = [threading.Thread(target=run, args=(item,)) for item in items]
+		try:
+			for thread in threads:
+				thread.start()
+			for thread in threads:
+				thread.join(timeout=THREAD_TIMEOUT)
+				self.assertFalse(thread.is_alive(), "a worker did not finish")
+
+			self.assertEqual(errors, [])
+			return self._count(coupon)
+		finally:
+			self._commit_cleanup()
+
+	def _commit_cleanup(self):
+		"""The fixtures above were committed, so rolling back the test cannot
+		remove them."""
+		self._delete_course_records()
+		for doctype, name in reversed(self.cleanup_items):
+			if frappe.db.exists(doctype, name):
+				frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+		self.cleanup_items = []
+		frappe.db.commit()  # nosemgrep


### PR DESCRIPTION
## Problem

Coupon redemptions were counted wrong, so a coupon could be used past its `usage_limit`.

1. **Lost counts.** `update_coupon_redemption` read the count, added one, then wrote it back separately. Two redemptions at once both read the same number and wrote the same result — one was lost. A threaded test on the old code recorded 2 redemptions out of 8 concurrent calls.
2. **Wrong payment credited.** A gateway retry picked whichever Integration Request was newest, so it could land on an unpaid checkout the learner had open and count a second redemption.
3. **Repeat checkouts.** Nothing stopped a learner paying again for access they already had — double charge, extra redemption, nothing granted.
4. **Certificate purchase with no enrollment.** `set_value` with filters updated zero rows silently, so the purchase was never recorded.

## Fix

- Lock the coupon row (`for_update`) before reading it, and count after enrolling so the lock is held briefly. Still writes via `set_value` to keep `modified` and the doc cache current.
- Use the callback's own payload, and check the payment's state + gateway payment id (also `for_update`) before crediting.
- Checkout returns early when the learner already has access, keeping any billing details they edited.
- Certificate purchase enrolls the learner first.
- Over the usage limit: reject if nothing was paid; if money already moved, record it and log the overshoot out of band.

Thanks to Dr. Hossein Hajipour, Reware Labs for reporting this!
