### PR TITLE
fix: drop the razorpay dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "beautifulsoup4>=4.12,<4.14",
     "lxml~=6.0.2",
     "cairocffi==1.5.1",
-    "razorpay~=1.4.1",
     "fuzzywuzzy~=0.18.0",
 ]
 


### PR DESCRIPTION
- LMS pinned `razorpay~=1.4.1` while `payments` — which `required_apps` installs alongside it — pins `razorpay~=2.0.0`. The ranges are disjoint, so the two cannot be resolved together; bench only gets away with it because it installs apps one at a time,
- Nothing here imports the SDK — payments owns razorpay and LMS reaches it through `get_payment_gateway_controller` — so drop the dependency rather than re-pin it and have to chase payments' range on every bump.