### PR TITLE
fix: broken access control

### DIFF
--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -1867,6 +1867,14 @@ def track_video_watch_duration(lesson: str, videos: list):
 	"""
 	Track the watch duration of videos in a lesson.
 	"""
+	from lms.lms.permissions import can_access_lesson
+
+	if not isinstance(lesson, str):
+		frappe.throw(_("Lesson must be a string."))
+
+	if not can_access_lesson(lesson):
+		frappe.throw(_("You do not have access to this lesson."), frappe.PermissionError)
+
 	if not isinstance(videos, list):
 		videos = json.loads(videos)
 
@@ -1978,10 +1986,14 @@ def get_pwa_manifest():
 
 @frappe.whitelist()
 def get_profile_details(username: str):
+	if not isinstance(username, str):
+		frappe.throw(_("Username must be a string."))
+
 	if not has_lms_role():
 		frappe.throw(
 			_("User does not have permission to access this user's profile details."), frappe.PermissionError
 		)
+
 	details = frappe.db.get_value(
 		"User",
 		{"username": username},
@@ -2005,7 +2017,11 @@ def get_profile_details(username: str):
 	)
 	if not details:
 		frappe.throw(_("User {0} not found").format(username), frappe.DoesNotExistError)
-	details.roles = frappe.get_roles(details.name)
+
+	roles = frappe.get_roles(details.name)
+	if details.name != frappe.session.user and not has_moderator_role():
+		roles = [role for role in roles if role in LMS_ROLES]
+	details.roles = roles
 	return details
 
 

--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -15,6 +15,21 @@ class LMSEnrollment(Document):
 		self.validate_course_enrollment_eligibility()
 		self.validate_owner()
 
+	def validate(self):
+		self.enforce_server_managed_fields()
+
+	def enforce_server_managed_fields(self):
+		"""Revert progress / purchased_certificate to their server-set values for non-staff."""
+		from lms.lms.utils import PRIVILEGED_ROLES
+
+		if PRIVILEGED_ROLES & set(frappe.get_roles()):
+			return
+
+		previous = None if self.is_new() else self.get_doc_before_save()
+		defaults = {"progress": 0, "purchased_certificate": 0}
+		for field, default in defaults.items():
+			setattr(self, field, previous.get(field) if previous else default)
+
 	def validate_owner(self):
 		"""Makes the member as the owner of the document so that users can update their progress"""
 		if self.owner != self.member:

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -137,6 +137,9 @@ def _validate_quiz_results(results):
 
 @frappe.whitelist()
 def submit_quiz(quiz: str, results: str | None = None):
+	if not isinstance(quiz, str):
+		frappe.throw(_("Invalid quiz."), frappe.ValidationError)
+
 	results = _parse_json_arg(results, _("quiz results")) if results else []
 	if not isinstance(results, list):
 		frappe.throw(_("Invalid quiz results submitted."), frappe.ValidationError)
@@ -158,6 +161,11 @@ def submit_quiz(quiz: str, results: str | None = None):
 	)
 	if not quiz_details:
 		frappe.throw(_("Invalid quiz."), frappe.ValidationError)
+
+	from lms.lms.permissions import can_access_quiz
+
+	if not can_access_quiz(quiz):
+		frappe.throw(_("You are not authorized to submit this quiz."), frappe.PermissionError)
 
 	data = process_results(results, quiz_details)
 	is_open_ended = data["is_open_ended"]

--- a/lms/tests/api/test_api.py
+++ b/lms/tests/api/test_api.py
@@ -191,6 +191,8 @@ class TestTrackVideoWatchDuration(BaseTestUtils):
 		self.course = self._create_course()
 		self.chapter = self._create_chapter("Chapter 1", self.course.name)
 		self.lesson = self._create_lesson("Lesson 1", self.chapter.name, self.course.name)
+		# track_video_watch_duration now requires lesson access; the student must be enrolled.
+		self._create_enrollment(self.student.email, self.course.name)
 		self._original_user = frappe.session.user
 		frappe.set_user(self.student.email)
 

--- a/lms/tests/security/test_enrollment_field_guard.py
+++ b/lms/tests/security/test_enrollment_field_guard.py
@@ -1,0 +1,57 @@
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestEnrollmentFieldGuard(BaseTestUtils, FrappeAPITestCase):
+	"""A student must not be able to write the server-managed progress /
+	purchased_certificate fields on their own enrollment
+	(VULN-2026-FRAPPE-LMS-009, -010)."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.student = self._create_user(f"efstud-{hash}@example.com", "Eli", "Student", ["LMS Student"])
+		self.moderator = self._create_user(f"efmod-{hash}@example.com", "Mac", "Derator", ["Moderator"])
+		self.course = self._create_course(title=f"Guard Course {hash}", instructor=self.moderator.email)
+		self.enrollment = self._create_enrollment(self.student.email, self.course.name)
+
+	def _as(self, user, mutate):
+		frappe.session.user = user
+		try:
+			doc = frappe.get_doc("LMS Enrollment", self.enrollment.name)
+			mutate(doc)
+			doc.save()
+		finally:
+			frappe.session.user = "Administrator"
+
+	def _stored(self, field):
+		return frappe.db.get_value("LMS Enrollment", self.enrollment.name, field)
+
+	def test_student_cannot_set_progress(self):
+		def mutate(doc):
+			doc.progress = 100
+
+		self._as(self.student.email, mutate)
+		self.assertEqual(self._stored("progress"), 0)
+
+	def test_student_cannot_set_purchased_certificate(self):
+		def mutate(doc):
+			doc.purchased_certificate = 1
+
+		self._as(self.student.email, mutate)
+		self.assertEqual(self._stored("purchased_certificate"), 0)
+
+	def test_moderator_can_set_progress(self):
+		def mutate(doc):
+			doc.progress = 100
+
+		self._as(self.moderator.email, mutate)
+		self.assertEqual(self._stored("progress"), 100)
+
+	def test_server_side_set_value_still_writes_progress(self):
+		# The legitimate write path (update_enrollment / update_certificate_purchase) uses
+		# frappe.db.set_value, which bypasses validate() and must remain unaffected.
+		frappe.db.set_value("LMS Enrollment", self.enrollment.name, "progress", 55)
+		self.assertEqual(self._stored("progress"), 55)

--- a/lms/tests/security/test_profile_details_disclosure.py
+++ b/lms/tests/security/test_profile_details_disclosure.py
@@ -1,0 +1,63 @@
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.api import get_profile_details
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestProfileDetailsDisclosure(BaseTestUtils, FrappeAPITestCase):
+	"""get_profile_details must not leak privileged roles to other users, and must not
+	behave as a username-enumeration oracle (VULN-2026-FRAPPE-LMS-001, -003)."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.student = self._create_user(f"pstud-{hash}@example.com", "Pat", "Student", ["LMS Student"])
+		self.moderator = self._create_user(f"pmod-{hash}@example.com", "Mo", "Derator", ["Moderator"])
+		self.admin_user = self._create_user(
+			f"padmin-{hash}@example.com", "Ada", "Ministrator", ["System Manager", "LMS Student"]
+		)
+		self.admin_username = f"padminuser{hash}"
+		frappe.db.set_value("User", self.admin_user.name, "username", self.admin_username)
+		self.student_username = f"pstuduser{hash}"
+		frappe.db.set_value("User", self.student.name, "username", self.student_username)
+
+	def _call(self, user, username):
+		frappe.session.user = user
+		try:
+			return get_profile_details(username)
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_student_does_not_see_privileged_roles_of_other_user(self):
+		details = self._call(self.student.email, self.admin_username)
+		self.assertNotIn("System Manager", details.roles)
+		# LMS-facing roles the UI needs are still exposed.
+		self.assertIn("LMS Student", details.roles)
+
+	def test_owner_sees_full_role_list(self):
+		details = self._call(self.admin_user.email, self.admin_username)
+		self.assertIn("System Manager", details.roles)
+
+	def test_moderator_sees_full_role_list(self):
+		details = self._call(self.moderator.email, self.admin_username)
+		self.assertIn("System Manager", details.roles)
+
+	def test_guest_is_denied(self):
+		# Every logged-in LMS user gets the LMS Student role (User before_insert hook
+		# add_lms_student_role), so Guest is the reachable no-LMS-role caller. The authz
+		# check must fire before any target lookup.
+		with self.assertRaises(frappe.PermissionError):
+			self._call("Guest", self.admin_username)
+
+	def test_nonexistent_username_raises_does_not_exist_not_500(self):
+		# Both valid and invalid usernames must fail the same way for an unauthorized/absent
+		# target — no 200-vs-500 discrepancy to enumerate accounts with.
+		with self.assertRaises(frappe.DoesNotExistError):
+			self._call(self.student.email, f"nosuchuser-{frappe.generate_hash(length=8)}")
+
+	def test_non_string_username_rejected(self):
+		# Rejected either by Frappe's whitelist type validation (FrappeTypeError,
+		# from the `username: str` annotation) or by our own isinstance guard.
+		with self.assertRaises((frappe.ValidationError, frappe.FrappeTypeError)):
+			self._call(self.student.email, ["administrator"])

--- a/lms/tests/security/test_quiz_submission_access.py
+++ b/lms/tests/security/test_quiz_submission_access.py
@@ -1,0 +1,95 @@
+import json
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.doctype.lms_quiz.lms_quiz import submit_quiz
+from lms.lms.doctype.lms_quiz_submission.lms_quiz_submission import MaximumAttemptsExceededError
+from lms.lms.test_helpers import BaseTestUtils
+
+
+def _quiz_block_content(quiz):
+	return json.dumps(
+		{
+			"time": 1765194986690,
+			"blocks": [{"id": "q1", "type": "quiz", "data": {"quiz": quiz}}],
+			"version": "2.29.0",
+		}
+	)
+
+
+class TestQuizSubmissionAccess(BaseTestUtils, FrappeAPITestCase):
+	"""submit_quiz must require quiz access and enforce max_attempts
+	(VULN-2026-FRAPPE-LMS-005)."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"sqinstr-{hash}@example.com", "Iris", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.enrolled = self._create_user(f"sqenr-{hash}@example.com", "Ela", "Enrolled", ["LMS Student"])
+		self.outsider = self._create_user(f"sqout-{hash}@example.com", "Otis", "Outsider", ["LMS Student"])
+
+		self.questions = self._create_quiz_questions()
+		self.quiz = self._create_quiz(title=f"Submit Quiz {hash}")
+		self.course = self._create_course(title=f"Submit Course {hash}", instructor=self.instructor.email)
+		self.chapter = self._create_chapter(f"SQChapter {hash}", self.course.name)
+		# Embedding the quiz in a lesson makes save_lesson_details_in_quiz set
+		# LMS Quiz.course/lesson, which is what can_access_quiz keys off.
+		self.lesson = self._create_lesson(
+			f"SQLesson {hash}", self.chapter.name, self.course.name, _quiz_block_content(self.quiz.name)
+		)
+		self._create_enrollment(self.enrolled.email, self.course.name)
+
+		self.results = [{"question_name": q.name, "answer": ["Option 1"]} for q in self.questions]
+
+	def _submit(self, user):
+		frappe.session.user = user
+		try:
+			return submit_quiz(self.quiz.name, json.dumps(self.results))
+		finally:
+			frappe.session.user = "Administrator"
+
+	def _cleanup_submissions(self, member):
+		for name in frappe.get_all(
+			"LMS Quiz Submission", {"quiz": self.quiz.name, "member": member}, pluck="name"
+		):
+			frappe.delete_doc("LMS Quiz Submission", name, force=True)
+
+	def test_non_string_quiz_rejected(self):
+		# A non-string quiz must fail cleanly, not with a 500 from the ORM: either
+		# Frappe's whitelist type validation (FrappeTypeError, from the `quiz: str`
+		# annotation) or our own isinstance guard rejects it.
+		frappe.session.user = self.enrolled.email
+		try:
+			with self.assertRaises((frappe.ValidationError, frappe.FrappeTypeError)):
+				submit_quiz(["not", "a", "string"], json.dumps(self.results))
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_non_enrolled_user_cannot_submit(self):
+		with self.assertRaises(frappe.PermissionError):
+			self._submit(self.outsider.email)
+		self.assertEqual(
+			frappe.db.count("LMS Quiz Submission", {"quiz": self.quiz.name, "member": self.outsider.email}),
+			0,
+		)
+
+	def test_enrolled_user_can_submit(self):
+		result = self._submit(self.enrolled.email)
+		self.assertIn("submission", result)
+		self._cleanup_submissions(self.enrolled.email)
+
+	def test_max_attempts_enforced(self):
+		# max_attempts is enforced downstream by LMSQuizSubmission.validate; this guards
+		# against that gate regressing (the score-oracle cap the access check relies on).
+		self._cleanup_submissions(self.enrolled.email)
+		frappe.db.set_value("LMS Quiz", self.quiz.name, "max_attempts", 1)
+		try:
+			self._submit(self.enrolled.email)
+			with self.assertRaises(MaximumAttemptsExceededError):
+				self._submit(self.enrolled.email)
+		finally:
+			frappe.db.set_value("LMS Quiz", self.quiz.name, "max_attempts", 0)
+			self._cleanup_submissions(self.enrolled.email)

--- a/lms/tests/security/test_video_watch_enrollment.py
+++ b/lms/tests/security/test_video_watch_enrollment.py
@@ -1,0 +1,53 @@
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+
+from lms.lms.api import track_video_watch_duration
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestVideoWatchEnrollment(BaseTestUtils, FrappeAPITestCase):
+	"""track_video_watch_duration must require lesson access (VULN-2026-FRAPPE-LMS-002)."""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"vinstr-{hash}@example.com", "Ida", "Instr", ["Course Creator", "Moderator"]
+		)
+		self.enrolled = self._create_user(f"venr-{hash}@example.com", "Ed", "Enrolled", ["LMS Student"])
+		self.outsider = self._create_user(f"vout-{hash}@example.com", "Ozzy", "Outsider", ["LMS Student"])
+
+		self.course = self._create_course(title=f"Video Course {hash}", instructor=self.instructor.email)
+		self.chapter = self._create_chapter(f"VChapter {hash}", self.course.name)
+		self.lesson = self._create_lesson(f"VLesson {hash}", self.chapter.name, self.course.name)
+		self._create_enrollment(self.enrolled.email, self.course.name)
+		self.videos = [{"source": "https://example.com/v.mp4", "watch_time": 999}]
+
+	def _watch_records(self, member):
+		return frappe.db.count("LMS Video Watch Duration", {"lesson": self.lesson.name, "member": member})
+
+	def _call(self, user):
+		frappe.session.user = user
+		try:
+			track_video_watch_duration(self.lesson.name, self.videos)
+		finally:
+			frappe.session.user = "Administrator"
+
+	def test_non_enrolled_user_cannot_track(self):
+		with self.assertRaises(frappe.PermissionError):
+			self._call(self.outsider.email)
+		self.assertEqual(self._watch_records(self.outsider.email), 0)
+
+	def test_enrolled_user_can_track(self):
+		self._call(self.enrolled.email)
+		self.assertEqual(self._watch_records(self.enrolled.email), 1)
+
+	def test_non_string_lesson_rejected(self):
+		# Rejected either by Frappe's whitelist type validation (FrappeTypeError,
+		# from the `lesson: str` annotation) or by our own isinstance guard.
+		frappe.session.user = self.enrolled.email
+		try:
+			with self.assertRaises((frappe.ValidationError, frappe.FrappeTypeError)):
+				track_video_watch_duration(["not", "a", "string"], self.videos)
+		finally:
+			frappe.session.user = "Administrator"


### PR DESCRIPTION
Adds server-side authorization to three endpoints/doctypes where checks were missing:

- get_profile_details — validates input type and filters the returned role list to LMS roles for non-owner/non-moderator callers, so privileged roles (System Manager, etc.) are no longer exposed to any students
- track_video_watch_duration — now requires lesson access before writing a watch record, so users can't forge watch time for lessons they aren't entitled to.
- submit_quiz — now requires quiz access (same gate the read path uses), so quizzes can't be submitted without enrollment; also type-guards the quiz arg.
- LMS Enrollment — a validate() guard reverts progress / purchased_certificate for non-privileged users, closing self-set of completion and paid-certificate flags (read_only isn't server-enforced; only permlevel is).