### PR TITLE
fix: lesson editor formatting, profile permissions, and Razorpay order creation

### DIFF
--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -58,7 +58,7 @@
 					     grid is empty by default. Say so instead of showing a blank
 					     box that reads as a broken picker. -->
 					<div
-						v-else-if="!images.loading"
+						v-else-if="hasFetched && !images.loading"
 						class="mt-2 w-[25.5rem] rounded border border-dashed p-4 text-center text-sm text-ink-gray-5"
 					>
 						<template v-if="search">
@@ -111,6 +111,13 @@ const images = createResource({
 })
 
 const hasImages = computed(() => images.data?.length > 0)
+
+// `auto: true` calls the *debounced* fetch, so `loading` stays false for the
+// whole debounce window. Keying the empty state off `loading` alone told a
+// correctly configured site its Unsplash key was missing for those 500ms.
+const hasFetched = computed(
+	() => images.data !== null && images.data !== undefined
+)
 
 watch(
 	() => search.value,

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -36,6 +36,7 @@
 						</FileUploader>
 					</div>
 					<div
+						v-if="hasImages"
 						class="relative mt-2 grid w-[25.5rem] gap-2 bg-surface-base lg:grid-cols-2"
 					>
 						<button
@@ -53,8 +54,26 @@
 							/>
 						</button>
 					</div>
+					<!-- Unsplash needs an access key that most sites never set, so the
+					     grid is empty by default. Say so instead of showing a blank
+					     box that reads as a broken picker. -->
 					<div
-						v-if="images.data"
+						v-else-if="!images.loading"
+						class="mt-2 w-[25.5rem] rounded border border-dashed p-4 text-center text-sm text-ink-gray-5"
+					>
+						<template v-if="search">
+							{{ __('No images found for "{0}".').format(search) }}
+						</template>
+						<template v-else>
+							{{
+								__(
+									'Image search is unavailable. Add an Unsplash access key in Settings, or upload your own image.'
+								)
+							}}
+						</template>
+					</div>
+					<div
+						v-if="hasImages"
 						class="mt-2 text-center text-sm text-ink-gray-4"
 					>
 						{{ __('Image search powered by') }}
@@ -75,7 +94,7 @@ import {
 	Button,
 	createResource,
 } from 'frappe-ui'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const search = ref(null)
 const emit = defineEmits(['select'])
@@ -90,6 +109,8 @@ const images = createResource({
 	auto: true,
 	debounce: 500,
 })
+
+const hasImages = computed(() => images.data?.length > 0)
 
 watch(
 	() => search.value,

--- a/frontend/src/composables/useStudentView.ts
+++ b/frontend/src/composables/useStudentView.ts
@@ -1,0 +1,99 @@
+import {
+	computed,
+	inject,
+	provide,
+	type ComputedRef,
+	type InjectionKey,
+	type Ref,
+} from 'vue'
+
+/**
+ * Student View shows a lesson as a learner sees it, but every component below
+ * it still injected the real `$user`, whose `is_moderator` / `is_instructor` /
+ * `is_evaluator` flags stay true. So the preview kept rendering instructor
+ * affordances — most visibly Assignment.vue's Grading panel, which let a
+ * moderator submit the assignment in preview and then grade themselves.
+ *
+ * `$user` is provided app-wide in main.js and read via `inject('$user')`
+ * everywhere, so providing a mocked one at the preview boundary shadows it for
+ * the whole subtree without touching a single consumer.
+ *
+ * This is presentation fidelity, not a security boundary: the session keeps all
+ * its real server-side permissions. Backend impersonation would be a genuine
+ * privilege-escalation surface for no user benefit.
+ */
+export const IS_STUDENT_VIEW: InjectionKey<
+	Ref<boolean> | ComputedRef<boolean>
+> = Symbol('isStudentView')
+
+const INSTRUCTOR_FLAGS = [
+	'is_moderator',
+	'is_instructor',
+	'is_evaluator',
+	'is_system_manager',
+] as const
+
+const INSTRUCTOR_ROLES = [
+	'Moderator',
+	'Course Creator',
+	'Batch Evaluator',
+	'System Manager',
+]
+
+type UserResource = {
+	data?: Record<string, unknown> | null
+	reload?: () => unknown
+	[key: string]: unknown
+}
+
+/** The real user with every instructor signal stripped out. */
+export function asStudent(data: Record<string, unknown> | null | undefined) {
+	if (!data) return data
+
+	const roles = Array.isArray(data.roles) ? data.roles : undefined
+
+	return {
+		...data,
+		...Object.fromEntries(INSTRUCTOR_FLAGS.map((flag) => [flag, false])),
+		is_student: true,
+		...(roles
+			? {
+					roles: roles.filter(
+						(role) => !INSTRUCTOR_ROLES.includes(role as string)
+					),
+			  }
+			: {}),
+	}
+}
+
+/**
+ * Shadow `$user` for this subtree with a student-shaped view of the real user.
+ *
+ * `active` is a getter rather than a boolean so leaving Student View restores
+ * the real flags reactively, without remounting the preview.
+ */
+export function provideStudentView(user: UserResource, active: () => boolean) {
+	const isStudentView = computed(() => Boolean(active()))
+
+	const mockedUser = new Proxy(user, {
+		get(target, key, receiver) {
+			if (key === 'data' && isStudentView.value) {
+				return asStudent(target.data)
+			}
+			return Reflect.get(target, key, receiver)
+		},
+	})
+
+	provide('$user', mockedUser)
+	provide(IS_STUDENT_VIEW, isStudentView)
+
+	return { isStudentView, mockedUser }
+}
+
+/** For the few places that need the flag itself rather than the mocked user. */
+export function useStudentView(): Ref<boolean> | ComputedRef<boolean> {
+	return inject(
+		IS_STUDENT_VIEW,
+		computed(() => false)
+	)
+}

--- a/frontend/src/pages/AssignmentSubmission.vue
+++ b/frontend/src/pages/AssignmentSubmission.vue
@@ -18,10 +18,20 @@ import { Breadcrumbs, createResource, usePageMeta } from 'frappe-ui'
 import { computed, inject, onMounted, ref } from 'vue'
 import { sessionStore } from '../stores/session'
 import Assignment from '@/components/Assignment.vue'
+import { provideStudentView } from '@/composables/useStudentView'
 
 const user = inject('$user')
 const fromLesson = ref(false)
 const { brand } = sessionStore()
+
+// Rendered in an iframe from the lesson preview, so provide/inject can't reach
+// this app instance — Student View arrives as a query param instead. Without
+// this the Grading panel shows up inside the preview and a moderator who
+// submits the assignment there can grade themselves.
+const studentView = ref(
+	new URLSearchParams(window.location.search).get('studentView') === '1'
+)
+provideStudentView(user, () => studentView.value)
 
 const props = defineProps({
 	assignmentID: {

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -77,10 +77,11 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createResource } from 'frappe-ui'
 import { useSidebar } from '@/stores/sidebar'
+import { provideStudentView } from '@/composables/useStudentView'
 import CourseOutline from '@/components/CourseOutline.vue'
 import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -102,6 +103,14 @@ const selected = defineModel('selected', { default: null })
 const mode = defineModel('mode', { default: 'edit' })
 const route = useRoute()
 const router = useRouter()
+
+// Student View swaps in the real Lesson.vue but the components below it still
+// injected the real `$user`, so instructor affordances (grading, instructor
+// notes, zen mode) stayed visible. Shadow `$user` for this subtree while the
+// preview is on. The provide is unconditional; the value tracks `mode`, so
+// leaving preview restores the real flags without a remount.
+const realUser = inject('$user')
+provideStudentView(realUser, () => mode.value === 'preview')
 
 // Collapse the app sidebar while the lesson editor is open to give the
 // editing surface room, then restore it on leaving the tab. Mirrors the

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -368,8 +368,10 @@ import UserAvatar from '@/components/UserAvatar.vue'
 import Notes from '@/components/Notes/Notes.vue'
 import InlineLessonMenu from '@/components/Notes/InlineLessonMenu.vue'
 import { getLmsRoute } from '@/utils/basePath'
+import { useStudentView } from '@/composables/useStudentView'
 
 const user = inject('$user')
+const isStudentView = useStudentView()
 const socket = inject('$socket')
 const router = useRouter()
 const route = useRoute()
@@ -536,7 +538,7 @@ const renderEditor = (holder, content) => {
 		document.getElementById(holder).innerHTML = ''
 	return new EditorJS({
 		holder: holder,
-		tools: getEditorTools(),
+		tools: getEditorTools(false, {}, { studentView: isStudentView.value }),
 		data: sanitizeEditorJs(JSON.parse(content)),
 		readOnly: true,
 		defaultBlock: 'embed',

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -31,6 +31,7 @@
 				rows="1"
 				class="lesson-title w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-2xl font-bold leading-tight text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 				@input="onTitleInput"
+				@keydown.enter="onTitleEnter"
 			/>
 
 			<details
@@ -92,7 +93,11 @@ import {
 import { ChevronRight, NotebookPen } from 'lucide-vue-next'
 import { useDebounceFn } from '@vueuse/core'
 import { enablePlyr, sanitizeEditorJs } from '@/utils'
-import { hasEditorContent, shouldSkipLessonSave } from '@/utils/lessonForm'
+import {
+	hasEditorContent,
+	shouldSkipLessonSave,
+	toSingleLineTitle,
+} from '@/utils/lessonForm'
 import { convertBodyToBlocks as convertToJSON } from '@/utils/lessonMacros'
 import { hasVideoContent } from '@/utils/video'
 import BlockEditor from '@/components/BlockEditor.vue'
@@ -107,7 +112,17 @@ const instructorEditor = ref(null)
 const user = inject('$user')
 const titleRef = ref(null)
 
+// A lesson title is one line. The field stays a textarea so a long title wraps
+// and grows; only the explicit break is refused.
+function onTitleEnter(event) {
+	// Enter also confirms an IME candidate — never swallow that one.
+	if (event.isComposing) return
+	event.preventDefault()
+}
+
 function onTitleInput() {
+	// Enter is refused on keydown, but a paste or a drop can still carry breaks.
+	lesson.title = toSingleLineTitle(lesson.title)
 	autoGrowTitle()
 	markDirty({ fromTitle: true })
 }
@@ -227,6 +242,8 @@ const lessonDetails = createResource({
 			Object.keys(data.lesson).forEach((key) => {
 				lesson[key] = data.lesson[key]
 			})
+			// Titles saved before Enter was refused still hold breaks.
+			lesson.title = toSingleLineTitle(lesson.title)
 			lesson.include_in_preview = data?.lesson?.include_in_preview
 				? true
 				: false

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -166,7 +166,7 @@
 					<span class="lucide-check size-4 me-2" />
 					{{ __('Your calendar is set.') }}
 				</div>
-				<Button @click="() => authorizeCalendar.submit()">
+				<Button @click="startCalendarAuthorization">
 					{{ __('Authorize Google Calendar Access') }}
 				</Button>
 			</div>
@@ -350,18 +350,36 @@ const deleteRow = (name) => {
 	deleteSlot.submit({ name })
 }
 
+// The calendar record is created here rather than by the page load: reading a
+// profile must not write documents in that user's name.
+const ensureCalendar = createResource({
+	url: 'lms.lms.api.ensure_evaluator_calendar',
+	onError(err) {
+		toast.error(err.messages?.[0] || err)
+	},
+})
+
 const authorizeCalendar = createResource({
 	url: 'frappe.integrations.doctype.google_calendar.google_calendar.authorize_access',
-	makeParams() {
+	makeParams(values) {
 		return {
-			g_calendar: evaluator.data?.calendar,
+			g_calendar: values.calendar,
 			reauthorize: 1,
 		}
 	},
 	onSuccess(data) {
 		window.open(data.url)
 	},
+	onError(err) {
+		toast.error(err.messages?.[0] || err)
+	},
 })
+
+const startCalendarAuthorization = async () => {
+	const calendar = evaluator.data?.calendar || (await ensureCalendar.submit())
+	if (!calendar) return
+	authorizeCalendar.submit({ calendar })
+}
 
 const days = computed(() => {
 	return [

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -122,16 +122,19 @@
 					{{ __('I am unavailable') }}
 				</h2>
 				<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+					<!-- `@update:modelValue`, not `@blur`: the date control renders as a
+					     popover, so a native listener bound as a fallthrough attr is not
+					     reliably reached. -->
 					<FormControl
 						type="date"
 						:label="__('From')"
 						v-model="from"
 						:disabled="!isSessionUser()"
-						@blur="
-							() => {
+						@update:modelValue="
+							(value) => {
 								updateUnavailability.submit({
 									field: 'unavailable_from',
-									value: from,
+									value,
 								})
 							}
 						"
@@ -141,11 +144,11 @@
 						:label="__('To')"
 						v-model="to"
 						:disabled="!isSessionUser()"
-						@blur="
-							() => {
+						@update:modelValue="
+							(value) => {
 								updateUnavailability.submit({
 									field: 'unavailable_to',
-									value: to,
+									value,
 								})
 							}
 						"
@@ -239,17 +242,16 @@ const formatTime = (time) => {
 	return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`
 }
 
+// Availability goes through lms.lms.api rather than frappe.client.*: the raw
+// framework endpoints fall back to Course Evaluator's role permissions, which
+// grant blanket write to Moderator, Batch Evaluator and Course Creator with no
+// owner condition, so anyone holding one could edit anyone else's calendar.
 const createSlot = createResource({
-	url: 'frappe.client.insert',
+	url: 'lms.lms.api.add_evaluator_slot',
 	makeParams(values) {
 		return {
-			doc: {
-				doctype: 'Evaluator Schedule',
-				parent: evaluator.data?.slots.name,
-				parentfield: 'schedule',
-				parenttype: 'Course Evaluator',
-				...newSlot,
-			},
+			evaluator: props.profile.data?.name,
+			...newSlot,
 		}
 	},
 	onSuccess() {
@@ -266,11 +268,11 @@ const createSlot = createResource({
 })
 
 const updateSlot = createResource({
-	url: 'frappe.client.set_value',
+	url: 'lms.lms.api.update_evaluator_slot',
 	makeParams(values) {
 		return {
-			doctype: 'Evaluator Schedule',
-			name: values.name,
+			evaluator: props.profile.data?.name,
+			slot: values.name,
 			fieldname: values.field,
 			value: values.value,
 		}
@@ -284,11 +286,11 @@ const updateSlot = createResource({
 })
 
 const deleteSlot = createResource({
-	url: 'frappe.client.delete',
+	url: 'lms.lms.api.delete_evaluator_slot',
 	makeParams(values) {
 		return {
-			doctype: 'Evaluator Schedule',
-			name: values.name,
+			evaluator: props.profile.data?.name,
+			slot: values.name,
 		}
 	},
 	onSuccess() {
@@ -301,11 +303,10 @@ const deleteSlot = createResource({
 })
 
 const updateUnavailability = createResource({
-	url: 'frappe.client.set_value',
+	url: 'lms.lms.api.set_evaluator_unavailability',
 	makeParams(values) {
 		return {
-			doctype: 'Course Evaluator',
-			name: evaluator.data?.slots.name,
+			evaluator: props.profile.data?.name,
 			fieldname: values.field,
 			value: values.value,
 		}

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
@@ -163,8 +163,23 @@ import { useRouter } from 'vue-router'
 import { openSettings } from '@/utils'
 import { useSettings } from '@/stores/settings'
 import { getLmsRoute } from '@/utils/basePath'
+import { provideStudentView } from '@/composables/useStudentView'
 
-const user = inject<any>('$user')
+const realUser = inject<any>('$user')
+
+// Rendered in an iframe from the lesson preview, so provide/inject can't reach
+// this app instance — Student View arrives as a query param instead, exactly as
+// it does for assignment submissions. Unlike AssignmentSubmission, this page
+// reads the instructor flags in its *own* template (the settings button, the
+// view-someone-else's-submission branch), so it uses the masked user itself
+// rather than only providing it to children.
+const studentView = ref(
+	new URLSearchParams(window.location.search).get('studentView') === '1'
+)
+const { mockedUser: user } = provideStudentView(
+	realUser,
+	() => studentView.value
+)
 const code = ref<string | null>('')
 const output = ref<string | null>(null)
 const error = ref<boolean | null>(null)

--- a/frontend/src/tests/ProfileEvaluator.test.ts
+++ b/frontend/src/tests/ProfileEvaluator.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for ProfileEvaluator.vue — the evaluator availability panel.
+ *
+ * Focus: every write goes through the ownership-checked `lms.lms.api`
+ * endpoints. It used to call `frappe.client.insert` / `set_value` / `delete`
+ * directly, which fall back to Course Evaluator's role permissions — those
+ * grant blanket write to Moderator, Batch Evaluator and Course Creator with no
+ * owner condition, so any of them could edit any other evaluator's calendar.
+ *
+ * Also guards the unavailability dates: they were wired with `@blur`, but the
+ * date control renders as a popover, so the write has to hang off
+ * `@update:modelValue` to be reached at all.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const { resources } = vi.hoisted(() => ({ resources: { value: [] as any[] } }))
+
+vi.mock('frappe-ui', () => ({
+	createResource: (config: any) => {
+		const res: any = { loading: false, config, data: null }
+		res.submit = vi.fn((values: any) => {
+			res.lastParams = config.makeParams ? config.makeParams(values) : values
+		})
+		res.reload = vi.fn()
+		resources.value.push(res)
+		return res
+	},
+	toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+	Button: {
+		props: ['label'],
+		emits: ['click'],
+		template: `<button @click="$emit('click')"><slot /></button>`,
+	},
+	Badge: { template: `<span><slot /></span>` },
+	FormControl: {
+		props: ['modelValue', 'type', 'label', 'options', 'id', 'disabled'],
+		emits: ['update:modelValue'],
+		template: `<input :data-type="type" :data-label="label" :value="modelValue"
+			@input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+}))
+
+vi.mock('@/utils', () => ({ convertToTitleCase: (s: string) => s }))
+
+const EVALUATOR = 'eva@example.com'
+
+function findResource(url: string) {
+	return resources.value.find((r) => r.config.url === url)
+}
+
+async function mountPanel(sessionUser = EVALUATOR) {
+	resources.value = []
+	const wrapper = mount(
+		await import('@/pages/ProfileEvaluator.vue').then((m) => m.default),
+		{
+			props: {
+				profile: { data: { name: EVALUATOR, username: 'eva' } },
+			},
+			global: {
+				provide: {
+					$user: {
+						data: { name: sessionUser, email: sessionUser, is_evaluator: true },
+					},
+				},
+				mocks: { __: (s: string) => s },
+			},
+		}
+	)
+	// The details resource is `auto`, so seed what the panel renders from.
+	const details = findResource('lms.lms.api.get_evaluator_details')
+	details.data = {
+		slots: {
+			name: EVALUATOR,
+			schedule: [
+				{ name: 42, day: 'Monday', start_time: '09:00', end_time: '10:00' },
+			],
+		},
+		calendar: null,
+		is_authorized: false,
+	}
+	await flushPromises()
+	return wrapper
+}
+
+describe('ProfileEvaluator availability writes', () => {
+	beforeEach(() => {
+		vi.stubGlobal('__', (s: string) => s)
+		resources.value = []
+	})
+
+	it('adds a slot through the ownership-checked endpoint', async () => {
+		await mountPanel()
+		const create = findResource('lms.lms.api.add_evaluator_slot')
+		expect(create).toBeTruthy()
+	})
+
+	it('updates a slot through the ownership-checked endpoint', async () => {
+		await mountPanel()
+		const update = findResource('lms.lms.api.update_evaluator_slot')
+		expect(update).toBeTruthy()
+
+		update.submit({ name: 42, field: 'day', value: 'Friday' })
+		expect(update.lastParams).toEqual({
+			evaluator: EVALUATOR,
+			slot: 42,
+			fieldname: 'day',
+			value: 'Friday',
+		})
+	})
+
+	it('deletes a slot through the ownership-checked endpoint', async () => {
+		await mountPanel()
+		const remove = findResource('lms.lms.api.delete_evaluator_slot')
+		expect(remove).toBeTruthy()
+
+		remove.submit({ name: 42 })
+		expect(remove.lastParams).toEqual({ evaluator: EVALUATOR, slot: 42 })
+	})
+
+	it('sets unavailability through the ownership-checked endpoint', async () => {
+		await mountPanel()
+		const unavailability = findResource(
+			'lms.lms.api.set_evaluator_unavailability'
+		)
+		expect(unavailability).toBeTruthy()
+
+		unavailability.submit({ field: 'unavailable_from', value: '2026-08-01' })
+		expect(unavailability.lastParams).toEqual({
+			evaluator: EVALUATOR,
+			fieldname: 'unavailable_from',
+			value: '2026-08-01',
+		})
+	})
+
+	it('never writes availability through raw framework endpoints', async () => {
+		await mountPanel()
+		const raw = resources.value.filter((r) =>
+			String(r.config.url).startsWith('frappe.client.')
+		)
+		expect(raw).toEqual([])
+	})
+
+	it('writes the unavailability date on change, not on blur', async () => {
+		const wrapper = await mountPanel()
+		const unavailability = findResource(
+			'lms.lms.api.set_evaluator_unavailability'
+		)
+
+		const dateFields = wrapper.findAll('[data-type="date"]')
+		expect(dateFields.length).toBe(2)
+
+		await dateFields[0].setValue('2026-08-01')
+		expect(unavailability.submit).toHaveBeenCalled()
+		expect(unavailability.lastParams).toEqual({
+			evaluator: EVALUATOR,
+			fieldname: 'unavailable_from',
+			value: '2026-08-01',
+		})
+	})
+})

--- a/frontend/src/tests/assignmentStudentView.test.ts
+++ b/frontend/src/tests/assignmentStudentView.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The assignment submission renders in an iframe — its own Vue app — so the
+ * preview's provide/inject can't reach it. Student View has to travel in the
+ * iframe URL, and the receiving page turns it back into a provide.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { calls } = vi.hoisted(() => ({ calls: { value: [] as any[] } }))
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+vi.mock('frappe-ui', () => ({
+	call: (method: string, args: any) => {
+		calls.value.push({ method, args })
+		return Promise.resolve('SUB-0001')
+	},
+	toast: {},
+}))
+vi.mock('@/stores/settings', () => ({ useSettings: () => ({}) }))
+vi.mock('@/stores/user', () => ({ usersStore: () => ({ userResource: {} }) }))
+vi.mock('@/router', () => ({ default: { push: vi.fn() } }))
+vi.mock('@/components/AssessmentPlugin.vue', () => ({ default: {} }))
+vi.mock('../translation', () => ({ default: {} }))
+vi.mock('@/utils/basePath', () => ({
+	getLmsRoute: (path: string) => `/lms/${path}`,
+}))
+vi.mock('lucide-vue-next', () => ({ Pencil: {} }))
+
+const { Assignment } = await import('@/utils/assignment')
+// Imported at module scope: '@/utils' pulls the whole editor toolchain and is
+// too slow to load inside a test's timeout.
+const { getEditorTools } = await import('@/utils')
+
+function renderReadOnly(config: Record<string, unknown> | undefined) {
+	const tool = new Assignment({
+		data: { assignment: 'ASSIGN-1' },
+		api: {},
+		readOnly: true,
+		config,
+	})
+	tool.wrapper = document.createElement('div')
+	tool.renderAssignment('ASSIGN-1')
+	return tool
+}
+
+async function iframeSrc(config: Record<string, unknown> | undefined) {
+	const tool = renderReadOnly(config)
+	// let the get_own_assignment_submission promise settle
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	return tool.wrapper.querySelector('iframe')?.getAttribute('src') ?? ''
+}
+
+describe('assignment iframe URL', () => {
+	beforeEach(() => {
+		calls.value = []
+		vi.stubGlobal('__', (s: string) => s)
+	})
+
+	it('marks the iframe as Student View when the tool config says so', async () => {
+		const src = await iframeSrc({ studentView: true })
+
+		expect(src).toContain('fromLesson=1')
+		expect(src).toContain('studentView=1')
+	})
+
+	it('omits the flag for a normal lesson view', async () => {
+		const src = await iframeSrc({ studentView: false })
+
+		expect(src).toContain('fromLesson=1')
+		expect(src).not.toContain('studentView')
+	})
+
+	it('omits the flag when no config is passed at all', async () => {
+		const src = await iframeSrc(undefined)
+
+		expect(src).not.toContain('studentView')
+	})
+})
+
+describe('getEditorTools wiring', () => {
+	it('hands the assignment tool the Student View flag', () => {
+		const tools = getEditorTools(false, {}, { studentView: true }) as Record<
+			string,
+			any
+		>
+
+		expect(tools.assignment.config.studentView).toBe(true)
+	})
+
+	it('defaults the flag off', () => {
+		const tools = getEditorTools() as Record<string, any>
+
+		expect(tools.assignment.config.studentView).toBe(false)
+	})
+})

--- a/frontend/src/tests/coverImageEmptyState.test.ts
+++ b/frontend/src/tests/coverImageEmptyState.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `createResource({auto: true, debounce})` calls the *debounced* fetch, so
+ * `loading` stays false for the whole debounce window. Keying the empty state
+ * off `loading` alone told a correctly configured site that its Unsplash
+ * integration was missing, for the first 500ms the picker was open.
+ */
+import { describe, expect, it } from 'vitest'
+import { computed, ref } from 'vue'
+
+type Resource = { data: unknown; loading: boolean }
+
+/** The template's two conditions, as written in EditCoverImage.vue. */
+function emptyState(images: Resource) {
+	const hasImages = computed(
+		() => (images.data as unknown[] | null)?.length > 0
+	)
+	const hasFetched = computed(
+		() => images.data !== null && images.data !== undefined
+	)
+	return {
+		showsGrid: () => hasImages.value,
+		showsMessage: () => !hasImages.value && hasFetched.value && !images.loading,
+	}
+}
+
+describe('cover-image picker empty state', () => {
+	it('says nothing while the debounced fetch has not run yet', () => {
+		// auto:true has fired but the debounce has not elapsed: no data, and
+		// loading is still false because the debounced call has not started.
+		const state = emptyState({ data: null, loading: false })
+
+		expect(state.showsMessage()).toBe(false)
+	})
+
+	it('says nothing while the request is in flight', () => {
+		expect(emptyState({ data: null, loading: true }).showsMessage()).toBe(false)
+	})
+
+	it('reports the integration as unavailable once an empty result comes back', () => {
+		expect(emptyState({ data: [], loading: false }).showsMessage()).toBe(true)
+	})
+
+	it('shows the grid when there are images', () => {
+		const state = emptyState({ data: [{ id: 'a' }], loading: false })
+
+		expect(state.showsGrid()).toBe(true)
+		expect(state.showsMessage()).toBe(false)
+	})
+})

--- a/frontend/src/tests/editorBold.test.ts
+++ b/frontend/src/tests/editorBold.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+vi.mock('frappe-ui', () => ({ call: () => {}, toast: {} }))
+vi.mock('@/stores/settings', () => ({ useSettings: () => ({}) }))
+vi.mock('@/stores/user', () => ({ usersStore: () => ({ userResource: {} }) }))
+
+const { Bold } = await import('@/utils/inline/Bold')
+const { getEditorTools } = await import('@/utils')
+
+// EditorJS's built-in Bold calls `document.execCommand('bold')`. Inside a
+// heading the text is already bold, so the browser reads the command as "on"
+// and *un*-bolds instead: it writes `<span style="font-weight: normal">`, which
+// the block sanitizer then drops. Bolding a heading was therefore impossible —
+// the toolbar button and Ctrl+B both silently did nothing. The Range-based tool
+// below wraps the selection in `<b>` regardless of the surrounding weight.
+function selectInside(host: HTMLElement, start: number, end: number): Range {
+	const range = document.createRange()
+	range.setStart(host.firstChild as Node, start)
+	range.setEnd(host.firstChild as Node, end)
+	const selection = window.getSelection()
+	selection?.removeAllRanges()
+	selection?.addRange(range)
+	return range
+}
+
+function makeApi() {
+	return {
+		styles: { inlineToolButtonActive: 'ce-inline-tool--active' },
+		selection: {
+			expandToTag: (node: HTMLElement): void => {
+				const range = document.createRange()
+				range.selectNodeContents(node)
+				const selection = window.getSelection()
+				selection?.removeAllRanges()
+				selection?.addRange(range)
+			},
+			findParentTag: (tag: string): HTMLElement | null => {
+				let node = window.getSelection()?.anchorNode ?? null
+				while (node) {
+					if (node.nodeType === 1 && (node as HTMLElement).tagName === tag) {
+						return node as HTMLElement
+					}
+					node = node.parentNode
+				}
+				return null
+			},
+		},
+	}
+}
+
+describe('Bold inline tool', () => {
+	let host: HTMLElement
+
+	beforeEach(() => {
+		document.body.innerHTML = ''
+	})
+
+	it('wraps the selection in <b> inside a heading', () => {
+		host = document.createElement('h2')
+		host.textContent = 'Heading probe text'
+		document.body.appendChild(host)
+
+		const bold = new Bold({ api: makeApi() } as never)
+		bold.surround(selectInside(host, 0, 7))
+
+		expect(host.innerHTML).toBe('<b>Heading</b> probe text')
+	})
+
+	it('wraps the selection in <b> inside a paragraph', () => {
+		host = document.createElement('div')
+		host.textContent = 'Paragraph probe text'
+		document.body.appendChild(host)
+
+		const bold = new Bold({ api: makeApi() } as never)
+		bold.surround(selectInside(host, 0, 9))
+
+		expect(host.innerHTML).toBe('<b>Paragraph</b> probe text')
+	})
+
+	it('unwraps an already bold selection', () => {
+		host = document.createElement('h2')
+		host.innerHTML = '<b>Heading</b> probe text'
+		document.body.appendChild(host)
+
+		const bold = new Bold({ api: makeApi() } as never)
+		const b = host.querySelector('b') as HTMLElement
+		selectInside(b, 0, 7)
+		bold.checkState()
+		expect(bold.state).toBe(true)
+
+		bold.surround(window.getSelection()!.getRangeAt(0))
+		expect(host.querySelector('b')).toBeNull()
+		expect(host.textContent).toBe('Heading probe text')
+	})
+
+	it('keeps <b> in the sanitizer allowlist', () => {
+		expect(Bold.sanitize).toEqual({ b: true })
+	})
+
+	it('is registered as the editor bold tool, replacing the execCommand one', () => {
+		const tools = getEditorTools() as Record<string, { class?: unknown }>
+		expect(tools.bold?.class).toBe(Bold)
+	})
+})

--- a/frontend/src/tests/editorHeadingSingleLine.test.ts
+++ b/frontend/src/tests/editorHeadingSingleLine.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Heading } from '@/utils/heading'
+import Header from '@editorjs/header'
+import type { HeaderData } from '@editorjs/header'
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+// '@/utils' pulls frappe-ui's resource plugin, which doesn't resolve under
+// vitest; only the tool-config shape matters here.
+vi.mock('frappe-ui', () => ({ call: () => {}, toast: {} }))
+vi.mock('@/stores/settings', () => ({ useSettings: () => ({}) }))
+vi.mock('@/stores/user', () => ({ usersStore: () => ({ userResource: {} }) }))
+
+const { getEditorTools } = await import('@/utils')
+
+function newHeading(data: Partial<HeaderData>): Heading {
+	return new Heading({
+		data,
+		api: {
+			i18n: { t: (text: string): string => text },
+			styles: { block: 'cdx-block' },
+		},
+		config: {},
+		readOnly: false,
+	})
+}
+
+function press(
+	element: HTMLElement,
+	key: string,
+	{ shiftKey = false } = {}
+): KeyboardEvent {
+	const event = new KeyboardEvent('keydown', {
+		key,
+		shiftKey,
+		bubbles: true,
+		cancelable: true,
+	})
+	element.dispatchEvent(event)
+	return event
+}
+
+describe('Heading — single line', () => {
+	it('refuses the Shift+Enter line break', () => {
+		const element = newHeading({ text: 'Title', level: 2 }).render()
+		expect(press(element, 'Enter', { shiftKey: true }).defaultPrevented).toBe(
+			true
+		)
+	})
+
+	it('leaves plain Enter to EditorJS so it still splits the block', () => {
+		const element = newHeading({ text: 'Title', level: 2 }).render()
+		expect(press(element, 'Enter').defaultPrevented).toBe(false)
+	})
+
+	it('keeps refusing breaks after the heading level changes', () => {
+		const heading = newHeading({ text: 'Title', level: 2 })
+		// The level tunes replace the element, so the guard has to come with it.
+		const wrapper = document.createElement('div')
+		wrapper.appendChild(heading.render())
+		heading.setLevel(4)
+
+		const element = heading.render()
+		expect(element.tagName).toBe('H4')
+		expect(press(element, 'Enter', { shiftKey: true }).defaultPrevented).toBe(
+			true
+		)
+	})
+
+	it.each(['First<br>Second', 'First<br/>Second', 'First<BR />Second'])(
+		'flattens a line break already stored in the heading (%s)',
+		(text) => {
+			const element = newHeading({ text, level: 2 }).render()
+
+			expect(element.querySelector('br')).toBeNull()
+			expect(element.textContent).toBe('First Second')
+		}
+	)
+
+	it('renders an empty heading without a text field', () => {
+		const element = newHeading({}).render()
+
+		expect(element.textContent).toBe('')
+		expect(press(element, 'Enter', { shiftKey: true }).defaultPrevented).toBe(
+			true
+		)
+	})
+
+	it('flattens line breaks carried in by a merged paragraph', () => {
+		const heading = newHeading({ text: 'Title', level: 2 })
+		heading.merge({ text: ' one<br>two' })
+		expect(heading.render().querySelector('br')).toBeNull()
+		expect(heading.render().textContent).toBe('Title one two')
+	})
+
+	it('is the class the editor registers for the header block', () => {
+		const tools = getEditorTools() as Record<string, { class?: unknown }>
+
+		expect(tools.header.class).toBe(Heading)
+	})
+})
+
+// The behaviour this replaced, kept as a characterisation test: the stock tool
+// lets the break through, and the sanitizer then drops it on save — which is
+// how a heading could look like two lines and reload as one glued word.
+describe('stock @editorjs/header', () => {
+	it('lets Shift+Enter through and keeps a stored break', () => {
+		const stock = new Header({
+			data: { text: 'First<br>Second', level: 2 },
+			api: {
+				i18n: { t: (text: string): string => text },
+				styles: { block: 'cdx-block' },
+			},
+			config: {},
+			readOnly: false,
+		})
+		const element = stock.render()
+
+		expect(press(element, 'Enter', { shiftKey: true }).defaultPrevented).toBe(
+			false
+		)
+		expect(element.querySelector('br')).not.toBeNull()
+	})
+})

--- a/frontend/src/tests/editorInlineToolbar.test.ts
+++ b/frontend/src/tests/editorInlineToolbar.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+// '@/utils' pulls frappe-ui's resource plugin, which doesn't resolve under
+// vitest. Only the tool-config shape matters here, so stub the pieces the
+// barrel reaches for on import.
+vi.mock('frappe-ui', () => ({ call: () => {}, toast: {} }))
+vi.mock('@/stores/settings', () => ({ useSettings: () => ({}) }))
+vi.mock('@/stores/user', () => ({ usersStore: () => ({ userResource: {} }) }))
+
+const { getEditorTools } = await import('@/utils')
+
+// EditorJS only fills `tool.inlineTools` when a block tool declares
+// `inlineToolbar`. A block that omits it gets an empty collection, so
+// InlineToolbar.allowedToShow() bails on `inlineTools.size !== 0` and the
+// toolbar never opens; Ctrl+B then falls through to the browser's execCommand,
+// which writes a `font-weight` span that the sanitizer strips on save. Headings
+// shipped without the key, so headings could not be bolded at all.
+const TEXT_BLOCKS = ['header', 'paragraph', 'markdown', 'list', 'table']
+
+// Code and embeds deliberately opt out: rich formatting inside a code block or
+// an embed caption is not wanted.
+const NO_TOOLBAR_BLOCKS = ['codeBox', 'embed']
+
+type ToolEntry = { inlineToolbar?: boolean | string[] }
+
+describe('editor inline toolbar wiring', () => {
+	const tools = getEditorTools() as Record<string, ToolEntry>
+
+	it.each(TEXT_BLOCKS)('lets you bold inside a %s block', (block) => {
+		const inlineToolbar = tools[block]?.inlineToolbar
+		expect(Array.isArray(inlineToolbar) || inlineToolbar === true).toBe(true)
+		if (Array.isArray(inlineToolbar)) {
+			expect(inlineToolbar).toContain('bold')
+			expect(inlineToolbar).toContain('italic')
+		}
+	})
+
+	it.each(TEXT_BLOCKS)('gives the %s block the shared tool order', (block) => {
+		expect(tools[block]?.inlineToolbar).toEqual(tools.paragraph?.inlineToolbar)
+	})
+
+	it.each(NO_TOOLBAR_BLOCKS)('keeps the toolbar off %s blocks', (block) => {
+		expect(tools[block]?.inlineToolbar).toBeFalsy()
+	})
+})

--- a/frontend/src/tests/lessonForm.test.ts
+++ b/frontend/src/tests/lessonForm.test.ts
@@ -3,6 +3,7 @@ import {
 	hasInstructorContent,
 	hasEditorContent,
 	shouldSkipLessonSave,
+	toSingleLineTitle,
 } from '@/utils/lessonForm'
 
 // Regression guard: a transient/empty editor (hot-reload remount, render race,
@@ -112,5 +113,32 @@ describe('shouldSkipLessonSave', () => {
 		expect(shouldSkipLessonSave('   ', false)).toBe(true)
 		expect(shouldSkipLessonSave(null, false)).toBe(true)
 		expect(shouldSkipLessonSave(undefined, false)).toBe(true)
+	})
+})
+
+describe('toSingleLineTitle', () => {
+	it('collapses a line break into a single space', () => {
+		expect(toSingleLineTitle('Assignment\nsjksjla')).toBe('Assignment sjksjla')
+	})
+
+	it('collapses CRLF and runs of blank lines', () => {
+		expect(toSingleLineTitle('One\r\nTwo')).toBe('One Two')
+		expect(toSingleLineTitle('One\n\n\nTwo')).toBe('One Two')
+	})
+
+	it('does not leave double spaces around a break', () => {
+		expect(toSingleLineTitle('One \n Two')).toBe('One Two')
+	})
+
+	it('leaves a single-line title untouched', () => {
+		expect(toSingleLineTitle('A perfectly ordinary title')).toBe(
+			'A perfectly ordinary title'
+		)
+	})
+
+	it('returns an empty string for no title', () => {
+		expect(toSingleLineTitle('')).toBe('')
+		expect(toSingleLineTitle(null)).toBe('')
+		expect(toSingleLineTitle(undefined)).toBe('')
 	})
 })

--- a/frontend/src/tests/lessonFormTeardown.test.ts
+++ b/frontend/src/tests/lessonFormTeardown.test.ts
@@ -78,13 +78,10 @@ vi.mock('@/components/BlockEditor.vue', async () => {
 						if (field === 'content' && editorState.rejectBodySave) {
 							throw new Error('editor torn down mid-save')
 						}
-						if (
-							field === 'instructor_content' &&
-							editorState.rejectNotesSave
-						) {
+						if (field === 'instructor_content' && editorState.rejectNotesSave) {
 							throw new Error('editor torn down mid-save')
 						}
-						return alive ? (editorState.saveData[field] ?? null) : null
+						return alive ? editorState.saveData[field] ?? null : null
 					},
 				})
 				return () => h('div', { class: 'block-editor-stub' })
@@ -313,7 +310,9 @@ describe('LessonForm teardown autosave', () => {
 		const editLesson = findResource('frappe.client.set_value')
 		expect(editLesson.submit).toHaveBeenCalledTimes(1)
 		// The stored notes must survive — folding the empty default would wipe them.
-		expect(editLesson.lastParams.fieldname.instructor_content).toBe(STORED_NOTES)
+		expect(editLesson.lastParams.fieldname.instructor_content).toBe(
+			STORED_NOTES
+		)
 	})
 
 	it('does not save the lesson on teardown once it has been marked deleted', async () => {
@@ -343,5 +342,81 @@ describe('LessonForm teardown autosave', () => {
 		const editLesson = findResource('frappe.client.set_value')
 		expect(editLesson.submit).toHaveBeenCalledTimes(1)
 		expect(editLesson.lastParams.name).toBe(LESSON_NAME)
+	})
+})
+
+// The title is a <textarea> so a long title can wrap and the field can grow with
+// it — which also let Enter put a real newline in the title.
+describe('LessonForm title is single-line', () => {
+	let wrapper: VueWrapper
+
+	beforeEach(() => {
+		created.list.length = 0
+		editorState.saveData = {}
+	})
+
+	afterEach(() => {
+		try {
+			wrapper?.unmount()
+		} catch {
+			// already unmounted by the test
+		}
+		document.body.innerHTML = ''
+	})
+
+	const titleField = () => wrapper.find('textarea.lesson-title')
+
+	const pressEnter = ({ isComposing = false } = {}) => {
+		const event = new KeyboardEvent('keydown', {
+			key: 'Enter',
+			bubbles: true,
+			cancelable: true,
+			isComposing,
+		})
+		titleField().element.dispatchEvent(event)
+		return event
+	}
+
+	it('refuses Enter', async () => {
+		wrapper = await mountLoaded()
+
+		expect(pressEnter().defaultPrevented).toBe(true)
+	})
+
+	it('lets Enter through while an IME candidate is being confirmed', async () => {
+		wrapper = await mountLoaded()
+
+		expect(pressEnter({ isComposing: true }).defaultPrevented).toBe(false)
+	})
+
+	it('collapses a pasted multi-line title', async () => {
+		wrapper = await mountLoaded()
+
+		await editTitle(wrapper, 'First line\nsecond line')
+		await flushPromises()
+
+		expect((titleField().element as HTMLTextAreaElement).value).toBe(
+			'First line second line'
+		)
+	})
+
+	it('flattens a title that was stored with a break', async () => {
+		wrapper = await mountLoaded({ title: 'Assignment\nsjksjla' })
+
+		expect((titleField().element as HTMLTextAreaElement).value).toBe(
+			'Assignment sjksjla'
+		)
+	})
+
+	it('persists the flattened title, not the break', async () => {
+		wrapper = await mountLoaded()
+		editorState.saveData.content = paragraph('Body text')
+
+		await editTitle(wrapper, 'Assignment\nsjksjla')
+		wrapper.unmount()
+		await flushPromises()
+
+		const editLesson = findResource('frappe.client.set_value')
+		expect(editLesson.lastParams.fieldname.title).toBe('Assignment sjksjla')
 	})
 })

--- a/frontend/src/tests/programStudentView.test.ts
+++ b/frontend/src/tests/programStudentView.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The programming-exercise submission renders in an iframe — its own Vue app —
+ * so the preview's provide/inject can't reach it. Student View has to travel in
+ * the iframe URL, exactly as it does for assignments; without this the preview
+ * kept showing the moderator-only settings button.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { calls } = vi.hoisted(() => ({ calls: { value: [] as any[] } }))
+
+declare global {
+	interface Window {
+		__: (text: string) => string
+	}
+}
+window.__ = (text: string): string => text
+window.matchMedia ??= (() => ({
+	matches: false,
+	addEventListener: () => {},
+	removeEventListener: () => {},
+})) as unknown as typeof window.matchMedia
+
+vi.mock('frappe-ui', () => ({
+	call: (method: string, args: any) => {
+		calls.value.push({ method, args })
+		return Promise.resolve({ name: 'SUB-0001' })
+	},
+	toast: {},
+}))
+vi.mock('@/stores/settings', () => ({ useSettings: () => ({}) }))
+vi.mock('@/stores/user', () => ({
+	usersStore: () => ({ userResource: { data: { name: 'me@example.com' } } }),
+}))
+vi.mock('@/router', () => ({ default: { push: vi.fn() } }))
+vi.mock('../translation', () => ({ default: {} }))
+vi.mock('@/translation', () => ({ default: {} }))
+vi.mock('@/pages/ProgrammingExercises/ProgrammingExerciseModal.vue', () => ({
+	default: {},
+}))
+vi.mock('@/utils/basePath', () => ({
+	getLmsRoute: (path: string) => `/lms/${path}`,
+}))
+vi.mock('lucide-vue-next', () => ({ Code: {} }))
+
+const { Program } = await import('@/utils/program')
+// Imported at module scope: '@/utils' pulls the whole editor toolchain.
+const { getEditorTools } = await import('@/utils')
+
+async function iframeSrc(config: Record<string, unknown> | undefined) {
+	const tool = new Program({
+		data: { exercise: 'EX-1' },
+		api: {},
+		readOnly: true,
+		config,
+	} as any) as any
+	tool.wrapper = document.createElement('div')
+	tool.renderExercise('EX-1')
+	// let the get_value promise settle
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	return tool.wrapper.querySelector('iframe')?.getAttribute('src') ?? ''
+}
+
+describe('programming-exercise iframe URL', () => {
+	beforeEach(() => {
+		calls.value = []
+	})
+
+	it('marks the iframe as Student View when the tool config says so', async () => {
+		const src = await iframeSrc({ studentView: true })
+
+		expect(src).toContain('fromLesson=1')
+		expect(src).toContain('studentView=1')
+	})
+
+	it('omits the flag for a normal lesson view', async () => {
+		const src = await iframeSrc({ studentView: false })
+
+		expect(src).toContain('fromLesson=1')
+		expect(src).not.toContain('studentView')
+	})
+
+	it('omits the flag when no config is passed at all', async () => {
+		expect(await iframeSrc(undefined)).not.toContain('studentView')
+	})
+})
+
+describe('getEditorTools wiring', () => {
+	it('hands the programming-exercise tool the Student View flag', () => {
+		const tools = getEditorTools(false, {}, { studentView: true }) as Record<
+			string,
+			any
+		>
+
+		expect(tools.program.config.studentView).toBe(true)
+	})
+
+	it('defaults the flag off', () => {
+		const tools = getEditorTools() as Record<string, any>
+
+		expect(tools.program.config.studentView).toBe(false)
+	})
+})

--- a/frontend/src/tests/studentView.test.ts
+++ b/frontend/src/tests/studentView.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for Student View — the lesson-editor preview that shows a course as a
+ * learner sees it.
+ *
+ * The preview swapped in the real Lesson.vue but every component under it kept
+ * injecting the real `$user`, whose `is_moderator` / `is_instructor` /
+ * `is_evaluator` flags stay true. The visible consequence was Assignment.vue's
+ * Grading panel: a moderator who submitted the assignment inside the preview
+ * was immediately offered the Grade select and could grade themselves.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { defineComponent, h, inject, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import {
+	asStudent,
+	provideStudentView,
+	useStudentView,
+} from '@/composables/useStudentView'
+
+const MODERATOR = {
+	name: 'mod@example.com',
+	email: 'mod@example.com',
+	full_name: 'Mod Erator',
+	user_image: '/files/mod.png',
+	is_moderator: true,
+	is_instructor: true,
+	is_evaluator: true,
+	is_system_manager: true,
+	is_student: false,
+	roles: ['Moderator', 'Course Creator', 'Batch Evaluator', 'LMS Student'],
+}
+
+describe('asStudent', () => {
+	it('flips every instructor flag off and marks the viewer a student', () => {
+		const student = asStudent(MODERATOR) as Record<string, unknown>
+
+		expect(student.is_moderator).toBe(false)
+		expect(student.is_instructor).toBe(false)
+		expect(student.is_evaluator).toBe(false)
+		expect(student.is_system_manager).toBe(false)
+		expect(student.is_student).toBe(true)
+	})
+
+	it('drops instructor roles but keeps the learner ones', () => {
+		const student = asStudent(MODERATOR) as Record<string, unknown>
+
+		expect(student.roles).toEqual(['LMS Student'])
+	})
+
+	it('passes every non-role field through untouched', () => {
+		const student = asStudent(MODERATOR) as Record<string, unknown>
+
+		expect(student.name).toBe(MODERATOR.name)
+		expect(student.email).toBe(MODERATOR.email)
+		expect(student.full_name).toBe(MODERATOR.full_name)
+		expect(student.user_image).toBe(MODERATOR.user_image)
+	})
+
+	it('leaves a missing user alone', () => {
+		expect(asStudent(null)).toBe(null)
+		expect(asStudent(undefined)).toBe(undefined)
+	})
+})
+
+// A stand-in for the components under the preview: it reads `$user` exactly the
+// way Assignment.vue does and reports the same gate.
+const GradingProbe = defineComponent({
+	setup() {
+		const user = inject<{ data?: Record<string, unknown> }>('$user')
+		const isStudentView = useStudentView()
+		return () =>
+			h('div', [
+				h(
+					'span',
+					{ 'data-testid': 'can-grade' },
+					String(
+						Boolean(
+							user?.data?.is_moderator ||
+								user?.data?.is_evaluator ||
+								user?.data?.is_instructor
+						)
+					)
+				),
+				h(
+					'span',
+					{ 'data-testid': 'student-view' },
+					String(isStudentView.value)
+				),
+				h('span', { 'data-testid': 'name' }, String(user?.data?.name ?? '')),
+			])
+	},
+})
+
+function mountUnderPreview(
+	active: () => boolean,
+	resource = { data: { ...MODERATOR } }
+) {
+	const Wrapper = defineComponent({
+		setup() {
+			provideStudentView(resource, active)
+			return () => h(GradingProbe)
+		},
+	})
+	return mount(Wrapper)
+}
+
+describe('provideStudentView', () => {
+	it('leaves the real flags alone outside Student View', () => {
+		const wrapper = mountUnderPreview(() => false)
+
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('true')
+		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('false')
+	})
+
+	it('hides the grading gate inside Student View', () => {
+		const wrapper = mountUnderPreview(() => true)
+
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('false')
+		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('true')
+	})
+
+	it('still identifies the real user, so their own submission loads', () => {
+		const wrapper = mountUnderPreview(() => true)
+
+		expect(wrapper.get('[data-testid="name"]').text()).toBe(MODERATOR.email)
+	})
+
+	it('restores the real flags when the preview is turned off, without a remount', async () => {
+		const active = ref(true)
+		const wrapper = mountUnderPreview(() => active.value)
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('false')
+
+		active.value = false
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('true')
+	})
+
+	it('defaults to "not student view" when nothing provided it', () => {
+		const Bare = defineComponent({ setup: () => () => h(GradingProbe) })
+		const wrapper = mount(Bare, {
+			global: { provide: { $user: { data: { ...MODERATOR } } } },
+		})
+
+		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('false')
+	})
+})

--- a/frontend/src/types/editorjs-header.d.ts
+++ b/frontend/src/types/editorjs-header.d.ts
@@ -1,0 +1,33 @@
+// @editorjs/header ships no type declarations. Declare only the surface our
+// Heading subclass touches (see utils/heading.ts) — including the two API
+// members the base tool reads, so a test can construct one without a cast.
+declare module '@editorjs/header' {
+	export interface HeaderData {
+		text: string
+		level: number
+	}
+
+	export interface HeaderConfig {
+		placeholder?: string
+		levels?: number[]
+		defaultLevel?: number
+	}
+
+	export interface HeaderApi {
+		styles: { block: string }
+		i18n: { t: (text: string) => string }
+	}
+
+	export default class Header {
+		constructor(options: {
+			data: Partial<HeaderData>
+			config: HeaderConfig
+			api: HeaderApi
+			readOnly: boolean
+		})
+		getTag(): HTMLElement
+		render(): HTMLElement
+		merge(data: Partial<HeaderData>): void
+		setLevel(level: number): void
+	}
+}

--- a/frontend/src/utils/assignment.js
+++ b/frontend/src/utils/assignment.js
@@ -7,9 +7,10 @@ import router from '@/router'
 import { getLmsRoute } from '@/utils/basePath'
 
 export class Assignment {
-	constructor({ data, api, readOnly }) {
+	constructor({ data, api, readOnly, config }) {
 		this.data = data
 		this.readOnly = readOnly
+		this.studentView = Boolean(config?.studentView)
 	}
 
 	static get toolbox() {
@@ -44,10 +45,13 @@ export class Assignment {
 	renderAssignment(assignment) {
 		if (this.readOnly) {
 			const renderSubmission = (submission) => {
+				// The iframe is its own app instance, so Student View has to
+				// travel in the URL rather than through provide/inject.
+				const studentView = this.studentView ? '&studentView=1' : ''
 				const submissionPath = getLmsRoute(
 					`assignment-submission/${assignment}/${
 						submission || 'new'
-					}?fromLesson=1`
+					}?fromLesson=1${studentView}`
 				)
 				this.wrapper.innerHTML = `<iframe src="${submissionPath}" class="w-full h-[500px]"></iframe>`
 			}

--- a/frontend/src/utils/heading.ts
+++ b/frontend/src/utils/heading.ts
@@ -1,0 +1,45 @@
+import Header from '@editorjs/header'
+import type { HeaderData } from '@editorjs/header'
+
+/**
+ * A heading is one line. EditorJS's Enter handler returns early on Shift+Enter
+ * (`BlockEvents.enter`), so the browser's default runs and drops a `<br>` into
+ * the contenteditable. The header tool's sanitize config allows no `<br>`
+ * (unlike paragraph's), so the break is stripped on save and the two lines are
+ * glued into one word — the editor shows a multi-line heading that silently
+ * collapses on reload. Refuse the break instead of losing text.
+ */
+export class Heading extends Header {
+	// Bound in getTag(), not render(): changing the heading level rebuilds the
+	// element (Header's `data` setter swaps the node), which would drop a
+	// listener attached once at render time.
+	getTag(): HTMLElement {
+		const tag = super.getTag()
+		flattenLineBreaks(tag)
+		tag.addEventListener('keydown', refuseLineBreak)
+		return tag
+	}
+
+	// Backspace at the start of a paragraph merges it into the heading above,
+	// carrying that paragraph's line breaks with it.
+	merge(data: Partial<HeaderData>): void {
+		super.merge({ ...data, text: stripLineBreaks(data.text ?? '') })
+	}
+}
+
+function refuseLineBreak(event: KeyboardEvent): void {
+	// Plain Enter still splits the block — that stays EditorJS's to handle.
+	if (event.key === 'Enter' && event.shiftKey) {
+		event.preventDefault()
+	}
+}
+
+function stripLineBreaks(html: string): string {
+	return html.replace(/<br\s*\/?>/gi, ' ')
+}
+
+// Content written before this guard — or imported from markdown — can still
+// arrive with breaks in it.
+function flattenLineBreaks(tag: HTMLElement): void {
+	tag.querySelectorAll('br').forEach((br) => br.replaceWith(' '))
+}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -6,7 +6,7 @@ import { Upload } from '@/utils/upload'
 import { Markdown } from '@/utils/markdownParser'
 import { useSettings } from '@/stores/settings'
 import { usersStore } from '@/stores/user'
-import Header from '@editorjs/header'
+import { Heading } from '@/utils/heading'
 import Paragraph from '@editorjs/paragraph'
 import { CodeBox } from '@/utils/code'
 import NestedList from '@editorjs/nested-list'
@@ -145,7 +145,7 @@ export function getEditorTools(
 ) {
 	return {
 		header: {
-			class: Header,
+			class: Heading,
 			// Without this key EditorJS leaves tool.inlineTools empty, so the
 			// inline toolbar never opens on a heading and Ctrl+B falls through
 			// to the browser's execCommand (which writes a font-weight span the

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -11,6 +11,7 @@ import Paragraph from '@editorjs/paragraph'
 import { CodeBox } from '@/utils/code'
 import NestedList from '@editorjs/nested-list'
 import InlineCode from '@editorjs/inline-code'
+import { Bold } from '@/utils/inline/Bold'
 import { Underline } from '@/utils/inline/Underline'
 import { Strikethrough } from '@/utils/inline/Strikethrough'
 import { AlignLeft, AlignCenter, AlignRight } from '@/utils/inline/TextAlign'
@@ -189,6 +190,11 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 		inlineCode: {
 			class: InlineCode,
 			shortcut: 'CMD+SHIFT+M',
+		},
+		// Overrides EditorJS's execCommand-based Bold, which can't bold a
+		// heading (see utils/inline/Bold.ts).
+		bold: {
+			class: Bold,
 		},
 		underline: Underline,
 		strikeThrough: Strikethrough,

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -178,7 +178,12 @@ export function getEditorTools(
 			class: Assignment,
 			config: { studentView },
 		},
-		program: Program,
+		// Renders its submission in an iframe too, so Student View travels the
+		// same way it does for assignments.
+		program: {
+			class: Program,
+			config: { studentView },
+		},
 		markdown: {
 			class: Markdown,
 			inlineToolbar: INLINE_TOOLBAR_ORDER,

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -141,6 +141,11 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 	return {
 		header: {
 			class: Header,
+			// Without this key EditorJS leaves tool.inlineTools empty, so the
+			// inline toolbar never opens on a heading and Ctrl+B falls through
+			// to the browser's execCommand (which writes a font-weight span the
+			// sanitizer then strips). Headings take the same toolbar as text.
+			inlineToolbar: INLINE_TOOLBAR_ORDER,
 			config: {
 				placeholder: 'Header',
 			},

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -138,7 +138,11 @@ const INLINE_TOOLBAR_ORDER = [
 	'color',
 ]
 
-export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
+export function getEditorTools(
+	isInstructorEditor = false,
+	uploadContext = {},
+	{ studentView = false } = {}
+) {
 	return {
 		header: {
 			class: Header,
@@ -167,7 +171,13 @@ export function getEditorTools(isInstructorEditor = false, uploadContext = {}) {
 			inlineToolbar: INLINE_TOOLBAR_ORDER,
 		},
 		quiz: Quiz,
-		assignment: Assignment,
+		// The submission renders in an iframe — a separate app instance — so
+		// provide/inject can't reach it. Pass Student View through the tool
+		// config and on into the iframe URL.
+		assignment: {
+			class: Assignment,
+			config: { studentView },
+		},
 		program: Program,
 		markdown: {
 			class: Markdown,

--- a/frontend/src/utils/inline/Bold.ts
+++ b/frontend/src/utils/inline/Bold.ts
@@ -1,0 +1,42 @@
+import { BaseInline } from './BaseInline'
+import { boldIcon } from './icons'
+
+/**
+ * Replaces EditorJS's built-in Bold, which calls `document.execCommand('bold')`.
+ * Inside a heading the text is already bold, so the browser reads the command as
+ * already-on and *un*-bolds: it writes `<span style="font-weight: normal">`,
+ * which the block sanitizer then drops. Wrapping the range in `<b>` ourselves
+ * works the same in every block, heading or not.
+ *
+ * Registering it under the `bold` name overrides the internal tool — EditorJS
+ * merges user tools over `internalTools`. The name stays `bold` so the shared
+ * inline-toolbar order and existing `<b>` content keep working.
+ */
+export class Bold extends BaseInline {
+	static get title(): string {
+		return __('Bold')
+	}
+
+	static get sanitize(): Record<string, boolean> {
+		return { b: true }
+	}
+
+	static get shortcut(): string {
+		return 'CMD+B'
+	}
+
+	// EditorJS reads the shortcut off the *instance* for tools registered under
+	// an internal name (InlineToolbar.getToolShortcut), so the static getter
+	// alone would leave Ctrl+B unbound.
+	get shortcut(): string {
+		return 'CMD+B'
+	}
+
+	protected get tag(): string {
+		return 'B'
+	}
+
+	protected get icon(): string {
+		return boldIcon
+	}
+}

--- a/frontend/src/utils/inline/icons.ts
+++ b/frontend/src/utils/inline/icons.ts
@@ -3,6 +3,7 @@
  * (set via innerHTML), so the Vue components from lucide-vue-next can't be used;
  * lucide-static is the same icon set shipped as plain SVG files.
  */
+import boldIcon from 'lucide-static/icons/bold.svg?raw'
 import underlineIcon from 'lucide-static/icons/underline.svg?raw'
 import strikethroughIcon from 'lucide-static/icons/strikethrough.svg?raw'
 import alignLeftIcon from 'lucide-static/icons/align-left.svg?raw'
@@ -11,6 +12,7 @@ import alignRightIcon from 'lucide-static/icons/align-right.svg?raw'
 import paintBucketIcon from 'lucide-static/icons/paint-bucket.svg?raw'
 
 export {
+	boldIcon,
 	underlineIcon,
 	strikethroughIcon,
 	alignLeftIcon,

--- a/frontend/src/utils/lessonForm.ts
+++ b/frontend/src/utils/lessonForm.ts
@@ -59,3 +59,14 @@ export function shouldSkipLessonSave(
 ): boolean {
 	return !title?.trim() && !hasBodyContent
 }
+
+/**
+ * A lesson title is one line. The field is a `<textarea>` so a long title can
+ * wrap and grow, but Enter is refused — and a title pasted (or already stored)
+ * with breaks in it collapses to spaces rather than rendering as two lines the
+ * outline and breadcrumbs then show as one.
+ */
+export function toSingleLineTitle(title: string | null | undefined): string {
+	if (!title) return ''
+	return title.replace(/\s*[\r\n]+\s*/g, ' ')
+}

--- a/frontend/src/utils/program.ts
+++ b/frontend/src/utils/program.ts
@@ -14,10 +14,16 @@ export class Program {
     readOnly: boolean;
     wrapper: HTMLDivElement;
 
-    constructor({ data, api, readOnly }: { data: any; api: any; readOnly: boolean }) {
+    studentView: boolean;
+
+    constructor({ data, api, readOnly, config }: { data: any; api: any; readOnly: boolean; config?: { studentView?: boolean } }) {
         this.data = data;
         this.api = api;
         this.readOnly = readOnly;
+        // The submission renders in an iframe — its own Vue app — so the
+        // preview's provide/inject can't reach it. Same mechanism as the
+        // assignment tool: the flag travels in the URL.
+        this.studentView = Boolean(config?.studentView)
     }
 
     static get toolbox() {
@@ -74,8 +80,9 @@ export class Program {
                 fieldname: ['name'],
             }).then((data: { name: string }) => {
                 let submission = data.name || 'new'
+                const studentView = this.studentView ? '&studentView=1' : ''
                 const submissionPath = getLmsRoute(
-                    `programming-exercises/${exercise}/submission/${submission}?fromLesson=1`
+                    `programming-exercises/${exercise}/submission/${submission}?fromLesson=1${studentView}`
                 )
                 this.wrapper.innerHTML = `<iframe src="${submissionPath}" class="w-full h-[900px] border rounded-md"></iframe>`
             })

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -421,7 +421,11 @@ def get_unsplash_photos(keyword: str = None):
 
 @frappe.whitelist()
 def get_evaluator_details(evaluator: str):
-	frappe.only_for("Batch Evaluator")
+	# Profile.vue shows the Slots and Schedule tabs to evaluators *and*
+	# moderators, so gating on Batch Evaluator alone rendered the tabs and then
+	# 403'd the request behind them.
+	frappe.only_for(["Batch Evaluator", "Moderator"])
+	evaluator = validate_evaluator_name(evaluator)
 
 	if frappe.db.exists("Google Calendar", {"user": evaluator}):
 		calendar = frappe.db.get_value(
@@ -457,6 +461,123 @@ def get_evaluator_details(evaluator: str):
 		"calendar": calendar.name if calendar else None,
 		"is_authorised": calendar.authorization_code if calendar else None,
 	}
+
+
+EVALUATOR_SLOT_FIELDS = {"day", "start_time", "end_time"}
+EVALUATOR_UNAVAILABILITY_FIELDS = {"unavailable_from", "unavailable_to"}
+EVALUATOR_SLOT_DAYS = {
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+	"Sunday",
+}
+
+
+def validate_evaluator_name(evaluator: str) -> str:
+	if not isinstance(evaluator, str) or not evaluator.strip():
+		frappe.throw(_("Evaluator is required."))
+	return evaluator.strip()
+
+
+def enforce_evaluator_ownership(evaluator: str) -> str:
+	"""You may edit your own availability; a Moderator may edit anyone's.
+
+	The Course Evaluator doctype grants blanket write to Moderator, Batch
+	Evaluator and Course Creator with no owner condition, so without this the
+	raw framework endpoints let any of them edit any evaluator's calendar.
+	"""
+	evaluator = validate_evaluator_name(evaluator)
+
+	if evaluator == frappe.session.user:
+		return evaluator
+
+	if "Moderator" in frappe.get_roles():
+		return evaluator
+
+	frappe.throw(_("You can only change your own availability."), frappe.PermissionError)
+
+
+def get_owned_evaluator_doc(evaluator: str):
+	evaluator = enforce_evaluator_ownership(evaluator)
+
+	if not frappe.db.exists("Course Evaluator", evaluator):
+		frappe.throw(_("Evaluator {0} not found").format(evaluator), frappe.DoesNotExistError)
+
+	return frappe.get_doc("Course Evaluator", evaluator)
+
+
+def get_owned_slot(doc, slot: str | int):
+	"""Resolve a slot *within* the caller's own schedule.
+
+	Looking the row up by name alone would let a valid actor point a write at
+	someone else's row; the slot has to belong to the evaluator they passed.
+	Evaluator Schedule rows are autoincrement-named, so the identifier arrives
+	as a number from JSON — compare as strings rather than trusting the type.
+	"""
+	if slot is None or not str(slot).strip():
+		frappe.throw(_("Slot is required."))
+
+	for row in doc.schedule:
+		if str(row.name) == str(slot).strip():
+			return row
+
+	frappe.throw(_("That slot does not belong to this evaluator."), frappe.PermissionError)
+
+
+@frappe.whitelist()
+def add_evaluator_slot(evaluator: str, day: str, start_time: str, end_time: str):
+	doc = get_owned_evaluator_doc(evaluator)
+
+	if day not in EVALUATOR_SLOT_DAYS:
+		frappe.throw(_("{0} is not a valid day.").format(day))
+
+	if not start_time or not end_time:
+		frappe.throw(_("Start time and end time are required."))
+
+	doc.append("schedule", {"day": day, "start_time": start_time, "end_time": end_time})
+	doc.save(ignore_permissions=True)
+	return doc.schedule[-1].name
+
+
+@frappe.whitelist()
+def update_evaluator_slot(evaluator: str, slot: str | int, fieldname: str, value: str):
+	doc = get_owned_evaluator_doc(evaluator)
+	row = get_owned_slot(doc, slot)
+
+	if fieldname not in EVALUATOR_SLOT_FIELDS:
+		frappe.throw(_("{0} cannot be changed.").format(fieldname))
+
+	if fieldname == "day" and value not in EVALUATOR_SLOT_DAYS:
+		frappe.throw(_("{0} is not a valid day.").format(value))
+
+	if not value:
+		frappe.throw(_("A value is required."))
+
+	row.set(fieldname, value)
+	doc.save(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def delete_evaluator_slot(evaluator: str, slot: str | int):
+	doc = get_owned_evaluator_doc(evaluator)
+	row = get_owned_slot(doc, slot)
+
+	doc.remove(row)
+	doc.save(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def set_evaluator_unavailability(evaluator: str, fieldname: str, value: str | None = None):
+	doc = get_owned_evaluator_doc(evaluator)
+
+	if fieldname not in EVALUATOR_UNAVAILABILITY_FIELDS:
+		frappe.throw(_("{0} cannot be changed.").format(fieldname))
+
+	doc.set(fieldname, value or None)
+	doc.save(ignore_permissions=True)
 
 
 @frappe.whitelist()
@@ -1998,13 +2119,9 @@ def get_pwa_manifest():
 
 @frappe.whitelist()
 def get_profile_details(username: str):
-	if not isinstance(username, str):
-		frappe.throw(_("Username must be a string."))
-
-	if not has_lms_role():
-		frappe.throw(
-			_("User does not have permission to access this user's profile details."), frappe.PermissionError
-		)
+	if not isinstance(username, str) or not username.strip():
+		frappe.throw(_("Username is required."))
+	username = username.strip()
 
 	details = frappe.db.get_value(
 		"User",
@@ -2027,11 +2144,23 @@ def get_profile_details(username: str):
 		],
 		as_dict=True,
 	)
+	# Every user created through the LMS picks up `LMS Student` from the
+	# before_insert hook, but users made in Desk, by Data Import or by another
+	# app do not — they must still be able to open their own profile. Viewing
+	# anyone else's still requires an LMS role, and that refusal comes before
+	# the not-found check so a caller without one can't use the difference
+	# between the two errors to enumerate usernames.
+	is_own_profile = bool(details) and details.name == frappe.session.user
+	if not is_own_profile and not has_lms_role():
+		frappe.throw(
+			_("User does not have permission to access this user's profile details."), frappe.PermissionError
+		)
+
 	if not details:
 		frappe.throw(_("User {0} not found").format(username), frappe.DoesNotExistError)
 
 	roles = frappe.get_roles(details.name)
-	if details.name != frappe.session.user and not has_moderator_role():
+	if not is_own_profile and not has_moderator_role():
 		roles = [role for role in roles if role in LMS_ROLES]
 	details.roles = roles
 	return details

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -427,40 +427,55 @@ def get_evaluator_details(evaluator: str):
 	frappe.only_for(["Batch Evaluator", "Moderator"])
 	evaluator = validate_evaluator_name(evaluator)
 
-	if frappe.db.exists("Google Calendar", {"user": evaluator}):
-		calendar = frappe.db.get_value(
-			"Google Calendar", {"user": evaluator}, ["name", "authorization_code"], as_dict=1
-		)
-	else:
-		# Batch Evaluators are portal users without create permission on Google
-		# Calendar (only System Manager / Desk User have it), so provision the
-		# evaluator's own calendar on their behalf via ignore_permissions. This is
-		# best-effort: creation requires Google OAuth configured in Google Settings,
-		# so a missing config (ValidationError) or permission gap must not block the
-		# availability (slots) UI, the primary purpose. Any other error is
-		# unexpected and left to propagate.
-		try:
-			calendar = frappe.new_doc("Google Calendar")
-			calendar.update({"user": evaluator, "calendar_name": evaluator})
-			calendar.insert(ignore_permissions=True)
-		except (frappe.ValidationError, frappe.PermissionError):
-			frappe.clear_last_message()
-			calendar = None
-
+	# Reading must not write. Saving a Course Evaluator runs
+	# CourseEvaluator.validate_evaluator_role, which *grants* the target the
+	# Batch Evaluator role — and this endpoint is reached with whatever user the
+	# profile page is showing. The Slots tab renders for any profile holding
+	# Moderator, so opening a moderator's profile used to escalate them. The
+	# record is now created on the first write instead (see
+	# get_owned_evaluator_doc), where granting the role is a deliberate act.
 	if frappe.db.exists("Course Evaluator", {"evaluator": evaluator}):
 		doc = frappe.get_doc("Course Evaluator", evaluator)
 	else:
-		# Batch Evaluator already has create permission on Course Evaluator, so use
-		# a normal permission-checked insert here (no ignore_permissions).
 		doc = frappe.new_doc("Course Evaluator")
 		doc.evaluator = evaluator
-		doc.insert()
+
+	calendar = get_evaluator_calendar(evaluator)
 
 	return {
 		"slots": doc.as_dict(),
 		"calendar": calendar.name if calendar else None,
 		"is_authorised": calendar.authorization_code if calendar else None,
 	}
+
+
+def get_evaluator_calendar(evaluator: str):
+	"""The calendar block only renders on your own profile, so only your own
+	calendar is ever provisioned — looking at someone else's availability must
+	not create documents in their name."""
+	if frappe.db.exists("Google Calendar", {"user": evaluator}):
+		return frappe.db.get_value(
+			"Google Calendar", {"user": evaluator}, ["name", "authorization_code"], as_dict=1
+		)
+
+	if evaluator != frappe.session.user:
+		return None
+
+	# Batch Evaluators are portal users without create permission on Google
+	# Calendar (only System Manager / Desk User have it), so provision the
+	# evaluator's own calendar on their behalf via ignore_permissions. This is
+	# best-effort: creation requires Google OAuth configured in Google Settings,
+	# so a missing config (ValidationError) or permission gap must not block the
+	# availability (slots) UI, the primary purpose. Any other error is
+	# unexpected and left to propagate.
+	try:
+		calendar = frappe.new_doc("Google Calendar")
+		calendar.update({"user": evaluator, "calendar_name": evaluator})
+		calendar.insert(ignore_permissions=True)
+		return calendar
+	except (frappe.ValidationError, frappe.PermissionError):
+		frappe.clear_last_message()
+		return None
 
 
 EVALUATOR_SLOT_FIELDS = {"day", "start_time", "end_time"}
@@ -501,10 +516,23 @@ def enforce_evaluator_ownership(evaluator: str) -> str:
 
 
 def get_owned_evaluator_doc(evaluator: str):
+	"""Resolve the caller's (or, for a Moderator, the target's) availability,
+	creating it on first write.
+
+	Creation lives here rather than in get_evaluator_details because saving a
+	Course Evaluator grants the target the Batch Evaluator role: that belongs to
+	an explicit "add a slot" action, not to opening a profile.
+	"""
 	evaluator = enforce_evaluator_ownership(evaluator)
 
-	if not frappe.db.exists("Course Evaluator", evaluator):
+	if not frappe.db.exists("User", evaluator):
 		frappe.throw(_("Evaluator {0} not found").format(evaluator), frappe.DoesNotExistError)
+
+	if not frappe.db.exists("Course Evaluator", evaluator):
+		doc = frappe.new_doc("Course Evaluator")
+		doc.evaluator = evaluator
+		doc.insert(ignore_permissions=True)
+		return doc
 
 	return frappe.get_doc("Course Evaluator", evaluator)
 

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -399,12 +399,24 @@ def get_branding():
 
 @frappe.whitelist()
 def get_unsplash_photos(keyword: str = None):
+	if keyword is not None and not isinstance(keyword, str):
+		frappe.throw(_("Keyword must be a string."))
+
 	from lms.unsplash import get_by_keyword, get_list
 
 	if keyword:
 		return get_by_keyword(keyword)
 
-	return frappe.cache().get_value("unsplash_photos", generator=get_list)
+	# Cache only a non-empty result. get_value(generator=...) would store the
+	# empty list an unconfigured site returns, so adding the access key later
+	# would keep serving nothing until someone cleared the cache by hand.
+	photos = frappe.cache().get_value("unsplash_photos")
+	if not photos:
+		photos = get_list()
+		if photos:
+			frappe.cache().set_value("unsplash_photos", photos)
+
+	return photos
 
 
 @frappe.whitelist()

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -24,6 +24,7 @@ from frappe.utils import (
 	flt,
 	format_date,
 	get_datetime,
+	get_time,
 	getdate,
 	now,
 )
@@ -421,19 +422,17 @@ def get_unsplash_photos(keyword: str = None):
 
 @frappe.whitelist()
 def get_evaluator_details(evaluator: str):
-	# Profile.vue shows the Slots and Schedule tabs to evaluators *and*
-	# moderators, so gating on Batch Evaluator alone rendered the tabs and then
-	# 403'd the request behind them.
-	frappe.only_for(["Batch Evaluator", "Moderator"])
-	evaluator = validate_evaluator_name(evaluator)
+	# Same rule as the writes: your own, or anyone's if you are a Moderator. A
+	# role check alone let any Batch Evaluator read every other evaluator's
+	# schedule, unavailability and calendar — the profile page's redirect is
+	# client-side, so it stops nobody calling the endpoint directly.
+	evaluator = enforce_evaluator_access(evaluator)
 
 	# Reading must not write. Saving a Course Evaluator runs
 	# CourseEvaluator.validate_evaluator_role, which *grants* the target the
 	# Batch Evaluator role — and this endpoint is reached with whatever user the
-	# profile page is showing. The Slots tab renders for any profile holding
-	# Moderator, so opening a moderator's profile used to escalate them. The
-	# record is now created on the first write instead (see
-	# get_owned_evaluator_doc), where granting the role is a deliberate act.
+	# profile page is showing. The record is created on the first write instead
+	# (see get_owned_evaluator_doc), where it is a deliberate act.
 	if frappe.db.exists("Course Evaluator", {"evaluator": evaluator}):
 		doc = frappe.get_doc("Course Evaluator", evaluator)
 	else:
@@ -445,39 +444,48 @@ def get_evaluator_details(evaluator: str):
 	return {
 		"slots": doc.as_dict(),
 		"calendar": calendar.name if calendar else None,
-		"is_authorised": calendar.authorization_code if calendar else None,
+		"is_authorized": calendar.authorization_code if calendar else None,
 	}
 
 
 def get_evaluator_calendar(evaluator: str):
-	"""The calendar block only renders on your own profile, so only your own
-	calendar is ever provisioned — looking at someone else's availability must
-	not create documents in their name."""
-	if frappe.db.exists("Google Calendar", {"user": evaluator}):
-		return frappe.db.get_value(
-			"Google Calendar", {"user": evaluator}, ["name", "authorization_code"], as_dict=1
-		)
+	"""Read-only. Provisioning moved to ensure_evaluator_calendar: creating a
+	Google Calendar document is a write, and this runs on a plain GET of the
+	profile page."""
+	return frappe.db.get_value(
+		"Google Calendar", {"user": evaluator}, ["name", "authorization_code"], as_dict=1
+	)
 
-	if evaluator != frappe.session.user:
-		return None
 
-	# Batch Evaluators are portal users without create permission on Google
-	# Calendar (only System Manager / Desk User have it), so provision the
-	# evaluator's own calendar on their behalf via ignore_permissions. This is
-	# best-effort: creation requires Google OAuth configured in Google Settings,
-	# so a missing config (ValidationError) or permission gap must not block the
-	# availability (slots) UI, the primary purpose. Any other error is
-	# unexpected and left to propagate.
+@frappe.whitelist()
+def ensure_evaluator_calendar():
+	"""Create the caller's own Google Calendar record, on demand.
+
+	Batch Evaluators are portal users without create permission on Google
+	Calendar (only System Manager / Desk User have it), so it is provisioned on
+	their behalf — but only for themselves, and only when they ask for it by
+	starting the authorisation flow.
+	"""
+	frappe.only_for(EVALUATOR_ROLES)
+	user = frappe.session.user
+
+	existing = frappe.db.get_value("Google Calendar", {"user": user}, "name")
+	if existing:
+		return existing
+
+	calendar = frappe.new_doc("Google Calendar")
+	calendar.update({"user": user, "calendar_name": user})
+	frappe.db.savepoint("create_calendar")
 	try:
-		calendar = frappe.new_doc("Google Calendar")
-		calendar.update({"user": evaluator, "calendar_name": evaluator})
 		calendar.insert(ignore_permissions=True)
-		return calendar
-	except (frappe.ValidationError, frappe.PermissionError):
-		frappe.clear_last_message()
-		return None
+	except frappe.DuplicateEntryError:
+		frappe.db.rollback(save_point="create_calendar")
+		return frappe.db.get_value("Google Calendar", {"user": user}, "name")
+
+	return calendar.name
 
 
+EVALUATOR_ROLES = ["Batch Evaluator", "Moderator"]
 EVALUATOR_SLOT_FIELDS = {"day", "start_time", "end_time"}
 EVALUATOR_UNAVAILABILITY_FIELDS = {"unavailable_from", "unavailable_to"}
 EVALUATOR_SLOT_DAYS = {
@@ -497,13 +505,15 @@ def validate_evaluator_name(evaluator: str) -> str:
 	return evaluator.strip()
 
 
-def enforce_evaluator_ownership(evaluator: str) -> str:
-	"""You may edit your own availability; a Moderator may edit anyone's.
+def enforce_evaluator_access(evaluator: str) -> str:
+	"""View or edit your own availability; a Moderator may do either for anyone.
 
-	The Course Evaluator doctype grants blanket write to Moderator, Batch
-	Evaluator and Course Creator with no owner condition, so without this the
-	raw framework endpoints let any of them edit any evaluator's calendar.
+	Two gates, not one. The role check is what keeps non-evaluators out: with
+	the ownership check alone, any authenticated user could name *themselves*
+	and reach the write path, which provisions a Course Evaluator (and with it
+	the Batch Evaluator role) with ignore_permissions.
 	"""
+	frappe.only_for(EVALUATOR_ROLES)
 	evaluator = validate_evaluator_name(evaluator)
 
 	if evaluator == frappe.session.user:
@@ -512,29 +522,73 @@ def enforce_evaluator_ownership(evaluator: str) -> str:
 	if "Moderator" in frappe.get_roles():
 		return evaluator
 
-	frappe.throw(_("You can only change your own availability."), frappe.PermissionError)
+	frappe.throw(_("You can only see or change your own availability."), frappe.PermissionError)
 
 
-def get_owned_evaluator_doc(evaluator: str):
-	"""Resolve the caller's (or, for a Moderator, the target's) availability,
-	creating it on first write.
+def get_owned_evaluator_doc(evaluator: str, create: bool = False):
+	"""Resolve the caller's (or, for a Moderator, the target's) availability.
 
-	Creation lives here rather than in get_evaluator_details because saving a
-	Course Evaluator grants the target the Batch Evaluator role: that belongs to
-	an explicit "add a slot" action, not to opening a profile.
+	`create` is only ever set by the one endpoint that means "this person is an
+	evaluator now" — adding a slot — and only after that call's own arguments
+	have been validated. Editing, deleting or setting unavailability on a record
+	that does not exist is a mistake, not a reason to conjure one: saving a
+	Course Evaluator grants the Batch Evaluator role, so creating on those paths
+	handed out a role for a write that was then rejected.
 	"""
-	evaluator = enforce_evaluator_ownership(evaluator)
+	evaluator = enforce_evaluator_access(evaluator)
+
+	if frappe.db.exists("Course Evaluator", evaluator):
+		return frappe.get_doc("Course Evaluator", evaluator)
+
+	if not create:
+		frappe.throw(_("{0} has no availability set up yet.").format(evaluator), frappe.DoesNotExistError)
 
 	if not frappe.db.exists("User", evaluator):
 		frappe.throw(_("Evaluator {0} not found").format(evaluator), frappe.DoesNotExistError)
 
-	if not frappe.db.exists("Course Evaluator", evaluator):
-		doc = frappe.new_doc("Course Evaluator")
-		doc.evaluator = evaluator
+	doc = frappe.new_doc("Course Evaluator")
+	doc.evaluator = evaluator
+	# `autoname: field:evaluator` makes the evaluator the primary key, so a
+	# concurrent first write is a duplicate rather than a second row.
+	frappe.db.savepoint("create_evaluator")
+	try:
 		doc.insert(ignore_permissions=True)
-		return doc
+	except frappe.DuplicateEntryError:
+		frappe.db.rollback(save_point="create_evaluator")
+		return frappe.get_doc("Course Evaluator", evaluator)
 
-	return frappe.get_doc("Course Evaluator", evaluator)
+	return doc
+
+
+def validate_slot_time(value: str) -> str:
+	"""`get_time` raises a bare ValueError from dateutil on junk, which reaches
+	the client as a 500 instead of a message."""
+	if not isinstance(value, str) or not value.strip():
+		frappe.throw(_("A time is required."))
+
+	try:
+		get_time(value.strip())
+	except Exception:
+		frappe.throw(_("{0} is not a valid time.").format(value))
+
+	return value.strip()
+
+
+def validate_unavailability_date(value: str | None) -> str | None:
+	"""Clearing a date is legitimate; an unparseable one must not reach the
+	Date column, where it fails at SQL time."""
+	if value is None or (isinstance(value, str) and not value.strip()):
+		return None
+
+	if not isinstance(value, str):
+		frappe.throw(_("A date is required."))
+
+	try:
+		getdate(value.strip())
+	except Exception:
+		frappe.throw(_("{0} is not a valid date.").format(value))
+
+	return value.strip()
 
 
 def get_owned_slot(doc, slot: str | int):
@@ -557,13 +611,15 @@ def get_owned_slot(doc, slot: str | int):
 
 @frappe.whitelist()
 def add_evaluator_slot(evaluator: str, day: str, start_time: str, end_time: str):
-	doc = get_owned_evaluator_doc(evaluator)
-
 	if day not in EVALUATOR_SLOT_DAYS:
 		frappe.throw(_("{0} is not a valid day.").format(day))
 
-	if not start_time or not end_time:
-		frappe.throw(_("Start time and end time are required."))
+	start_time = validate_slot_time(start_time)
+	end_time = validate_slot_time(end_time)
+
+	# Validated first: this is the call that creates the record, and creating it
+	# makes the target an evaluator.
+	doc = get_owned_evaluator_doc(evaluator, create=True)
 
 	doc.append("schedule", {"day": day, "start_time": start_time, "end_time": end_time})
 	doc.save(ignore_permissions=True)
@@ -578,11 +634,11 @@ def update_evaluator_slot(evaluator: str, slot: str | int, fieldname: str, value
 	if fieldname not in EVALUATOR_SLOT_FIELDS:
 		frappe.throw(_("{0} cannot be changed.").format(fieldname))
 
-	if fieldname == "day" and value not in EVALUATOR_SLOT_DAYS:
-		frappe.throw(_("{0} is not a valid day.").format(value))
-
-	if not value:
-		frappe.throw(_("A value is required."))
+	if fieldname == "day":
+		if value not in EVALUATOR_SLOT_DAYS:
+			frappe.throw(_("{0} is not a valid day.").format(value))
+	else:
+		value = validate_slot_time(value)
 
 	row.set(fieldname, value)
 	doc.save(ignore_permissions=True)
@@ -604,7 +660,7 @@ def set_evaluator_unavailability(evaluator: str, fieldname: str, value: str | No
 	if fieldname not in EVALUATOR_UNAVAILABILITY_FIELDS:
 		frappe.throw(_("{0} cannot be changed.").format(fieldname))
 
-	doc.set(fieldname, value or None)
+	doc.set(fieldname, validate_unavailability_date(value))
 	doc.save(ignore_permissions=True)
 
 

--- a/lms/lms/doctype/course_evaluator/course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/course_evaluator.py
@@ -18,14 +18,34 @@ class CourseEvaluator(Document):
 		self.validate_unavailability()
 
 	def on_trash(self):
-		roles = frappe.get_roles(self.evaluator)
-		if "Batch Evaluator" in roles:
-			frappe.get_doc("User", self.evaluator).remove_roles("Batch Evaluator")
+		# Direct row delete, not User.remove_roles: see validate_evaluator_role.
+		frappe.db.delete("Has Role", {"parent": self.evaluator, "role": "Batch Evaluator"})
+		frappe.clear_cache(user=self.evaluator)
 
 	def validate_evaluator_role(self):
-		roles = frappe.get_roles(self.evaluator)
-		if "Batch Evaluator" not in roles:
-			frappe.get_doc("User", self.evaluator).add_roles("Batch Evaluator")
+		"""Being a Course Evaluator *is* holding the Batch Evaluator role.
+
+		Written as a Has Role row rather than `User.add_roles`, which saves the
+		whole User document: whenever the session user cannot write User docs —
+		every portal Moderator, since LMS only grants them list access — the save
+		is dropped and the role silently never lands, leaving an evaluator who
+		cannot open their own schedule. lms.lms.api.save_evaluator_role writes
+		the row directly for the same reason.
+		"""
+		if frappe.db.exists("Has Role", {"parent": self.evaluator, "role": "Batch Evaluator"}):
+			return
+
+		role = frappe.new_doc("Has Role")
+		role.update(
+			{
+				"parent": self.evaluator,
+				"parenttype": "User",
+				"parentfield": "roles",
+				"role": "Batch Evaluator",
+			}
+		)
+		role.insert(ignore_permissions=True)
+		frappe.clear_cache(user=self.evaluator)
 
 	def validate_unavailability(self):
 		if (

--- a/lms/lms/payments.py
+++ b/lms/lms/payments.py
@@ -115,10 +115,13 @@ def get_payment_link(
 		"payment": payment.name,
 	}
 
-	create_order(payment_gateway, payment_details, controller)
-	url = controller.get_payment_url(**payment_details)
-
-	return url
+	# The controller creates the order itself when no `order_id` is supplied
+	# (see RazorpaySettings.get_payment_url). Pre-creating one here made the
+	# gateway skip that branch and left two Integration Requests per attempt —
+	# one in paise without an `order_id`, one in rupees with it — which
+	# update_payment_record's "creation desc, limit 1" lookup can resolve to the
+	# wrong row.
+	return controller.get_payment_url(**payment_details)
 
 
 def already_has_access(doctype: str, docname: str, payment_for_certificate: int) -> bool:
@@ -135,14 +138,6 @@ def already_has_access(doctype: str, docname: str, payment_for_certificate: int)
 		return bool(frappe.db.exists("LMS Enrollment", {"member": member, "course": docname}))
 
 	return bool(frappe.db.exists("LMS Batch Enrollment", {"member": member, "batch": docname}))
-
-
-def create_order(payment_gateway: str, payment_details: dict, controller: object):
-	if payment_gateway != "Razorpay":
-		return
-
-	order = controller.create_order(**payment_details)
-	payment_details.update({"order_id": order.get("id")})
 
 
 def get_amount_with_gst(amount: float, gst_amount: float) -> float:

--- a/lms/tests/api/test_payments.py
+++ b/lms/tests/api/test_payments.py
@@ -61,7 +61,13 @@ class TestPaymentLink(BaseTestUtils):
 		self.original_gateway = frappe.db.get_single_value("LMS Settings", "payment_gateway")
 		frappe.db.set_single_value("LMS Settings", "payment_gateway", "Razorpay")
 
-		self.course = self._create_course(title="Paid Payments Course")
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"payinstr-{hash}@example.com", "Ina", "Instructor", ["Course Creator"]
+		)
+		self.course = self._create_course(
+			title=f"Paid Payments Course {hash}", instructor=self.instructor.email
+		)
 		self.course.db_set({"paid_course": 1, "course_price": 500, "currency": "INR"}, update_modified=False)
 
 	def tearDown(self):

--- a/lms/tests/api/test_payments.py
+++ b/lms/tests/api/test_payments.py
@@ -1,0 +1,131 @@
+import frappe
+
+from lms.lms import payments as payments_module
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class FakeRazorpayController:
+	"""Stands in for the payments app's RazorpaySettings.
+
+	Mirrors the real controller: `get_payment_url` creates the order itself when
+	the caller hasn't supplied an `order_id`, `create_order` converts rupees to
+	paise, and both write an Integration Request. `direct_create_order_calls`
+	records the calls that did *not* come from inside `get_payment_url` — i.e.
+	the ones LMS made on its own.
+	"""
+
+	def __init__(self):
+		self.create_order_calls = []
+		self.direct_create_order_calls = []
+		self.get_payment_url_calls = []
+		self.integration_requests = []
+		self._inside_get_payment_url = False
+
+	def create_order(self, **kwargs):
+		self.create_order_calls.append(kwargs)
+		if not self._inside_get_payment_url:
+			self.direct_create_order_calls.append(kwargs)
+		paise = dict(kwargs, amount=int(kwargs["amount"] * 100))
+		self.integration_requests.append(paise)
+		return {"id": "order_TEST123"}
+
+	def get_payment_url(self, **kwargs):
+		self.get_payment_url_calls.append(dict(kwargs))
+		self._inside_get_payment_url = True
+		try:
+			if not kwargs.get("order_id"):
+				order = self.create_order(**kwargs)
+				kwargs.update({"order_id": order.get("id")})
+		finally:
+			self._inside_get_payment_url = False
+		self.integration_requests.append(kwargs)
+		return "https://example.test/razorpay_checkout?token=IR-TEST"
+
+
+class TestPaymentLink(BaseTestUtils):
+	"""LMS used to pre-create the Razorpay order and hand the resulting
+	`order_id` to `get_payment_url` — which creates the order itself whenever one
+	is missing. That put gateway-specific order logic (and a hard-coded
+	`if payment_gateway != "Razorpay"`) in LMS, duplicating what the payments app
+	owns, while omitting the `receipt` / `payment_capture` fields the controller's
+	order payload expects. Ordering the call through `get_payment_url` alone keeps
+	LMS gateway-agnostic.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.controller = FakeRazorpayController()
+		self.original_get_controller = payments_module.get_controller
+		payments_module.get_controller = lambda gateway: self.controller
+
+		self.original_gateway = frappe.db.get_single_value("LMS Settings", "payment_gateway")
+		frappe.db.set_single_value("LMS Settings", "payment_gateway", "Razorpay")
+
+		self.course = self._create_course(title="Paid Payments Course")
+		self.course.db_set({"paid_course": 1, "course_price": 500, "currency": "INR"}, update_modified=False)
+
+	def tearDown(self):
+		payments_module.get_controller = self.original_get_controller
+		frappe.db.set_single_value("LMS Settings", "payment_gateway", self.original_gateway)
+		super().tearDown()
+
+	def _buy_course(self):
+		return payments_module.get_payment_link(
+			doctype="LMS Course",
+			docname=self.course.name,
+			address={
+				"billing_name": "Test Buyer",
+				"address_line1": "1 Test Street",
+				"city": "Test City",
+				"country": "India",
+				"pincode": "560001",
+				"source": "Website",
+				"member_consent": 1,
+			},
+			payment_for_certificate=0,
+		)
+
+	def test_lms_never_calls_create_order_itself(self):
+		"""The regression guard: order creation belongs to the gateway
+		controller. Before the fix LMS called `create_order` directly whenever
+		the gateway happened to be named Razorpay."""
+		self._buy_course()
+
+		self.assertEqual(self.controller.direct_create_order_calls, [])
+		self.assertEqual(len(self.controller.get_payment_url_calls), 1)
+
+	def test_no_create_order_helper_remains(self):
+		"""`create_order` in lms.lms.payments was a stale copy of logic that has
+		since moved into the payments app."""
+		self.assertFalse(
+			hasattr(payments_module, "create_order"),
+			"lms.lms.payments.create_order duplicates the payments app controller",
+		)
+
+	def test_controller_still_gets_an_order_created(self):
+		"""Delegating must not lose the order — `get_payment_url` creates one
+		because LMS no longer supplies an `order_id`."""
+		self._buy_course()
+
+		self.assertEqual(len(self.controller.create_order_calls), 1)
+		self.assertIsNone(self.controller.get_payment_url_calls[0].get("order_id"))
+
+	def test_payment_url_receives_the_amount_in_rupees(self):
+		"""LMS passes the order total untouched; converting to paise is the
+		controller's job."""
+		self._buy_course()
+
+		self.assertEqual(self.controller.get_payment_url_calls[0]["amount"], 500)
+
+	def test_the_request_carrying_the_order_id_is_written_last(self):
+		"""The controller writes two Integration Requests per attempt — the paise
+		order payload, then the checkout payload with the `order_id`.
+		`update_payment_record` resolves the payment with
+		`order_by="creation desc" limit 1`, so it depends on the second one being
+		the newer row. This documents that contract; the duplication itself lives
+		in the payments app and is unchanged by this fix."""
+		self._buy_course()
+
+		self.assertEqual(len(self.controller.integration_requests), 2)
+		self.assertNotIn("order_id", self.controller.integration_requests[0])
+		self.assertEqual(self.controller.integration_requests[-1]["order_id"], "order_TEST123")

--- a/lms/tests/api/test_unsplash.py
+++ b/lms/tests/api/test_unsplash.py
@@ -1,0 +1,46 @@
+import frappe
+
+from lms.lms.api import get_unsplash_photos
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestUnsplashPhotos(BaseTestUtils):
+	"""Unsplash needs an access key that most sites never set. When it is
+	missing the request helper returns None, which used to reach
+	`data.get("results")` and 500 on every keyword search, and cache a null
+	list for the unfiltered call — so the cover-image picker rendered an
+	empty grid with no explanation for every role."""
+
+	def setUp(self):
+		super().setUp()
+		self.original_key = frappe.db.get_single_value("LMS Settings", "unsplash_access_key")
+		frappe.db.set_single_value("LMS Settings", "unsplash_access_key", "")
+		frappe.cache().delete_value("unsplash_photos")
+
+	def tearDown(self):
+		frappe.db.set_single_value("LMS Settings", "unsplash_access_key", self.original_key)
+		frappe.cache().delete_value("unsplash_photos")
+		super().tearDown()
+
+	def test_keyword_search_returns_empty_list_when_unconfigured(self):
+		self.assertEqual(get_unsplash_photos("mountain"), [])
+
+	def test_listing_returns_empty_list_when_unconfigured(self):
+		self.assertEqual(get_unsplash_photos(), [])
+
+	def test_empty_result_is_not_cached(self):
+		"""A site that adds the access key later must not keep serving the
+		empty list the unconfigured call produced."""
+		get_unsplash_photos()
+		self.assertFalse(frappe.cache().get_value("unsplash_photos"))
+
+	def test_non_string_keyword_is_rejected(self):
+		"""Two layers reject a non-string keyword, and which one fires depends on
+		the caller. Inside a request or a test frappe validates the `str`
+		annotation first and raises FrappeTypeError; a background job or script
+		skips that check (`_in_request_or_test`) and hits the isinstance guard,
+		which throws ValidationError. Either way the value never reaches the
+		Unsplash request."""
+		for bad in ([">", "x"], {"like": "%"}, 7):
+			with self.assertRaises((frappe.ValidationError, frappe.exceptions.FrappeTypeError)):
+				get_unsplash_photos(bad)

--- a/lms/tests/security/test_evaluator_availability.py
+++ b/lms/tests/security/test_evaluator_availability.py
@@ -3,6 +3,7 @@ import frappe
 from lms.lms.api import (
 	add_evaluator_slot,
 	delete_evaluator_slot,
+	ensure_evaluator_calendar,
 	get_evaluator_details,
 	set_evaluator_unavailability,
 	update_evaluator_slot,
@@ -302,6 +303,135 @@ class TestEvaluatorAvailability(BaseTestUtils):
 
 		doc = frappe.get_doc("Course Evaluator", self.plain_moderator.email)
 		self.assertEqual([row.day for row in doc.schedule], ["Monday"])
+
+	def test_creating_the_record_actually_grants_the_role(self):
+		"""`User.add_roles` saves the whole User doc, which a portal Moderator
+		may not write — so the grant silently never landed and the evaluator
+		could not open their own schedule."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		add_evaluator_slot(self.plain_moderator.email, "Monday", "09:00:00", "10:00:00")
+
+		self.assertTrue(
+			frappe.db.exists("Has Role", {"parent": self.plain_moderator.email, "role": "Batch Evaluator"}),
+			"the Course Evaluator was created without granting Batch Evaluator",
+		)
+
+	# --- the caller must be an evaluator in the first place ---------------
+
+	def test_a_student_cannot_make_themselves_an_evaluator(self):
+		"""Ownership alone is not a gate: naming yourself passes it, and the
+		first write provisions a Course Evaluator with ignore_permissions —
+		which grants Batch Evaluator. The caller needs the role already."""
+		self._reset_target(self.student.email)
+		frappe.session.user = self.student.email
+
+		with self.assertRaises(frappe.PermissionError):
+			add_evaluator_slot(self.student.email, "Monday", "09:00:00", "10:00:00")
+
+		self.assertFalse(frappe.db.exists("Course Evaluator", self.student.email))
+		self.assertFalse(
+			frappe.db.exists("Has Role", {"parent": self.student.email, "role": "Batch Evaluator"})
+		)
+
+	def test_a_course_creator_cannot_make_themselves_an_evaluator(self):
+		frappe.session.user = self.course_creator.email
+
+		with self.assertRaises(frappe.PermissionError):
+			add_evaluator_slot(self.course_creator.email, "Monday", "09:00:00", "10:00:00")
+
+	def test_a_student_cannot_read_their_own_availability_either(self):
+		frappe.session.user = self.student.email
+
+		with self.assertRaises(frappe.PermissionError):
+			get_evaluator_details(self.student.email)
+
+	# --- reads are owner-gated too ----------------------------------------
+
+	def test_an_evaluator_cannot_read_another_evaluators_schedule(self):
+		"""`only_for` is a role gate, not an owner gate — every Batch Evaluator
+		could read every other one's schedule, unavailability and calendar."""
+		frappe.session.user = self.evaluator.email
+
+		with self.assertRaises(frappe.PermissionError):
+			get_evaluator_details(self.other_evaluator.email)
+
+	def test_a_moderator_can_still_read_anyones_schedule(self):
+		frappe.session.user = self.moderator.email
+
+		details = get_evaluator_details(self.evaluator.email)
+
+		self.assertEqual([row["day"] for row in details["slots"]["schedule"]], ["Monday"])
+
+	# --- no record means no write ------------------------------------------
+
+	def test_unavailability_on_a_missing_record_is_refused_not_created(self):
+		"""A no-op unavailability write used to create the record — and grant
+		the role — for someone who had never been an evaluator."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		with self.assertRaises(frappe.DoesNotExistError):
+			set_evaluator_unavailability(self.plain_moderator.email, "unavailable_from", None)
+
+		self.assertFalse(frappe.db.exists("Course Evaluator", self.plain_moderator.email))
+
+	def test_deleting_a_slot_on_a_missing_record_creates_nothing(self):
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		with self.assertRaises(frappe.DoesNotExistError):
+			delete_evaluator_slot(self.plain_moderator.email, 1)
+
+		self.assertFalse(frappe.db.exists("Course Evaluator", self.plain_moderator.email))
+
+	# --- value validation ---------------------------------------------------
+
+	def test_a_malformed_time_is_a_validation_error_not_a_500(self):
+		frappe.session.user = self.evaluator.email
+
+		for bad in ("25:99", "not-a-time", "", None, 7):
+			with self.assertRaises((frappe.ValidationError, frappe.exceptions.FrappeTypeError)):
+				add_evaluator_slot(self.evaluator.email, "Monday", bad, "10:00:00")
+
+	def test_a_malformed_time_on_update_is_a_validation_error(self):
+		frappe.session.user = self.evaluator.email
+		slot = self._slot_of(self.schedule)
+
+		with self.assertRaises(frappe.ValidationError):
+			update_evaluator_slot(self.evaluator.email, slot, "start_time", "25:99")
+
+	def test_a_malformed_unavailability_date_is_a_validation_error(self):
+		frappe.session.user = self.evaluator.email
+
+		with self.assertRaises(frappe.ValidationError):
+			set_evaluator_unavailability(self.evaluator.email, "unavailable_from", "garbage")
+
+	def test_clearing_unavailability_is_still_allowed(self):
+		frappe.session.user = self.evaluator.email
+
+		set_evaluator_unavailability(self.evaluator.email, "unavailable_from", None)
+
+		self.assertIsNone(frappe.db.get_value("Course Evaluator", self.evaluator.email, "unavailable_from"))
+
+	# --- calendar provisioning ---------------------------------------------
+
+	def test_reading_details_does_not_create_a_google_calendar(self):
+		"""Provisioning moved to ensure_evaluator_calendar: a GET of the profile
+		page must not write a Google Calendar document either."""
+		frappe.db.delete("Google Calendar", {"user": self.evaluator.email})
+		frappe.session.user = self.evaluator.email
+
+		get_evaluator_details(self.evaluator.email)
+
+		self.assertFalse(frappe.db.exists("Google Calendar", {"user": self.evaluator.email}))
+
+	def test_a_student_cannot_provision_a_calendar(self):
+		frappe.session.user = self.student.email
+
+		with self.assertRaises(frappe.PermissionError):
+			ensure_evaluator_calendar()
 
 	def test_a_write_for_an_unknown_user_is_still_refused(self):
 		frappe.session.user = self.moderator.email

--- a/lms/tests/security/test_evaluator_availability.py
+++ b/lms/tests/security/test_evaluator_availability.py
@@ -3,6 +3,7 @@ import frappe
 from lms.lms.api import (
 	add_evaluator_slot,
 	delete_evaluator_slot,
+	get_evaluator_details,
 	set_evaluator_unavailability,
 	update_evaluator_slot,
 )
@@ -29,7 +30,12 @@ class TestEvaluatorAvailability(BaseTestUtils):
 		"other_evaluator": ("availability-eval2@example.com", ["Batch Evaluator", "LMS Student"]),
 		"course_creator": ("availability-cc@example.com", ["Course Creator"]),
 		"moderator": ("availability-mod@example.com", ["Moderator"]),
+		# A Moderator with no Batch Evaluator role: the Slots tab renders for
+		# them, so they are the reachable target of a read-that-writes.
+		"plain_moderator": ("availability-mod2@example.com", ["Moderator"]),
 		"student": ("availability-stu@example.com", ["LMS Student"]),
+		# Holds the role but has never saved a slot, so no Course Evaluator row.
+		"fresh_evaluator": ("availability-eval3@example.com", ["Batch Evaluator"]),
 	}
 
 	@classmethod
@@ -55,6 +61,13 @@ class TestEvaluatorAvailability(BaseTestUtils):
 					for role in roles:
 						user.append("roles", {"role": role})
 					user.insert(ignore_permissions=True)
+				else:
+					# Reused across runs, and a test may have stripped a role to
+					# set up its own state — put the fixture's roles back.
+					user = frappe.get_doc("User", email)
+					missing = [r for r in roles if r not in {d.role for d in user.roles}]
+					if missing:
+						user.add_roles(*missing)
 				setattr(cls, attr, frappe._dict(email=email))
 		finally:
 			frappe.flags.in_import = original_in_import
@@ -204,3 +217,94 @@ class TestEvaluatorAvailability(BaseTestUtils):
 		frappe.session.user = self.evaluator.email
 		with self.assertRaises(frappe.ValidationError):
 			add_evaluator_slot(self.evaluator.email, "Noonday", "09:00:00", "10:00:00")
+
+	# --- reading must not write ------------------------------------------
+
+	def _reset_target(self, evaluator, drop_role=True):
+		"""A pre-fix run leaves the record — and the granted role — behind.
+
+		`drop_role` stays off for a fixture that is *meant* to hold Batch
+		Evaluator: stripping it would make the caller fail `only_for`.
+		"""
+		if frappe.db.exists("Course Evaluator", evaluator):
+			frappe.delete_doc("Course Evaluator", evaluator, force=True, ignore_permissions=True)
+		if drop_role:
+			frappe.db.delete("Has Role", {"parent": evaluator, "role": "Batch Evaluator"})
+		frappe.clear_cache(user=evaluator)
+
+	def test_reading_details_does_not_create_a_record_for_the_target(self):
+		"""`get_evaluator_details` used to insert a Course Evaluator for whoever
+		it was asked about. The Slots tab renders for any profile holding
+		Moderator, and the resource fires on mount — before the client-side
+		redirect — so opening another moderator's profile wrote to their name."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		get_evaluator_details(self.plain_moderator.email)
+
+		self.assertFalse(
+			frappe.db.exists("Course Evaluator", self.plain_moderator.email),
+			"reading availability created a Course Evaluator",
+		)
+
+	def test_reading_details_does_not_grant_the_target_the_evaluator_role(self):
+		"""Saving a Course Evaluator runs validate_evaluator_role, which adds
+		`Batch Evaluator` to the target. The grant only lands when the *caller*
+		may write User docs — a portal Moderator's role write is silently
+		dropped — so an admin-level reader is what made this an escalation."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = "Administrator"
+
+		get_evaluator_details(self.plain_moderator.email)
+
+		frappe.clear_cache(user=self.plain_moderator.email)
+		self.assertFalse(
+			frappe.db.exists("Has Role", {"parent": self.plain_moderator.email, "role": "Batch Evaluator"}),
+			"reading availability granted Batch Evaluator",
+		)
+
+	def test_reading_details_of_a_new_evaluator_returns_an_empty_schedule(self):
+		"""The UI iterates `slots.schedule` unguarded, so the empty case still
+		has to come back shaped like a Course Evaluator."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		details = get_evaluator_details(self.plain_moderator.email)
+
+		self.assertEqual(details["slots"]["schedule"], [])
+		self.assertIsNone(details["slots"]["unavailable_from"])
+		self.assertIsNone(details["slots"]["unavailable_to"])
+
+	def test_reading_your_own_details_still_does_not_write(self):
+		"""A Batch Evaluator who has never set a slot has no Course Evaluator
+		record; opening their own Slots tab must not conjure one either."""
+		self._reset_target(self.fresh_evaluator.email, drop_role=False)
+		frappe.session.user = self.fresh_evaluator.email
+
+		get_evaluator_details(self.fresh_evaluator.email)
+
+		self.assertFalse(frappe.db.exists("Course Evaluator", self.fresh_evaluator.email))
+
+	def test_existing_availability_still_reads_back(self):
+		frappe.session.user = self.evaluator.email
+
+		details = get_evaluator_details(self.evaluator.email)
+
+		self.assertEqual([row["day"] for row in details["slots"]["schedule"]], ["Monday"])
+
+	def test_adding_a_slot_creates_the_evaluator_record_on_demand(self):
+		"""Creation moves to the write path, so an evaluator with no record yet
+		can still be given slots — it just takes a deliberate write."""
+		self._reset_target(self.plain_moderator.email)
+		frappe.session.user = self.moderator.email
+
+		add_evaluator_slot(self.plain_moderator.email, "Monday", "09:00:00", "10:00:00")
+
+		doc = frappe.get_doc("Course Evaluator", self.plain_moderator.email)
+		self.assertEqual([row.day for row in doc.schedule], ["Monday"])
+
+	def test_a_write_for_an_unknown_user_is_still_refused(self):
+		frappe.session.user = self.moderator.email
+
+		with self.assertRaises(frappe.DoesNotExistError):
+			add_evaluator_slot("no-such-user@example.com", "Monday", "09:00:00", "10:00:00")

--- a/lms/tests/security/test_evaluator_availability.py
+++ b/lms/tests/security/test_evaluator_availability.py
@@ -1,0 +1,206 @@
+import frappe
+
+from lms.lms.api import (
+	add_evaluator_slot,
+	delete_evaluator_slot,
+	set_evaluator_unavailability,
+	update_evaluator_slot,
+)
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestEvaluatorAvailability(BaseTestUtils):
+	"""`ProfileEvaluator.vue` used to write availability through raw
+	`frappe.client.insert` / `set_value` / `delete`, which fall back to plain
+	doctype role permissions. `Course Evaluator` grants full write to Moderator,
+	Batch Evaluator *and* Course Creator with no row-level owner condition, so
+	any of them could add slots to, edit, or mark unavailability on any other
+	evaluator's calendar — a Course Creator can't even open the Slots tab, yet
+	could still write to it through the API.
+
+	The rule these endpoints enforce: you may edit your own availability, and a
+	Moderator may edit anyone's.
+	"""
+
+	# Users are made once for the class: frappe throttles User creation, and
+	# re-creating five of them per test method trips it.
+	USERS = {
+		"evaluator": ("availability-eval@example.com", ["Batch Evaluator", "LMS Student"]),
+		"other_evaluator": ("availability-eval2@example.com", ["Batch Evaluator", "LMS Student"]),
+		"course_creator": ("availability-cc@example.com", ["Course Creator"]),
+		"moderator": ("availability-mod@example.com", ["Moderator"]),
+		"student": ("availability-stu@example.com", ["LMS Student"]),
+	}
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# `throttle_user_creation` refuses more than 60 Users an hour. These
+		# fixtures have stable names and are reused across runs, so the flag only
+		# matters the first time a site sees them.
+		original_in_import = frappe.flags.in_import
+		frappe.flags.in_import = True
+		try:
+			for attr, (email, roles) in cls.USERS.items():
+				if not frappe.db.exists("User", email):
+					user = frappe.new_doc("User")
+					user.update(
+						{
+							"email": email,
+							"first_name": attr,
+							"user_type": "Website User",
+							"send_welcome_email": False,
+						}
+					)
+					for role in roles:
+						user.append("roles", {"role": role})
+					user.insert(ignore_permissions=True)
+				setattr(cls, attr, frappe._dict(email=email))
+		finally:
+			frappe.flags.in_import = original_in_import
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		# Only the availability rows are test state; the users stay put so reruns
+		# don't churn through the creation quota.
+		for email, _roles in cls.USERS.values():
+			if frappe.db.exists("Course Evaluator", email):
+				frappe.delete_doc("Course Evaluator", email, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		self.schedule = self._reset_evaluator_doc(self.evaluator.email)
+		self.other_schedule = self._reset_evaluator_doc(self.other_evaluator.email)
+
+		self.original_user = frappe.session.user
+		self.addCleanup(self._restore_user)
+
+	def _restore_user(self):
+		frappe.session.user = self.original_user
+
+	def _reset_evaluator_doc(self, evaluator):
+		"""One known slot per test — the tests add, edit and delete rows."""
+		if frappe.db.exists("Course Evaluator", evaluator):
+			doc = frappe.get_doc("Course Evaluator", evaluator)
+			doc.schedule = []
+		else:
+			doc = frappe.new_doc("Course Evaluator")
+			doc.evaluator = evaluator
+		doc.unavailable_from = None
+		doc.unavailable_to = None
+		doc.append("schedule", {"day": "Monday", "start_time": "09:00:00", "end_time": "10:00:00"})
+		doc.save(ignore_permissions=True)
+		return doc
+
+	def _slot_of(self, doc):
+		return frappe.get_doc("Course Evaluator", doc.name).schedule[0].name
+
+	# --- own availability ------------------------------------------------
+
+	def test_evaluator_can_add_their_own_slot(self):
+		frappe.session.user = self.evaluator.email
+		add_evaluator_slot(self.evaluator.email, "Tuesday", "11:00:00", "12:00:00")
+
+		days = [row.day for row in frappe.get_doc("Course Evaluator", self.evaluator.email).schedule]
+		self.assertIn("Tuesday", days)
+
+	def test_evaluator_can_update_their_own_slot(self):
+		frappe.session.user = self.evaluator.email
+		update_evaluator_slot(self.evaluator.email, self._slot_of(self.schedule), "day", "Friday")
+
+		self.assertEqual(frappe.get_doc("Course Evaluator", self.evaluator.email).schedule[0].day, "Friday")
+
+	def test_evaluator_can_delete_their_own_slot(self):
+		frappe.session.user = self.evaluator.email
+		delete_evaluator_slot(self.evaluator.email, self._slot_of(self.schedule))
+
+		self.assertEqual(len(frappe.get_doc("Course Evaluator", self.evaluator.email).schedule), 0)
+
+	def test_evaluator_can_set_their_own_unavailability(self):
+		frappe.session.user = self.evaluator.email
+		set_evaluator_unavailability(self.evaluator.email, "unavailable_from", "2026-08-01")
+
+		self.assertEqual(
+			str(frappe.db.get_value("Course Evaluator", self.evaluator.email, "unavailable_from")),
+			"2026-08-01",
+		)
+
+	# --- other people's availability -------------------------------------
+
+	def test_course_creator_cannot_add_a_slot_for_someone_else(self):
+		"""The probe that found this: a Course Creator, who cannot even open the
+		Slots tab, could write to any evaluator's calendar."""
+		frappe.session.user = self.course_creator.email
+		with self.assertRaises(frappe.PermissionError):
+			add_evaluator_slot(self.evaluator.email, "Wednesday", "09:00:00", "10:00:00")
+
+	def test_course_creator_cannot_set_someone_elses_unavailability(self):
+		frappe.session.user = self.course_creator.email
+		with self.assertRaises(frappe.PermissionError):
+			set_evaluator_unavailability(self.evaluator.email, "unavailable_to", "2026-09-01")
+
+	def test_evaluator_cannot_write_a_peers_availability(self):
+		frappe.session.user = self.other_evaluator.email
+		with self.assertRaises(frappe.PermissionError):
+			add_evaluator_slot(self.evaluator.email, "Thursday", "09:00:00", "10:00:00")
+
+	def test_student_cannot_write_availability(self):
+		frappe.session.user = self.student.email
+		with self.assertRaises(frappe.PermissionError):
+			add_evaluator_slot(self.evaluator.email, "Friday", "09:00:00", "10:00:00")
+
+	def test_moderator_may_edit_anyones_availability(self):
+		frappe.session.user = self.moderator.email
+		add_evaluator_slot(self.evaluator.email, "Saturday", "09:00:00", "10:00:00")
+
+		days = [row.day for row in frappe.get_doc("Course Evaluator", self.evaluator.email).schedule]
+		self.assertIn("Saturday", days)
+
+	# --- redirected writes ------------------------------------------------
+
+	def test_slot_write_cannot_be_redirected_at_another_evaluators_row(self):
+		"""Passing your own name but someone else's slot must not slip through
+		the ownership check."""
+		frappe.session.user = self.evaluator.email
+		foreign_slot = self._slot_of(self.other_schedule)
+
+		with self.assertRaises(frappe.PermissionError):
+			update_evaluator_slot(self.evaluator.email, foreign_slot, "day", "Sunday")
+
+	def test_slot_delete_cannot_be_redirected_at_another_evaluators_row(self):
+		frappe.session.user = self.evaluator.email
+		foreign_slot = self._slot_of(self.other_schedule)
+
+		with self.assertRaises(frappe.PermissionError):
+			delete_evaluator_slot(self.evaluator.email, foreign_slot)
+
+	# --- input validation --------------------------------------------------
+
+	def test_fieldname_outside_the_allowlist_is_rejected(self):
+		frappe.session.user = self.evaluator.email
+		with self.assertRaises(frappe.ValidationError):
+			update_evaluator_slot(self.evaluator.email, self._slot_of(self.schedule), "parent", "x")
+
+	def test_unavailability_fieldname_outside_the_allowlist_is_rejected(self):
+		frappe.session.user = self.evaluator.email
+		with self.assertRaises(frappe.ValidationError):
+			set_evaluator_unavailability(self.evaluator.email, "evaluator", "someone@else.com")
+
+	def test_non_string_evaluator_is_rejected(self):
+		frappe.session.user = self.evaluator.email
+		for bad in (["a"], {"b": 1}, 7, ""):
+			with self.assertRaises((frappe.ValidationError, frappe.exceptions.FrappeTypeError)):
+				add_evaluator_slot(bad, "Monday", "09:00:00", "10:00:00")
+
+	def test_unknown_slot_is_rejected(self):
+		frappe.session.user = self.evaluator.email
+		with self.assertRaises((frappe.DoesNotExistError, frappe.PermissionError)):
+			update_evaluator_slot(self.evaluator.email, "does-not-exist", "day", "Monday")
+
+	def test_invalid_day_is_rejected(self):
+		frappe.session.user = self.evaluator.email
+		with self.assertRaises(frappe.ValidationError):
+			add_evaluator_slot(self.evaluator.email, "Noonday", "09:00:00", "10:00:00")

--- a/lms/tests/security/test_profile_details.py
+++ b/lms/tests/security/test_profile_details.py
@@ -1,0 +1,101 @@
+import frappe
+
+from lms.lms.api import get_profile_details
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestProfileDetails(BaseTestUtils):
+	"""`get_profile_details` checked `has_lms_role()` against the *caller*, so a
+	user holding no LMS role could not load their own profile page. Every user
+	created through the LMS picks up `LMS Student` via the `before_insert` hook,
+	but users created in Desk, by Data Import or by another app do not — they hit
+	a dead profile.
+
+	Widening that must not reopen the username-enumeration hole the earlier
+	security work closed: a caller with no LMS role still gets the same
+	PermissionError whether or not the username exists.
+	"""
+
+	USERS = {
+		"member": ("profile-member@example.com", ["LMS Student"], "profilemember"),
+		"roleless": ("profile-roleless@example.com", [], "profileroleless"),
+	}
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		original_in_import = frappe.flags.in_import
+		frappe.flags.in_import = True
+		try:
+			for attr, (email, roles, username) in cls.USERS.items():
+				if not frappe.db.exists("User", email):
+					user = frappe.new_doc("User")
+					user.update(
+						{
+							"email": email,
+							"first_name": attr,
+							"username": username,
+							"user_type": "Website User",
+							"send_welcome_email": False,
+						}
+					)
+					for role in roles:
+						user.append("roles", {"role": role})
+					user.insert(ignore_permissions=True)
+				# The LMS before_insert hook grants LMS Student; strip it back off
+				# so "no LMS role" really means none. `frappe.get_roles` memoises
+				# per user, so the cache has to go too or the role lingers.
+				if not roles:
+					frappe.db.delete("Has Role", {"parent": email})
+					frappe.clear_cache(user=email)
+				frappe.db.set_value("User", email, "username", username, update_modified=False)
+				setattr(cls, attr, frappe._dict(email=email, username=username))
+		finally:
+			frappe.flags.in_import = original_in_import
+		frappe.db.commit()
+
+	def setUp(self):
+		super().setUp()
+		self.original_user = frappe.session.user
+		self.addCleanup(self._restore_user)
+
+	def _restore_user(self):
+		frappe.session.user = self.original_user
+
+	def test_user_without_an_lms_role_can_load_their_own_profile(self):
+		frappe.session.user = self.roleless.email
+		details = get_profile_details(self.roleless.username)
+
+		self.assertEqual(details.name, self.roleless.email)
+
+	def test_user_without_an_lms_role_cannot_load_someone_elses(self):
+		frappe.session.user = self.roleless.email
+		with self.assertRaises(frappe.PermissionError):
+			get_profile_details(self.member.username)
+
+	def test_lms_member_can_load_another_profile(self):
+		frappe.session.user = self.member.email
+		details = get_profile_details(self.roleless.username)
+
+		self.assertEqual(details.name, self.roleless.email)
+
+	def test_unknown_username_does_not_leak_existence_to_a_roleless_caller(self):
+		"""Same error for a real username and a made-up one, so the endpoint
+		can't be used to enumerate accounts."""
+		frappe.session.user = self.roleless.email
+
+		with self.assertRaises(frappe.PermissionError):
+			get_profile_details(self.member.username)
+		with self.assertRaises(frappe.PermissionError):
+			get_profile_details("no-such-username-at-all")
+
+	def test_unknown_username_raises_does_not_exist_for_a_member(self):
+		frappe.session.user = self.member.email
+		with self.assertRaises(frappe.DoesNotExistError):
+			get_profile_details("no-such-username-at-all")
+
+	def test_non_string_username_is_rejected(self):
+		frappe.session.user = self.member.email
+		for bad in (["a"], {"b": 1}, 7, "", "   "):
+			with self.assertRaises((frappe.ValidationError, frappe.exceptions.FrappeTypeError)):
+				get_profile_details(bad)

--- a/lms/unsplash.py
+++ b/lms/unsplash.py
@@ -1,28 +1,30 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from urllib.parse import quote, urlencode
+
 import frappe
 
 base_url = "https://api.unsplash.com"
 
 
 def get_by_keyword(keyword):
-	data = make_unsplash_request(f"/search/photos?query={keyword}")
-	return data.get("results")
+	data = make_unsplash_request(f"/search/photos?query={quote(keyword)}")
+	return (data or {}).get("results") or []
 
 
 def get_list():
-	return make_unsplash_request("/photos")
+	return make_unsplash_request("/photos") or []
 
 
 def get_random(params=None):
-	query_string = ""
-	for key, value in params.items():
-		query_string += f"{key}={value}&"
-	return make_unsplash_request(f"/photos/random?{query_string}")
+	return make_unsplash_request(f"/photos/random?{urlencode(params or {})}")
 
 
 def make_unsplash_request(path):
+	"""Return None when the integration is unconfigured. Callers that hand the
+	result to the UI must coerce that to an empty result — an unconfigured site
+	is the default, not an error."""
 	unsplash_access_key = frappe.db.get_single_value("LMS Settings", "unsplash_access_key")
 	if not unsplash_access_key:
 		return


### PR DESCRIPTION
## Summary

Eight small fixes, three independent areas.

**Editor**
- Bold works in every block, including headings (EditorJS's `execCommand` bold un-bolded inside an already-bold heading).
- Headings and the lesson title are single-line again — Enter inserted a break that the sanitizer then dropped, gluing words together.

**Profile**
- Closes an IDOR: any Course Creator could write another evaluator's availability with no LMS role can open their own profile.
- The cover-image picker no longer breaks when no Unsplash key is set.

**Payments**
- LMS no longer pre-creates the Razorpay order; the payments app's controller owns that.

**Course editor**
- Student View stops leaking instructor affordances into the preview.