### PR TITLE
fix(link): Open link in new tab to avoid context

### DIFF
--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -65,11 +65,8 @@ import Quiz from '@/components/QuizBlock.vue'
 import PdfBlock from '@/components/PdfBlock.vue'
 import MarkdownIt from 'markdown-it'
 import { useScreenSize } from '@/utils/composables'
-<<<<<<< Updated upstream
 import { getMacroArg } from '@/utils/lessonMacros'
-=======
 import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
->>>>>>> Stashed changes
 
 const screenSize = useScreenSize()
 

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -64,9 +64,12 @@
 import Quiz from '@/components/QuizBlock.vue'
 import PdfBlock from '@/components/PdfBlock.vue'
 import MarkdownIt from 'markdown-it'
-import DOMPurify from 'dompurify'
 import { useScreenSize } from '@/utils/composables'
+<<<<<<< Updated upstream
 import { getMacroArg } from '@/utils/lessonMacros'
+=======
+import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
+>>>>>>> Stashed changes
 
 const screenSize = useScreenSize()
 
@@ -75,7 +78,11 @@ const markdown = new MarkdownIt({
 	linkify: true,
 })
 
-const renderSafe = (block) => DOMPurify.sanitize(markdown.render(block))
+// Route markdown output through the shared sanitizer so the anchor-target
+// hook (open in new tab) and form-tag blocklist are applied uniformly with
+// the rest of the LMS render pipelines. Keeps one source of truth for what
+// counts as safe user-authored HTML.
+const renderSafe = (block) => sanitizeRichHTML(markdown.render(block))
 
 const props = defineProps({
 	content: {

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -545,6 +545,14 @@ const renderEditor = (holder, content) => {
 		i18n: {
 			direction: document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr',
 		},
+		onReady() {
+			const root = document.getElementById(holder)
+			if (!root) return
+			root.querySelectorAll('a').forEach((a) => {
+				a.setAttribute('target', '_blank')
+				a.setAttribute('rel', 'noopener noreferrer')
+			})
+		},
 	})
 }
 

--- a/frontend/src/tests/sanitizeRichHTML.test.ts
+++ b/frontend/src/tests/sanitizeRichHTML.test.ts
@@ -34,8 +34,32 @@ describe('sanitizeRichHTML', () => {
 		expect(out).toMatch(/<div class="prose">/)
 		expect(out).toMatch(/<table>/)
 		expect(out).toMatch(/<th>A<\/th>/)
-		expect(out).toMatch(/<a href="https:\/\/docs\.frappe\.io\/learning">/)
+		// The anchor now carries target/rel injected by the afterSanitizeAttributes
+		// hook — assert the href is preserved without pinning attribute order.
+		expect(out).toMatch(/<a\s[^>]*href="https:\/\/docs\.frappe\.io\/learning"/)
 		expect(out).toMatch(/<img src="https:\/\/example\.test\/a\.png">/)
+	})
+
+	it('opens all anchors in a new tab with safe rel', () => {
+		// Bare <a href> (as produced by EditorJS's built-in link tool) must
+		// gain target="_blank" and rel="noopener noreferrer" so lesson /
+		// quiz / assignment / course-description hyperlinks don't navigate
+		// away in the current tab.
+		const out = sanitizeRichHTML('<a href="https://example.test">click</a>')
+		expect(out).toMatch(/target="_blank"/)
+		expect(out).toMatch(/rel="noopener noreferrer"/)
+	})
+
+	it('overrides existing target/rel on anchors', () => {
+		// Even if the source specifies target="_self" or a different rel,
+		// the hook normalises to _blank + noopener noreferrer.
+		const out = sanitizeRichHTML(
+			'<a href="https://example.test" target="_self" rel="nofollow">click</a>',
+		)
+		expect(out).toMatch(/target="_blank"/)
+		expect(out).toMatch(/rel="noopener noreferrer"/)
+		expect(out).not.toMatch(/target="_self"/)
+		expect(out).not.toMatch(/rel="nofollow"/)
 	})
 
 	it('handles empty/null input', () => {

--- a/frontend/src/utils/sanitizeRichHTML.ts
+++ b/frontend/src/utils/sanitizeRichHTML.ts
@@ -9,9 +9,25 @@ import DOMPurify from 'dompurify'
 //
 // Kept in its own lean module (only pulls in DOMPurify) so it stays
 // importable/testable without index.js's heavy EditorJS/frappe-ui import chain.
+
+
+const purifier = DOMPurify()
+
+// Force every rendered anchor to open in a new tab with safe rel attributes.
+// EditorJS's built-in link inline tool creates bare <a href> anchors via
+// document.execCommand('createLink'), and DOMPurify strips `target` by default.
+// Together that means lesson/quiz/assignment hyperlinks navigate away in the 
+// current tab — students lose their context.
+purifier.addHook('afterSanitizeAttributes', (node) => {
+	if (node.tagName === 'A') {
+		node.setAttribute('target', '_blank')
+		node.setAttribute('rel', 'noopener noreferrer')
+	}
+})
+
 export const sanitizeRichHTML = (html?: string | null): string => {
 	if (!html) return ''
-	return DOMPurify.sanitize(html, {
+	return purifier.sanitize(html, {
 		FORBID_TAGS: [
 			'form',
 			'input',


### PR DESCRIPTION
closes: #2486 

This issue was discussed in one of the local conference here and I tried fixing this issue.

Things i have verified:

- Checked if editorjs offered out of the box option to open in new tab. But it doesn't support it
- https://github.com/trinhtam/editorjs-hyperlink/tree/master offers hyperlink option that I didn't try in this approach
- This solution only fixes the problem in the render side by DOM sanitization. The stored DOM will have anchor tag without any attributes. so export of this data may not preserve this function. 

Let me know if this can be handled in better way.

cc: @raizasafeel 