### PR TITLE
chore: Now, mon[dot]school domain is not owned by Frappe Team.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 Frappe Learning is an easy-to-use learning system that helps you bring structure to your content.
 
 ### Motivation
-In 2021, we were looking for a Learning Management System to launch [Mon.School](https://mon.school) for FOSS United. We checked out Moodle, but it didn’t feel right. The forms were unnecessarily lengthy and the UI was confusing. It shouldn't be this hard to create a course right? So I started making a learning system for Mon.School which soon became a product in itself. The aim is to have a simple platform that anyone can use to launch a course of their own and make knowledge sharing easier.
+In 2021, we were looking for a Learning Management System to launch ~~Mon.School~~[^1] for FOSS United. We checked out Moodle, but it didn’t feel right. The forms were unnecessarily lengthy and the UI was confusing. It shouldn't be this hard to create a course right? So I started making a learning system ~~for Mon.School which soon became a product in itself~~. The aim is to have a simple platform that anyone can use to launch a course of their own and make knowledge sharing easier.
+
+[^1]: ~~Mon.School~~ __*Now this domain is not owned by Frappe Team.*__
 
 ### Key Features
 


### PR DESCRIPTION
Now, mon[dot]school domain is not owned by Frappe Team.