### PR TITLE
feat: make student view a real route instead of editor mode

### DIFF
--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -264,7 +264,7 @@ function lessonRoute(lesson: OutlineLesson): RouteLocationRaw {
 			name: 'CourseDetail',
 			params: { courseName: props.courseName },
 			hash: '#course editor',
-			query: { editLesson: lesson.number, lessonMode: 'edit' },
+			query: { editLesson: lesson.number },
 		}
 	}
 	return {

--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -335,7 +335,7 @@ function navigateToLesson(lesson: OutlineLesson) {
 			name: 'CourseDetail',
 			params: { courseName: props.courseName },
 			hash: '#course editor',
-			query: { editLesson: lesson.number, lessonMode: 'edit' },
+			query: { editLesson: lesson.number },
 		})
 	}
 }

--- a/frontend/src/components/StudentLessonSidebar.vue
+++ b/frontend/src/components/StudentLessonSidebar.vue
@@ -59,6 +59,7 @@
 														chapterNumber: lesson.number.split('-')[0],
 														lessonNumber: lesson.number.split('-')[1],
 													},
+													query: studentViewQuery,
 											  }
 									"
 									class="flex w-full items-center gap-3 rounded ps-9 pe-3 py-2 text-start text-sm leading-5 text-ink-gray-8 hover:bg-surface-gray-2"
@@ -101,6 +102,7 @@
 
 <script setup>
 import { computed, watch, watchEffect } from 'vue'
+import { useRoute } from 'vue-router'
 import { createResource } from 'frappe-ui'
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import {
@@ -127,6 +129,13 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['select-lesson'])
+
+// Keep ?studentView=1 across lesson hops, or a moderator previewing the course
+// silently reverts to their own identity on the first sidebar click.
+const route = useRoute()
+const studentViewQuery = computed(() =>
+	route.query.studentView === '1' ? { studentView: 1 } : undefined
+)
 
 const outline = createResource({
 	url: 'lms.lms.utils.get_course_outline',

--- a/frontend/src/pages/Batches/BatchDetail.vue
+++ b/frontend/src/pages/Batches/BatchDetail.vue
@@ -73,7 +73,7 @@
 					</Button>
 				</Tooltip>
 				<Button
-					v-if="isAdmin"
+					v-if="isAdmin && currentTabLabel === 'Settings'"
 					variant="outline"
 					:theme="batch.data?.published ? 'red' : 'gray'"
 					:loading="publishToggle.loading"

--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -41,7 +41,7 @@
 					<!-- Edit mode autosaves continuously, so there is no Save
 					     button or dirty badge here. -->
 					<Tooltip
-						v-if="courseEditorRef?.lessonHasVideo && editorMode !== 'preview'"
+						v-if="courseEditorRef?.lessonHasVideo"
 						:text="__('Video Statistics')"
 					>
 						<Button
@@ -54,10 +54,7 @@
 							</template>
 						</Button>
 					</Tooltip>
-					<Tooltip
-						v-if="editorMode !== 'preview'"
-						:text="__('How to edit a lesson')"
-					>
+					<Tooltip :text="__('How to edit a lesson')">
 						<Button
 							variant="ghost"
 							:label="__('How to edit a lesson')"
@@ -68,20 +65,24 @@
 							</template>
 						</Button>
 					</Tooltip>
-					<Button
-						variant="outline"
-						@click="editorMode = editorMode === 'preview' ? 'edit' : 'preview'"
+					<router-link
+						:to="{
+							name: 'Lesson',
+							params: {
+								courseName: props.courseName,
+								chapterNumber: editorSelected.chapterNumber,
+								lessonNumber: editorSelected.lessonNumber,
+							},
+							query: { studentView: 1 },
+						}"
 					>
-						<template #prefix>
-							<span v-if="editorMode === 'preview'" class="lucide-x size-4" />
-							<span v-else class="lucide-eye size-4" />
-						</template>
-						{{
-							editorMode === 'preview'
-								? __('Close student view')
-								: __('Student View')
-						}}
-					</Button>
+						<Button variant="outline">
+							<template #prefix>
+								<span class="lucide-eye size-4" />
+							</template>
+							{{ __('Student View') }}
+						</Button>
+					</router-link>
 				</template>
 				<Button
 					v-if="tabIndex === 1 && course.data"
@@ -119,7 +120,6 @@
 							ref="courseEditorRef"
 							:course="course"
 							v-model:selected="editorSelected"
-							v-model:mode="editorMode"
 						/>
 						<CourseForm
 							v-else-if="tab.component === CourseForm"
@@ -136,7 +136,7 @@
 				</template>
 			</Tabs>
 			<div
-				v-if="tabIndex === 2 && course.data && editorMode === 'edit'"
+				v-if="tabIndex === 2 && course.data"
 				class="pointer-events-none absolute inset-x-0 top-0 z-10 hidden md:flex"
 			>
 				<div class="w-[70%]" />
@@ -210,7 +210,6 @@ interface EditorSelection {
 }
 
 const editorSelected = ref<EditorSelection | null>(null)
-const editorMode = ref<'edit' | 'preview'>('edit')
 const showLessonHelp = ref(false)
 
 // Settings tab (CourseForm) exposes the API the LayoutHeader actions need.
@@ -234,13 +233,7 @@ const courseFormRef = ref<CourseFormApi | null>(null)
 type CourseEditorApi = {
 	saveSelectedLesson: () => void
 	isDirty: ComputedRef<boolean>
-	hasPrev: ComputedRef<boolean>
-	hasNext: ComputedRef<boolean>
-	canGoZen: ComputedRef<boolean>
 	lessonHasVideo: ComputedRef<boolean>
-	previewPrev: () => void
-	previewNext: () => void
-	previewZen: () => void
 	openVideoStats: () => void
 	openAddChapter: () => void
 }

--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -95,7 +95,7 @@
 					{{ __('Enroll') }}
 				</Button>
 				<Button
-					v-if="user.data?.is_moderator"
+					v-if="tabIndex === 3 && user.data?.is_moderator"
 					:variant="course.data?.published ? 'outline' : 'solid'"
 					:theme="course.data?.published ? 'red' : 'gray'"
 					:loading="publishToggle.loading"

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -283,8 +283,12 @@ watch(
 // unmounts us, and the strip must not re-fire on its own replace.
 let legacyLessonModeHandled = false
 watch(
-	[() => route.query.lessonMode, () => selected.value?.number],
-	([lessonMode, selectedNumber]) => {
+	[
+		() => route.query.lessonMode,
+		() => selected.value?.number,
+		() => props.course?.data?.name,
+	],
+	([lessonMode, selectedNumber, courseName]) => {
 		if (legacyLessonModeHandled || !lessonMode) return
 		if (lessonMode !== 'preview') {
 			legacyLessonModeHandled = true
@@ -292,7 +296,6 @@ watch(
 			router.replace({ query, hash: route.hash || '#course editor' })
 			return
 		}
-		const courseName = props.course?.data?.name
 		const number = route.query.editLesson || selectedNumber
 		if (!courseName || !number) return
 		const [chapterNumber, lessonNumber] = String(number).split('-')

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -16,25 +16,13 @@
 					</div>
 				</div>
 				<LessonForm
-					v-else-if="mode === 'edit'"
+					v-else
 					ref="lessonFormRef"
 					:key="`edit-${selected.number}`"
 					:courseName="props.course.data.name"
 					:chapterNumber="selected.chapterNumber"
 					:lessonNumber="selected.lessonNumber"
 					@saved="onLessonSaved"
-				/>
-				<Lesson
-					v-else
-					ref="lessonViewRef"
-					:key="`preview-${selected.number}`"
-					:courseName="props.course.data.name"
-					:chapterNumber="selected.chapterNumber"
-					:lessonNumber="selected.lessonNumber"
-					:embedded="true"
-					@select-lesson="onSelectLesson"
-					@lesson-completed="onLessonCompleted"
-					@progress-updated="onProgressUpdated"
 				/>
 			</div>
 		</div>
@@ -43,16 +31,6 @@
 			<SkeletonLoader
 				v-if="outline.loading && !outline.data"
 				variant="editor-sidebar"
-			/>
-			<StudentLessonSidebar
-				v-else-if="mode === 'preview' && props.course?.data"
-				:courseName="props.course.data.name"
-				:courseTitle="props.course.data.title"
-				:progress="progressPercent"
-				:selectedLessonNumber="selected?.number"
-				:completedLesson="completedLesson"
-				:inlineSelect="true"
-				@select-lesson="onSelectLesson"
 			/>
 			<CourseOutline
 				v-else-if="props.course?.data"
@@ -77,16 +55,13 @@
 </template>
 
 <script setup>
-import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createResource } from 'frappe-ui'
 import { useSidebar } from '@/stores/sidebar'
-import { provideStudentView } from '@/composables/useStudentView'
 import CourseOutline from '@/components/CourseOutline.vue'
-import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import LessonForm from '@/pages/LessonForm.vue'
-import Lesson from '@/pages/Lesson.vue'
 import VideoStatistics from '@/components/Modals/VideoStatistics.vue'
 import {
 	findLessonNameByNumber,
@@ -100,17 +75,8 @@ const props = defineProps({
 })
 
 const selected = defineModel('selected', { default: null })
-const mode = defineModel('mode', { default: 'edit' })
 const route = useRoute()
 const router = useRouter()
-
-// Student View swaps in the real Lesson.vue but the components below it still
-// injected the real `$user`, so instructor affordances (grading, instructor
-// notes, zen mode) stayed visible. Shadow `$user` for this subtree while the
-// preview is on. The provide is unconditional; the value tracks `mode`, so
-// leaving preview restores the real flags without a remount.
-const realUser = inject('$user')
-provideStudentView(realUser, () => mode.value === 'preview')
 
 // Collapse the app sidebar while the lesson editor is open to give the
 // editing surface room, then restore it on leaving the tab. Mirrors the
@@ -123,29 +89,15 @@ onBeforeUnmount(() => {
 	sidebarStore.isSidebarCollapsed = false
 })
 
-// Keep ?editLesson + ?lessonMode in sync with what's selected so a refresh,
-// tab-switch round-trip, or shared URL lands on the same lesson in the same
-// mode. Guard against route-watcher → selected-watcher loops by comparing
-// values before replacing.
+// Keep ?editLesson in sync with what's selected so a refresh, tab-switch
+// round-trip, or shared URL lands on the same lesson. Guard against
+// route-watcher → selected-watcher loops by comparing values before
+// replacing.
 function syncSelectedToUrl(number) {
 	if (!number) return
-	const nextLessonMode = mode.value
-	if (
-		route.query.editLesson === number &&
-		route.query.lessonMode === nextLessonMode
-	)
-		return
+	if (route.query.editLesson === number) return
 	router.replace({
-		query: { ...route.query, editLesson: number, lessonMode: nextLessonMode },
-		hash: route.hash || '#course editor',
-	})
-}
-
-function syncModeToUrl(newMode) {
-	if (!selected.value || !newMode) return
-	if (route.query.lessonMode === newMode) return
-	router.replace({
-		query: { ...route.query, lessonMode: newMode },
+		query: { ...route.query, editLesson: number },
 		hash: route.hash || '#course editor',
 	})
 }
@@ -315,8 +267,7 @@ watch(
 
 // React to a deep-link change while the editor tab is already open.
 // Trust the query — a non-existent number means "new lesson", which
-// LessonForm renders in create mode. Mode is its own param so clicking
-// a lesson in preview keeps the user in preview.
+// LessonForm renders in create mode.
 watch(
 	() => route.query.editLesson,
 	(number) => {
@@ -325,41 +276,38 @@ watch(
 	}
 )
 
+// ?lessonMode is a dead param: student view used to be a mode of this editor
+// and is now the lesson route. Send an old `preview` link to that route once
+// a lesson number is resolvable, and strip any other value so it can't linger
+// in the query that syncSelectedToUrl copies forward. One-shot — a redirect
+// unmounts us, and the strip must not re-fire on its own replace.
+let legacyLessonModeHandled = false
 watch(
-	() => route.query.lessonMode,
-	(next) => {
-		if (next === 'edit' || next === 'preview') mode.value = next
+	[() => route.query.lessonMode, () => selected.value?.number],
+	([lessonMode, selectedNumber]) => {
+		if (legacyLessonModeHandled || !lessonMode) return
+		if (lessonMode !== 'preview') {
+			legacyLessonModeHandled = true
+			const { lessonMode: _dropped, ...query } = route.query
+			router.replace({ query, hash: route.hash || '#course editor' })
+			return
+		}
+		const courseName = props.course?.data?.name
+		const number = route.query.editLesson || selectedNumber
+		if (!courseName || !number) return
+		const [chapterNumber, lessonNumber] = String(number).split('-')
+		if (!chapterNumber || !lessonNumber) return
+		legacyLessonModeHandled = true
+		router.replace({
+			name: 'Lesson',
+			params: { courseName, chapterNumber, lessonNumber },
+			query: { studentView: 1 },
+		})
 	},
 	{ immediate: true }
 )
 
-watch(mode, (next) => {
-	syncModeToUrl(next)
-})
-
-// Live progress posted up from the embedded Lesson preview after a
-// save_progress success or a realtime `update_lesson_progress` event.
-// Prefer it over the stale `course.data.membership.progress` snapshot,
-// which is fetched once and never refreshed in this view.
-const liveProgress = ref(null)
-const progressPercent = computed(() => {
-	const p = liveProgress.value ?? props.course?.data?.membership?.progress
-	return p ? Math.ceil(p) : 0
-})
-
 const lessonFormRef = ref(null)
-const lessonViewRef = ref(null)
-
-// Lesson name that the embedded preview just marked complete — passed to
-// StudentLessonSidebar so its green tick flips immediately instead of
-// only after a refetch of the outline.
-const completedLesson = ref(null)
-function onLessonCompleted(name) {
-	completedLesson.value = name
-}
-function onProgressUpdated(value) {
-	if (typeof value === 'number') liveProgress.value = value
-}
 
 function saveSelectedLesson() {
 	lessonFormRef.value?.saveLesson?.()
@@ -367,47 +315,12 @@ function saveSelectedLesson() {
 
 const isDirty = computed(() => Boolean(lessonFormRef.value?.isDirty))
 
-// Preview-mode header controls, surfaced up to CourseDetail's top bar so
-// the moderator gets the same Prev / Next / Zen affordances students do.
-// hasPrev/hasNext are derived from the outline (already loaded) instead of
-// the embedded Lesson child — otherwise the buttons flicker out on every
-// navigation while the child remounts and refetches.
-const flatLessonNumbers = computed(() =>
-	(outline.data ?? []).flatMap((c) => c.lessons?.map((l) => l.number) ?? [])
-)
-const selectedIndex = computed(() =>
-	selected.value?.number
-		? flatLessonNumbers.value.indexOf(selected.value.number)
-		: -1
-)
-const hasPrev = computed(() => selectedIndex.value > 0)
-const hasNext = computed(
-	() =>
-		selectedIndex.value >= 0 &&
-		selectedIndex.value < flatLessonNumbers.value.length - 1
-)
-const canGoZen = computed(() => Boolean(lessonViewRef.value?.canGoZen?.()))
-function previewPrev() {
-	lessonViewRef.value?.switchLesson?.('prev')
-}
-function previewNext() {
-	lessonViewRef.value?.switchLesson?.('next')
-}
-function previewZen() {
-	lessonViewRef.value?.goFullScreen?.()
-}
-// The active lesson component differs by mode: the editor form when editing,
-// the embedded lesson view when previewing. Both expose lessonHasVideo/name/
-// title, so the Video Statistics affordance works the same in either mode.
-const activeLessonRef = computed(() =>
-	mode.value === 'edit' ? lessonFormRef.value : lessonViewRef.value
-)
 const lessonHasVideo = computed(() =>
-	Boolean(activeLessonRef.value?.lessonHasVideo?.())
+	Boolean(lessonFormRef.value?.lessonHasVideo?.())
 )
 const showStats = ref(false)
-const statsLessonName = computed(() => activeLessonRef.value?.lessonName?.())
-const statsLessonTitle = computed(() => activeLessonRef.value?.lessonTitle?.())
+const statsLessonName = computed(() => lessonFormRef.value?.lessonName?.())
+const statsLessonTitle = computed(() => lessonFormRef.value?.lessonTitle?.())
 function openVideoStats() {
 	showStats.value = true
 }
@@ -420,13 +333,7 @@ function openAddChapter() {
 defineExpose({
 	saveSelectedLesson,
 	isDirty,
-	hasPrev,
-	hasNext,
-	canGoZen,
 	lessonHasVideo,
-	previewPrev,
-	previewNext,
-	previewZen,
 	openVideoStats,
 	openAddChapter,
 })

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -1,7 +1,6 @@
 <template>
 	<div v-if="lesson.data" class="">
 		<header
-			v-if="!embedded"
 			class="sticky top-0 z-10 flex items-center justify-between border-b bg-surface-base px-3 py-2.5 sm:px-5"
 		>
 			<Breadcrumbs class="h-7" :items="breadcrumbs" />
@@ -14,15 +13,25 @@
 					</Button>
 				</Tooltip>
 				<CertificationLinks :courseName="courseName" />
+				<router-link
+					v-if="canEditLesson"
+					:to="{
+						name: 'CourseDetail',
+						params: { courseName: courseName },
+						hash: '#course editor',
+						query: { editLesson: `${chapterNumber}-${lessonNumber}` },
+					}"
+				>
+					<Button>
+						<template #prefix>
+							<span class="lucide-pencil size-4" />
+						</template>
+						{{ __('Editor view') }}
+					</Button>
+				</router-link>
 			</div>
 		</header>
-		<div
-			:class="
-				embedded
-					? 'grid grid-cols-1 h-full'
-					: 'grid md:grid-cols-[70%,30%] h-[94vh]'
-			"
-		>
+		<div class="grid md:grid-cols-[70%,30%] h-[94vh]">
 			<div v-if="lesson.data.no_preview" class="border-e">
 				<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
 					<div class="flex items-center justify-center mt-4 gap-x-2">
@@ -106,26 +115,7 @@
 								v-if="!zenModeEnabled"
 								class="flex items-center gap-x-2 mt-2 md:mt-0"
 							>
-								<router-link
-									v-if="isAdmin && !embedded"
-									:to="{
-										name: 'CourseDetail',
-										params: { courseName: courseName },
-										hash: '#course editor',
-										query: {
-											editLesson: `${chapterNumber}-${lessonNumber}`,
-											lessonMode: 'edit',
-										},
-									}"
-								>
-									<Button>
-										<template #prefix>
-											<span class="lucide-pencil size-4" />
-										</template>
-										{{ __('Edit') }}
-									</Button>
-								</router-link>
-								<Tooltip v-else-if="canGoZen()" :text="__('Zen Mode')">
+								<Tooltip v-if="canGoZen()" :text="__('Zen Mode')">
 									<Button @click="goFullScreen()" :label="__('Zen Mode')">
 										<template #icon>
 											<span class="lucide-focus size-4" />
@@ -290,7 +280,7 @@
 					</div>
 				</div>
 			</div>
-			<div v-if="!embedded" class="sticky top-10 h-[94vh]">
+			<div class="sticky top-10 h-[94vh]">
 				<StudentLessonSidebar
 					:courseName="courseName"
 					:courseTitle="lesson.data.course_title"
@@ -308,12 +298,6 @@
 		:lesson="lesson.data?.name"
 		v-model:notes="notes"
 		@updateNotes="updateNotes"
-	/>
-	<VideoStatistics
-		v-if="isAdmin"
-		v-model="showStatsDialog"
-		:lessonName="lesson.data?.name"
-		:lessonTitle="lesson.data?.title"
 	/>
 </template>
 <script setup>
@@ -360,28 +344,33 @@ import CourseInstructors from '@/components/CourseInstructors.vue'
 import ProgressBar from '@/components/ProgressBar.vue'
 import Discussions from '@/components/Discussions.vue'
 import CertificationLinks from '@/components/CertificationLinks.vue'
-import VideoStatistics from '@/components/Modals/VideoStatistics.vue'
-import { hasVideoContent } from '@/utils/video'
 import CourseOutline from '@/components/CourseOutline.vue'
 import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import Notes from '@/components/Notes/Notes.vue'
 import InlineLessonMenu from '@/components/Notes/InlineLessonMenu.vue'
 import { getLmsRoute } from '@/utils/basePath'
-import { useStudentView } from '@/composables/useStudentView'
+import { provideStudentView } from '@/composables/useStudentView'
 
-const user = inject('$user')
-const isStudentView = useStudentView()
-const socket = inject('$socket')
 const router = useRouter()
 const route = useRoute()
+const realUser = inject('$user')
+// A component's own provide() is invisible to its own inject(), so read the
+// handles provideStudentView returns rather than calling useStudentView().
+const { isStudentView, mockedUser } = provideStudentView(
+	realUser,
+	() => route.query.studentView === '1'
+)
+// Shadows every user.data read below and in every child, so the page renders
+// exactly what a student sees.
+const user = mockedUser
+const socket = inject('$socket')
 const allowDiscussions = ref(false)
 const editor = ref(null)
 const instructorEditor = ref(null)
 const lessonProgress = ref(0)
 const lessonContainer = ref(null)
 const zenModeEnabled = ref(false)
-const showStatsDialog = ref(false)
 const hasQuiz = ref(false)
 const discussionsContainer = ref(null)
 const timer = ref(0)
@@ -409,31 +398,6 @@ const props = defineProps({
 		type: String,
 		required: true,
 	},
-	embedded: {
-		type: Boolean,
-		default: false,
-	},
-})
-
-const emit = defineEmits([
-	'select-lesson',
-	'lesson-completed',
-	'progress-updated',
-])
-
-// Exposed for the parent so the CourseEditor preview can render the same
-// Prev / Next / Zen-mode controls as the student header but place them in
-// the page-level LayoutHeader instead of inside the lesson body.
-defineExpose({
-	switchLesson: (direction) => switchLesson(direction),
-	goFullScreen: () => goFullScreen(),
-	canGoZen: () => canGoZen(),
-	hasPrev: computed(() => Boolean(lesson.data?.prev)),
-	hasNext: computed(() => Boolean(lesson.data?.next)),
-	lessonHasVideo: () => lessonHasVideo.value,
-	showVideoStats: () => showVideoStats(),
-	lessonName: () => lesson.data?.name,
-	lessonTitle: () => lesson.data?.title,
 })
 
 let collapsedByLesson = false
@@ -444,7 +408,7 @@ onMounted(() => {
 	startTimer()
 	// Keep the app sidebar open for admins/instructors so they can navigate
 	// while reviewing; only collapse it for students to maximise reading space.
-	if (!props.embedded && !isCourseAdmin()) {
+	if (!isCourseAdmin()) {
 		sidebarStore.isSidebarCollapsed = true
 		collapsedByLesson = true
 	}
@@ -452,7 +416,6 @@ onMounted(() => {
 	socket.on('update_lesson_progress', (data) => {
 		if (data.course === props.courseName) {
 			lessonProgress.value = data.progress
-			emit('progress-updated', data.progress)
 		}
 	})
 })
@@ -471,8 +434,7 @@ const attachFullscreenEvent = () => {
 
 onBeforeUnmount(() => {
 	document.removeEventListener('fullscreenchange', attachFullscreenEvent)
-	if (!props.embedded && collapsedByLesson)
-		sidebarStore.isSidebarCollapsed = false
+	if (collapsedByLesson) sidebarStore.isSidebarCollapsed = false
 	trackVideoWatchDuration()
 })
 
@@ -599,13 +561,7 @@ const progress = createResource({
 	},
 	onSuccess(data) {
 		lessonProgress.value = data
-		const name = lesson.data?.name
-		completedLesson.value = name
-		// Tell the parent (CourseEditor preview) so it can flip the
-		// sidebar's green tick and update the percentage without waiting
-		// for a refresh of the course resource.
-		if (name) emit('lesson-completed', name)
-		emit('progress-updated', data)
+		completedLesson.value = lesson.data?.name
 	},
 })
 
@@ -654,13 +610,6 @@ const switchLesson = (direction) => {
 			: lesson.data.next.split('.')
 
 	const [chapterNumber, lessonNumber] = lessonIndex
-	// In the embedded editor preview, navigate the parent's selection so the
-	// pane swaps in place instead of routing away to /lesson/...
-	if (props.embedded) {
-		emit('select-lesson', { chapterNumber, lessonNumber })
-		return
-	}
-
 	router.push({
 		name: 'Lesson',
 		params: {
@@ -906,9 +855,9 @@ let videoFallbackArmed = false
 let fallbackGeneration = 0
 const fallbackToDwellTimer = (reason) => {
 	// The dwell fallback only matters for an enrolled student tracking progress.
-	// Don't surface the "mark as viewed" toast in the course editor preview or to
+	// Don't surface the "mark as viewed" toast in student view or to
 	// non-enrolled viewers (admins/instructors reviewing the lesson).
-	if (props.embedded || !lesson.data?.membership) return
+	if (isStudentView.value || !lesson.data?.membership) return
 	if (videoFallbackArmed) return
 	videoFallbackArmed = true
 	console.warn('[Lesson] video fallback engaged:', reason)
@@ -973,10 +922,12 @@ const isAdmin = computed(() => {
 	return user.data?.is_moderator || isInstructor
 })
 
-// The video-statistics button only makes sense when the lesson actually has a
-// video; showing it for text-only lessons opened an empty modal and logged a
-// console error.
-const lessonHasVideo = computed(() => hasVideoContent(lesson.data))
+// Reads the real user, not the student-view shadow, so the way back to the
+// editor survives ?studentView=1.
+const canEditLesson = computed(() => {
+	const isInstructor = lesson.data?.instructors?.includes(realUser.data?.name)
+	return realUser.data?.is_moderator || isInstructor
+})
 
 const allowInstructorContent = () => {
 	if (window.read_only_mode) return false
@@ -1018,10 +969,6 @@ const toggleInlineMenu = async () => {
 	if (selection.toString()) {
 		showInlineMenu.value = true
 	}
-}
-
-const showVideoStats = () => {
-	showStatsDialog.value = true
 }
 
 const canGoZen = () => {

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -590,6 +590,7 @@ const breadcrumbs = computed(() => {
 				chapterNumber: props.chapterNumber,
 				lessonNumber: props.lessonNumber,
 			},
+			query: studentViewQuery.value,
 		},
 	})
 	return crumbs
@@ -610,6 +611,7 @@ const switchLesson = (direction) => {
 			chapterNumber,
 			lessonNumber,
 		},
+		query: studentViewQuery.value,
 	})
 }
 
@@ -914,6 +916,13 @@ const isAdmin = computed(() => {
 	let isInstructor = lesson.data?.instructors?.includes(user.data?.name)
 	return user.data?.is_moderator || isInstructor
 })
+
+// Student view is a mode, not a destination: every hop that stays on a lesson
+// has to carry the flag, or Prev / Next / the sidebar silently drops the
+// moderator back into their own identity mid-course.
+const studentViewQuery = computed(() =>
+	isStudentView.value ? { studentView: 1 } : undefined
+)
 
 // Reads the real user, not the student-view shadow, so the way back to the
 // editor survives ?studentView=1.

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -5,13 +5,6 @@
 		>
 			<Breadcrumbs class="h-7" :items="breadcrumbs" />
 			<div class="flex items-center gap-x-2">
-				<Tooltip v-if="canGoZen() && isAdmin" :text="__('Zen Mode')">
-					<Button @click="goFullScreen()" :label="__('Zen Mode')">
-						<template #icon>
-							<span class="lucide-focus size-4" />
-						</template>
-					</Button>
-				</Tooltip>
 				<CertificationLinks :courseName="courseName" />
 				<router-link
 					v-if="canEditLesson"
@@ -22,11 +15,11 @@
 						query: { editLesson: `${chapterNumber}-${lessonNumber}` },
 					}"
 				>
-					<Button>
+					<Button variant="outline">
 						<template #prefix>
 							<span class="lucide-pencil size-4" />
 						</template>
-						{{ __('Editor view') }}
+						{{ __('Editor View') }}
 					</Button>
 				</router-link>
 			</div>

--- a/frontend/src/tests/studentView.test.ts
+++ b/frontend/src/tests/studentView.test.ts
@@ -1,12 +1,12 @@
 /**
- * Tests for Student View — the lesson-editor preview that shows a course as a
- * learner sees it.
+ * Tests for Student View — `?studentView=1` on the lesson route, which shows a
+ * course as a learner sees it.
  *
- * The preview swapped in the real Lesson.vue but every component under it kept
- * injecting the real `$user`, whose `is_moderator` / `is_instructor` /
+ * The lesson page renders the same components for everyone, and each of them
+ * injects the real `$user`, whose `is_moderator` / `is_instructor` /
  * `is_evaluator` flags stay true. The visible consequence was Assignment.vue's
- * Grading panel: a moderator who submitted the assignment inside the preview
- * was immediately offered the Grade select and could grade themselves.
+ * Grading panel: a moderator who submitted the assignment in student view was
+ * immediately offered the Grade select and could grade themselves.
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { defineComponent, h, inject, ref } from 'vue'
@@ -143,5 +143,108 @@ describe('provideStudentView', () => {
 		})
 
 		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('false')
+	})
+})
+
+/**
+ * Lesson.vue now owns the shadow itself: it injects the app-wide `$user`,
+ * calls provideStudentView on that, and binds the returned `mockedUser`. This
+ * models that arrangement, including the "Editor view" gate reading the real
+ * user through its own inject.
+ */
+const LessonStandIn = defineComponent({
+	props: { studentViewQuery: { type: String, default: undefined } },
+	setup(props) {
+		const realUser = inject<{ data?: Record<string, unknown> }>('$user')!
+		const { isStudentView, mockedUser } = provideStudentView(
+			realUser,
+			() => props.studentViewQuery === '1'
+		)
+		const user = mockedUser
+		// The real user, not the shadow — this is what gates "Editor view".
+		const ownInjected = inject<{ data?: Record<string, unknown> }>('$user')
+		const selfInjectedFlag = useStudentView()
+		return () =>
+			h('div', [
+				h(
+					'span',
+					{ 'data-testid': 'own-can-edit' },
+					String(Boolean(ownInjected?.data?.is_moderator))
+				),
+				h(
+					'span',
+					{ 'data-testid': 'own-real-user' },
+					String(Boolean(realUser.data?.is_moderator))
+				),
+				h(
+					'span',
+					{ 'data-testid': 'own-shadowed-user' },
+					String(Boolean(user.data?.is_moderator))
+				),
+				h(
+					'span',
+					{ 'data-testid': 'own-student-view' },
+					String(isStudentView.value)
+				),
+				h(
+					'span',
+					{ 'data-testid': 'own-self-injected' },
+					String(selfInjectedFlag.value)
+				),
+				h(GradingProbe),
+			])
+	},
+})
+
+function mountLesson(studentViewQuery?: string) {
+	return mount(LessonStandIn, {
+		props: { studentViewQuery },
+		global: { provide: { $user: { data: { ...MODERATOR } } } },
+	})
+}
+
+describe('a component that provides Student View to itself', () => {
+	it('shadows $user for its children when the query flag is on', () => {
+		const wrapper = mountLesson('1')
+
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('false')
+		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('true')
+	})
+
+	it('leaves its children on the real $user when the flag is off', () => {
+		const wrapper = mountLesson(undefined)
+
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('true')
+		expect(wrapper.get('[data-testid="student-view"]').text()).toBe('false')
+	})
+
+	it('still injects the real $user itself, so the way back stays visible', () => {
+		const wrapper = mountLesson('1')
+
+		expect(wrapper.get('[data-testid="own-can-edit"]').text()).toBe('true')
+		expect(wrapper.get('[data-testid="own-real-user"]').text()).toBe('true')
+		expect(wrapper.get('[data-testid="own-shadowed-user"]').text()).toBe(
+			'false'
+		)
+	})
+
+	it('cannot read its own flag back through useStudentView', () => {
+		const wrapper = mountLesson('1')
+
+		expect(wrapper.get('[data-testid="own-student-view"]').text()).toBe('true')
+		expect(wrapper.get('[data-testid="own-self-injected"]').text()).toBe(
+			'false'
+		)
+	})
+
+	it('flips the shadow when the query changes, without a remount', async () => {
+		const wrapper = mountLesson(undefined)
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('true')
+
+		await wrapper.setProps({ studentViewQuery: '1' })
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('false')
+
+		await wrapper.setProps({ studentViewQuery: undefined })
+		expect(wrapper.get('[data-testid="can-grade"]').text()).toBe('true')
 	})
 })

--- a/frontend/src/tests/studentViewNavigation.test.ts
+++ b/frontend/src/tests/studentViewNavigation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Student view is a mode carried in the URL (`?studentView=1`), not a
+ * destination, so every hop that stays on a lesson has to preserve it. The
+ * sidebar's lesson links dropped it, which silently returned a previewing
+ * moderator to their own identity on the first click — grading panels and
+ * instructor notes reappearing mid-course with no visible cause.
+ */
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
+
+const query = vi.hoisted(() => ({ current: {} as Record<string, unknown> }))
+
+vi.mock('vue-router', () => ({
+	useRoute: () => ({ params: {}, query: query.current }),
+	useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('frappe-ui', () => ({
+	createResource: () => ({
+		data: [
+			{
+				name: 'CH-1',
+				title: 'Chapter 1',
+				lessons: [
+					{ name: 'LESSON-1', title: 'Lesson 1', number: '1-1' },
+					{ name: 'LESSON-2', title: 'Lesson 2', number: '1-2' },
+				],
+			},
+		],
+		loading: false,
+		reload: vi.fn(),
+		fetch: vi.fn(),
+	}),
+	Progress: { template: `<div />` },
+}))
+
+vi.mock('@headlessui/vue', () => ({
+	Disclosure: { template: `<div><slot :open="true" /></div>` },
+	DisclosureButton: { template: `<button><slot /></button>` },
+	DisclosurePanel: { template: `<div><slot /></div>` },
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+function mountSidebar() {
+	return mount(StudentLessonSidebar, {
+		props: { courseName: 'course-1', courseTitle: 'Course 1' },
+		global: {
+			mocks: { __: (s: string) => s },
+			stubs: { 'router-link': RouterLinkStub },
+		},
+	})
+}
+
+function lessonLinkTargets(wrapper: ReturnType<typeof mountSidebar>) {
+	return wrapper
+		.findAllComponents(RouterLinkStub)
+		.map((link) => link.props('to') as Record<string, any>)
+		.filter((to) => to?.name === 'Lesson')
+}
+
+describe('StudentLessonSidebar lesson links', () => {
+	it('carries ?studentView=1 onward while previewing', () => {
+		query.current = { studentView: '1' }
+
+		const targets = lessonLinkTargets(mountSidebar())
+
+		expect(targets.length).toBeGreaterThan(0)
+		for (const to of targets) {
+			expect(to.query).toEqual({ studentView: 1 })
+		}
+	})
+
+	it('leaves the query off for an ordinary student', () => {
+		query.current = {}
+
+		const targets = lessonLinkTargets(mountSidebar())
+
+		expect(targets.length).toBeGreaterThan(0)
+		for (const to of targets) {
+			expect(to.query).toBeUndefined()
+		}
+	})
+
+	it('ignores a studentView value that is not the flag', () => {
+		query.current = { studentView: '0' }
+
+		for (const to of lessonLinkTargets(mountSidebar())) {
+			expect(to.query).toBeUndefined()
+		}
+	})
+})


### PR DESCRIPTION
- "Student View" in the course editor was `editorMode === 'preview'` which was a second lesson surface living inside CourseEditor.vue. 
- It now navigates to that page: /courses/:course/learn/:ch-:lesson with ?studentView=1 so no new views.
- Also removes Lesson.vue's `embedded` prop and its three preview-only emits, made publish button only show on settings page and removed zen mode from student header