### PR TITLE
 fix: make the LMS usable on a phone: tab bar, one scroller per list, honest counts

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -26,6 +26,7 @@ declare module 'vue' {
     BatchCourseModal: typeof import('./src/components/Modals/BatchCourseModal.vue')['default']
     BlockEditor: typeof import('./src/components/BlockEditor.vue')['default']
     BooleanSwitch: typeof import('./src/components/Controls/BooleanSwitch.vue')['default']
+    BottomSheet: typeof import('./src/components/BottomSheet.vue')['default']
     BrandSettings: typeof import('./src/components/Settings/BrandSettings.vue')['default']
     Categories: typeof import('./src/components/Settings/Categories.vue')['default']
     CertificationLinks: typeof import('./src/components/CertificationLinks.vue')['default']

--- a/frontend/src/components/BottomSheet.vue
+++ b/frontend/src/components/BottomSheet.vue
@@ -1,0 +1,126 @@
+<template>
+	<Teleport to="body">
+		<Transition name="sheet-backdrop">
+			<div
+				v-if="modelValue"
+				class="fixed inset-0 z-40 bg-black/40"
+				@click="close"
+			/>
+		</Transition>
+		<Transition name="sheet-panel">
+			<div
+				v-if="modelValue"
+				ref="panel"
+				class="standalone:pb-4 fixed inset-x-0 bottom-0 z-40 flex max-h-[85vh] flex-col rounded-t-2xl bg-surface-base shadow-2xl"
+				:style="panelStyle"
+				role="dialog"
+				aria-modal="true"
+			>
+				<!-- Drag handle -->
+				<div
+					ref="handle"
+					class="flex shrink-0 cursor-grab justify-center pb-1 pt-3 active:cursor-grabbing"
+				>
+					<div class="h-1 w-9 rounded-full bg-surface-gray-4" />
+				</div>
+
+				<!-- Header -->
+				<div
+					v-if="title || $slots.header"
+					class="flex shrink-0 items-start justify-between gap-3 px-5 pb-3 pt-1"
+				>
+					<slot name="header">
+						<div class="text-p-lg-semibold text-ink-gray-9">{{ title }}</div>
+					</slot>
+				</div>
+
+				<!-- Body -->
+				<div class="flex-1 overflow-y-auto overscroll-contain px-2 pb-4">
+					<slot />
+				</div>
+			</div>
+		</Transition>
+	</Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useScrollLock, useSwipe, useEventListener } from '@vueuse/core'
+
+const props = defineProps({
+	modelValue: {
+		type: Boolean,
+		default: false,
+	},
+	title: {
+		type: String,
+		default: '',
+	},
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const panel = ref(null)
+const handle = ref(null)
+
+function close() {
+	emit('update:modelValue', false)
+}
+
+// Lock the page behind the sheet so scrolling the list doesn't scroll the
+// lesson underneath it.
+const bodyLock = useScrollLock(
+	typeof document !== 'undefined' ? document.body : null
+)
+watch(
+	() => props.modelValue,
+	(open) => {
+		bodyLock.value = open
+	}
+)
+
+// Esc closes, matching the backdrop tap.
+useEventListener(document, 'keydown', (e) => {
+	if (props.modelValue && e.key === 'Escape') close()
+})
+
+// Swipe-down on the handle drags the panel and closes it past a threshold.
+const dragOffset = ref(0)
+const { lengthY, isSwiping } = useSwipe(handle, {
+	onSwipe() {
+		// lengthY = startY - currentY, so a downward drag is negative; only
+		// follow downward motion and never let the sheet drift upward.
+		const down = -lengthY.value
+		dragOffset.value = down > 0 ? down : 0
+	},
+	onSwipeEnd() {
+		if (dragOffset.value > 80) close()
+		dragOffset.value = 0
+	},
+})
+
+const panelStyle = computed(() => ({
+	transform: dragOffset.value ? `translateY(${dragOffset.value}px)` : '',
+	transition: isSwiping.value ? 'none' : '',
+}))
+</script>
+
+<style scoped>
+.sheet-backdrop-enter-active,
+.sheet-backdrop-leave-active {
+	transition: opacity 200ms ease;
+}
+.sheet-backdrop-enter-from,
+.sheet-backdrop-leave-to {
+	opacity: 0;
+}
+
+.sheet-panel-enter-active,
+.sheet-panel-leave-active {
+	transition: transform 250ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.sheet-panel-enter-from,
+.sheet-panel-leave-to {
+	transform: translateY(100%);
+}
+</style>

--- a/frontend/src/components/Layouts/DesktopLayout.vue
+++ b/frontend/src/components/Layouts/DesktopLayout.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="flex h-screen w-screen">
+	<div class="flex h-dvh w-screen">
 		<a
 			href="#main-content"
 			@click.prevent="skipToContent('main-content')"

--- a/frontend/src/components/Layouts/ListPage.vue
+++ b/frontend/src/components/Layouts/ListPage.vue
@@ -28,14 +28,11 @@
 			v-if="loading && !rows.length"
 			:variant="skeletonVariant"
 			:count="8"
-			class="min-h-0 flex-1 overflow-y-auto px-5 pb-5"
+			class="px-5 pb-5"
 		/>
 		<!-- The cards own the scroll box at every width, which is what leaves the
 		     header above and the footer below them both in place. -->
-		<div
-			v-else-if="rows.length && layout === 'grid'"
-			class="min-h-0 flex-1 overflow-y-auto px-5 pb-5"
-		>
+		<div v-else-if="rows.length && layout === 'grid'" class="px-5 pb-5">
 			<div
 				class="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
 			>

--- a/frontend/src/components/Layouts/ListPageBody.vue
+++ b/frontend/src/components/Layouts/ListPageBody.vue
@@ -1,14 +1,44 @@
 <template>
-	<!-- The shell every list page puts under its header. `min-h-0` is what lets
-	     the rows inside own the scroll box instead of growing the page: a flex
-	     child otherwise refuses to shrink below its content, so the page grows
-	     and takes the header with it out of view. Said once here rather than as
-	     a breakpoint variant on every list page. -->
-	<div class="flex min-h-0 flex-1 flex-col">
-		<slot />
+	<!-- The shell every list page puts under its header.
+
+	     On a desk `min-h-0` is what lets the rows inside own the scroll box
+	     instead of growing the page: a flex child otherwise refuses to shrink
+	     below its content, so the page grows and takes the header with it out
+	     of view.
+
+	     A phone must not do that. A scroll box nested inside the page means the
+	     page itself has no scroll range, and a browser only retracts its URL
+	     bar when the root scroller moves — so the bottom of the viewport stays
+	     unreachable however far you swipe. Below `sm` this grows with its
+	     content instead and MobileLayout's #scrollContainer does the scrolling;
+	     the header and footer hold their place with `sticky`, which needs no
+	     measuring and cannot drift. -->
+	<div class="flex flex-1 flex-col sm:min-h-0">
+		<!-- The title and filters scroll with the rows, at every width: they
+		     belong to the list, and a page that holds them still spends a third
+		     of a phone screen on controls the reader has already used. Only the
+		     app header above and the footer below stay put. -->
+		<div class="flex flex-1 flex-col sm:min-h-0 sm:overflow-y-auto">
+			<slot />
+		</div>
 		<!-- Sits under the rows, which scroll behind it, rather than at the end
-		     of them. shrink-0 so a long list cannot squeeze it away. -->
-		<div v-if="$slots.footer" class="shrink-0">
+		     of them: the page size and Load More are how you work a long list,
+		     so they stay put while you do. On a desk being the last flex child
+		     of a bounded column is enough, and shrink-0 stops a long list
+		     squeezing it away.
+
+		     On a phone it takes both. `sticky` holds it once the rows overflow
+		     and scroll under it; `mt-auto` puts it on the bottom edge when they
+		     do not, because a short list leaves the column with slack that
+		     nothing else claims and the strip would otherwise stop wherever the
+		     last row happened to end. The raised surface is the Espresso token
+		     for something content scrolls beneath, the one ListHeader uses where
+		     MappingListTable pins it. -->
+
+		<div
+			v-if="$slots.footer"
+			class="sticky bottom-0 z-10 mt-auto shrink-0 bg-surface-elevation-1 sm:static sm:mt-0"
+		>
 			<slot name="footer" />
 		</div>
 	</div>

--- a/frontend/src/components/Layouts/ListPageHeader.vue
+++ b/frontend/src/components/Layouts/ListPageHeader.vue
@@ -2,11 +2,19 @@
 	<!-- The title + filters strip every list page repeats. Spacing and
 	     breakpoints live here so a fix lands on all of them at once.
 
-	     This block does not scroll: it and the app header above it stay put at
-	     every width, and only the rows behind them move. Nothing here may grow
-	     past its content, or it eats the space the rows scroll in. -->
+	     It scrolls with the rows, at every width, and is never pinned: it
+	     belongs to the list rather than to the page chrome, and holding it still
+	     spends a third of a phone screen on controls the reader has already
+	     used. Only the app header above and the footer below stay put.
+
+	     Pinning it here would also be the old bug back: LayoutHeader is `sticky
+	     top-0` in the same scroller, so a second `sticky top-0` lands underneath
+	     it and loses its first 49px, and the offset that would clear it is the
+	     app header's own content height — the measurement that drifted and
+	     opened a band. It gets a rule on a phone instead, where it runs the full
+	     width and the rows begin straight under it. -->
 	<div
-		class="shrink-0 mb-5 flex flex-col justify-between px-5 pt-5 md:flex-row"
+		class="mb-5 flex shrink-0 flex-col justify-between border-b px-5 pb-4 pt-5 sm:border-b-0 sm:pb-0 md:flex-row"
 	>
 		<h1 class="text-lg-semibold text-ink-gray-9 mb-4 md:mb-0">
 			<slot name="title">{{ title }}</slot>

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -175,7 +175,7 @@ const isInstructor = ref(false)
 const isSignedIn = Boolean(user)
 const showMoreTab = hasMoreTab(isSignedIn)
 const primaryTabs = computed(() =>
-	pickPrimaryTabs(sidebarLinks.value, isSignedIn)
+	pickPrimaryTabs(sidebarLinks.value, isSignedIn, sidebarSettings.data)
 )
 
 const menuSections = computed(() =>

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="relative flex h-screen flex-col">
+	<!-- h-dvh, not h-screen: 100vh is the URL-bar-retracted viewport, so the tab
+	     bar sits below the visible area on a phone. Nothing above main scrolls,
+	     so the browser never retracts the bar to give that band back. -->
+	<div class="relative flex h-dvh flex-col">
 		<a
 			href="#scrollContainer"
 			@click.prevent="skipToContent('scrollContainer')"
@@ -7,51 +10,87 @@
 		>
 			{{ __('Skip to main content') }}
 		</a>
+		<!-- min-h-0 lets this flex child actually shrink so its own overflow
+		     scrolls. The tab bar below is a sibling in normal flow, not fixed, so
+		     main simply ends where the bar begins — padding can't do that job
+		     here, because Chromium drops a flex column's bottom padding from the
+		     scrollable area and the last row stays hidden under the bar. -->
 		<main
-			class="flex flex-1 flex-col overflow-y-auto pb-10 focus:outline-none"
+			class="flex min-h-0 flex-1 flex-col overflow-y-auto focus:outline-none"
 			id="scrollContainer"
 			tabindex="-1"
 		>
 			<slot />
 		</main>
 
-		<div class="relative z-20">
-			<!-- Dropdown menu -->
-			<div
-				id="mobileMoreMenu"
-				class="fixed bottom-16 end-2 w-[80%] space-y-4 rounded-md bg-surface-base p-5 text-base shadow-md"
-				v-show="showMenu"
-				ref="menu"
-			>
-				<button
-					v-for="link in otherLinks"
-					:key="link.label"
-					type="button"
-					class="flex w-full cursor-pointer items-center gap-x-2"
-					@click="handleClick(link)"
-				>
-					<component
-						:is="icons[link.icon]"
-						class="h-4 w-4 stroke-1.5 text-ink-gray-5"
-					/>
-					<div>{{ link.label }}</div>
-				</button>
-			</div>
+		<div class="relative z-20 shrink-0">
+			<!-- More: the overflow destinations, grouped into sections. No header:
+			     the sheet opens from a button that already says what it is, and
+			     the sections name themselves. -->
+			<BottomSheet v-if="showMoreTab" v-model="showMenu">
+				<div class="px-3">
+					<template v-for="section in menuSections" :key="section.title">
+						<div
+							class="px-2 pb-1 pt-3 text-p-xs font-medium uppercase tracking-wide text-ink-gray-5"
+						>
+							{{ __(section.title) }}
+						</div>
+						<button
+							v-for="item in section.items"
+							:key="item.label"
+							type="button"
+							class="flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-start hover:bg-surface-gray-2 active:bg-surface-gray-3"
+							@click="handleClick(item)"
+						>
+							<span
+								class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-surface-gray-2"
+							>
+								<component
+									:is="icons[item.icon]"
+									class="size-4 stroke-1.5 text-ink-gray-7"
+								/>
+							</span>
+							<span class="min-w-0 flex-1">
+								<span
+									class="block truncate text-p-base font-medium text-ink-gray-8"
+								>
+									{{ __(item.label) }}
+								</span>
+								<span
+									v-if="subtitleFor(item.label)"
+									class="block truncate text-p-sm text-ink-gray-5"
+								>
+									{{ __(subtitleFor(item.label)) }}
+								</span>
+							</span>
+							<span
+								class="lucide-chevron-right size-4 shrink-0 text-ink-gray-4"
+							/>
+						</button>
+					</template>
+					<!-- Reachable only before the admin-configured links land, or if
+					     every destination is already on the bar. -->
+					<div
+						v-if="!menuSections.length"
+						class="py-10 text-center text-p-sm text-ink-gray-5"
+					>
+						{{ __('Nothing else here') }}
+					</div>
+				</div>
+			</BottomSheet>
 
-			<!-- Fixed menu -->
+			<!-- Bottom bar: a few primary tabs + More -->
 			<nav
-				v-if="sidebarSettings.data"
+				v-if="!showMoreTab || sidebarSettings.data"
 				:aria-label="__('Primary')"
-				class="standalone:pb-4 fixed bottom-0 start-0 z-10 flex w-full items-center justify-around border-t border-outline-gray-2 bg-surface-base"
+				class="standalone:pb-4 z-10 flex w-full items-stretch border-t border-outline-gray-2 bg-surface-base"
 			>
 				<button
-					v-for="tab in sidebarLinks"
+					v-for="tab in primaryTabs"
 					:key="tab.label"
 					type="button"
-					:aria-label="__(tab.label)"
 					:aria-current="isActive(tab) ? 'page' : undefined"
-					:class="isVisible(tab) ? 'block' : 'hidden'"
-					class="flex flex-col items-center justify-center py-3 transition active:scale-95"
+					class="flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-1 py-2 transition active:scale-95"
 					@click="handleClick(tab)"
 				>
 					<component
@@ -59,21 +98,43 @@
 						class="h-6 w-6 stroke-1.5"
 						:class="[isActive(tab) ? 'text-ink-gray-9' : 'text-ink-gray-5']"
 					/>
+					<span
+						class="max-w-full truncate text-p-xs"
+						:class="[
+							isActive(tab) ? 'font-medium text-ink-gray-9' : 'text-ink-gray-5',
+						]"
+					>
+						{{ __(tabLabel(tab.label)) }}
+					</span>
 				</button>
 				<button
+					v-if="showMoreTab"
 					type="button"
-					:aria-label="__('More')"
 					:aria-expanded="showMenu"
-					aria-controls="mobileMoreMenu"
+					aria-haspopup="dialog"
+					class="flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-1 py-2 transition active:scale-95"
 					@click="toggleMenu"
 				>
 					<component
-						:is="icons['List']"
-						class="h-6 w-6 stroke-1.5 text-ink-gray-5"
+						:is="icons['Ellipsis']"
+						class="h-6 w-6 stroke-1.5"
+						:class="[showMenu ? 'text-ink-gray-9' : 'text-ink-gray-5']"
 					/>
+					<span
+						class="max-w-full truncate text-p-xs"
+						:class="[
+							showMenu ? 'font-medium text-ink-gray-9' : 'text-ink-gray-5',
+						]"
+					>
+						{{ __('More') }}
+					</span>
 				</button>
 			</nav>
 		</div>
+
+		<!-- Mounted here as well as in the desk sidebar's UserDropdown: only one
+		     layout is alive at a time, so this never double-mounts. -->
+		<SettingsModal v-if="isModerator" v-model="settingsStore.isSettingsOpen" />
 	</div>
 </template>
 <script setup>
@@ -81,40 +142,49 @@ import { skipToContent } from '@/utils/a11y'
 import { getSidebarLinks } from '@/utils'
 import { useRouter } from 'vue-router'
 import { call } from 'frappe-ui'
-import { ref, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { sessionStore } from '@/stores/session'
 import { useSettings } from '@/stores/settings'
 import { usersStore } from '@/stores/user'
 import * as icons from 'lucide-vue-next'
 import { toggleNotifications } from '@/stores/notifications'
+import BottomSheet from '@/components/BottomSheet.vue'
+import SettingsModal from '@/components/Settings/Settings.vue'
+import {
+	buildMenuSections,
+	hasMoreTab,
+	pickPrimaryTabs,
+	subtitleFor,
+	tabLabel,
+} from '@/utils/mobileNav'
 
 const { logout, user } = sessionStore()
 let { isLoggedIn } = sessionStore()
-const { sidebarSettings, loadSidebarSettings } = useSettings()
+const settingsStore = useSettings()
+const { sidebarSettings, loadSidebarSettings } = settingsStore
 const router = useRouter()
 let { userResource } = usersStore()
 const sidebarLinks = ref([])
 const otherLinks = ref([])
 const showMenu = ref(false)
-const menu = ref(null)
 const isModerator = ref(false)
 const isInstructor = ref(false)
 
-const handleOutsideClick = (e) => {
-	if (menu.value && !menu.value.contains(e.target)) {
-		showMenu.value = false
-	}
-}
+// `user` comes from the session cookie synchronously, so the bar is settled
+// before the first paint; a signed-out visitor gets a static five, no More.
+const isSignedIn = Boolean(user)
+const showMoreTab = hasMoreTab(isSignedIn)
+const primaryTabs = computed(() =>
+	pickPrimaryTabs(sidebarLinks.value, isSignedIn)
+)
 
-watch(showMenu, (val) => {
-	if (val) {
-		setTimeout(() => {
-			document.addEventListener('click', handleOutsideClick)
-		}, 0)
-	} else {
-		document.removeEventListener('click', handleOutsideClick)
-	}
-})
+const menuSections = computed(() =>
+	buildMenuSections(
+		sidebarLinks.value,
+		otherLinks.value,
+		primaryTabs.value.map((tab) => tab.label)
+	)
+)
 
 const destructureSidebarLinks = () => {
 	let links = []
@@ -140,6 +210,10 @@ const addOtherLinks = () => {
 	if (user) {
 		addLink('Notifications', 'Bell', 'Notifications')
 		addLink('Profile', 'UserRound')
+		// The desk sidebar's UserDropdown is the only other way in, and it
+		// isn't rendered on a phone — without this, a moderator on mobile has
+		// no route to Settings at all.
+		if (isModerator.value) addLink('Settings', 'Settings')
 		addLink('Log out', 'LogOut')
 	} else {
 		addLink('Log in', 'LogIn')
@@ -230,7 +304,8 @@ let isActive = (tab) => {
 const handleClick = (tab) => {
 	if (tab.label == 'Notifications') {
 		toggleNotifications()
-		toggleMenu()
+	} else if (tab.label == 'Settings') {
+		settingsStore.isSettingsOpen = true
 	} else if (tab.label == 'Log in') window.location.href = '/login'
 	else if (tab.label == 'Log out')
 		logout.submit().then(() => {
@@ -244,12 +319,7 @@ const handleClick = (tab) => {
 			},
 		})
 	else router.push({ name: tab.to })
-}
-
-const isVisible = (tab) => {
-	if (tab.label == 'Log in') return !isLoggedIn
-	else if (tab.label == 'Log out') return isLoggedIn
-	else return true
+	showMenu.value = false
 }
 
 const toggleMenu = () => {

--- a/frontend/src/components/Layouts/NoSidebarLayout.vue
+++ b/frontend/src/components/Layouts/NoSidebarLayout.vue
@@ -8,7 +8,7 @@
 			{{ __('Skip to main content') }}
 		</a>
 		<div class="h-full flex-1">
-			<div class="flex h-screen text-base bg-surface-base">
+			<div class="flex h-dvh text-base bg-surface-base">
 				<main
 					class="w-full overflow-auto focus:outline-none"
 					id="scrollContainer"

--- a/frontend/src/components/ResponsiveListView.vue
+++ b/frontend/src/components/ResponsiveListView.vue
@@ -161,7 +161,11 @@ const { isMobile } = useScreenSize()
 // the grid sizes to its widest column and the list scrolls sideways on any
 // screen narrower than the sum of its columns; a list page should narrow its
 // columns instead, which is what the minmax tracks below make possible.
-const SCROLLING_BODY_CLASS = 'min-h-0 flex-1 !w-full overflow-y-auto pb-5'
+//
+// It never scrolls on its own. The list page's body owns the one scroll box, so
+// the filters above these rows travel with them; a box here would hold those
+// filters still and, on a phone, leave the page itself with no scroll range.
+const PAGE_BODY_CLASS = '!w-full pb-5'
 
 // frappe-ui sizes the selection banner for a desk (596px), which is wider than
 // a phone; unpinning that lets it wrap inside the viewport instead.
@@ -169,7 +173,7 @@ const MOBILE_BANNER_CLASS =
 	'!min-w-0 max-w-[calc(100vw-2rem)] flex-wrap gap-y-2'
 
 const layoutClass = computed(() =>
-	props.pageScroll ? SCROLLING_BODY_CLASS : '!w-full'
+	props.pageScroll ? PAGE_BODY_CLASS : '!w-full'
 )
 
 /**

--- a/frontend/src/pages/Batches/Batches.vue
+++ b/frontend/src/pages/Batches/Batches.vue
@@ -4,6 +4,7 @@
 		:title="__('All Batches')"
 		:rows="batches.data || []"
 		:loading="batches.list.loading"
+		:total-count="batchCount"
 		:has-next-page="batches.hasNextPage"
 		v-model:page-length="pageLength"
 		empty-name="Batches"
@@ -113,6 +114,7 @@
 import {
 	Button,
 	createListResource,
+	createResource,
 	Dropdown,
 	FormControl,
 	TabButtons,
@@ -195,6 +197,19 @@ const setCategories = (data) => {
 	}
 }
 
+// Upcoming and Archived are settled against the current time in Python rather
+// than in the query, and `enrolled` is not a field, so only the endpoint that
+// resolves both can say how many batches a tab really holds.
+const batchCountResource = createResource({
+	url: 'lms.lms.utils.get_batch_count',
+	makeParams: () => ({ filters: filters.value }),
+	onError: (error) => {
+		console.error(error)
+	},
+})
+
+const batchCount = computed(() => batchCountResource.data ?? null)
+
 const updateBatches = () => {
 	updateFilters()
 	batches.update({
@@ -204,6 +219,10 @@ const updateBatches = () => {
 	batches.reload().then((data) => {
 		setCategories(data)
 	})
+	// Nothing orders the responses, so a slow count for a tab the user has
+	// left would overwrite the current one.
+	batchCountResource.abort()
+	batchCountResource.submit()
 }
 
 const updateFilters = () => {

--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -1,11 +1,28 @@
 <template>
-	<div class="flex h-full flex-col">
+	<div
+		class="flex flex-col"
+		:class="flowsWithPage ? 'min-h-full shrink-0' : 'h-full'"
+	>
 		<LayoutHeader :isLoading="!course.data">
 			<template #left-header>
-				<Breadcrumbs class="h-7" :items="breadcrumbs" />
-				<Badge v-if="course.data?.published" theme="green">
-					{{ __('Published') }}
-				</Badge>
+				<!-- Breadcrumbs plus a badge do not fit 390px beside the actions, so
+				     a phone gets a single back-link carrying the course title. -->
+				<router-link
+					v-if="isMobile"
+					:to="{ name: 'Courses' }"
+					class="flex min-w-0 items-center gap-1 text-ink-gray-9"
+				>
+					<span class="lucide-chevron-left size-4 shrink-0" />
+					<span class="truncate text-p-base-medium">
+						{{ course.data?.title }}
+					</span>
+				</router-link>
+				<template v-else>
+					<Breadcrumbs class="h-7" :items="breadcrumbs" />
+					<Badge v-if="course.data?.published" theme="green">
+						{{ __('Published') }}
+					</Badge>
+				</template>
 			</template>
 			<template #right-header>
 				<template v-if="tabIndex === 3 && courseFormRef">
@@ -13,7 +30,7 @@
 						{{ __('Not Saved') }}
 					</Badge>
 					<Dropdown
-						:options="courseFormRef.courseMenu"
+						:options="courseOptions"
 						:button="{
 							icon: 'lucide-ellipsis',
 							variant: 'ghost',
@@ -27,13 +44,23 @@
 						:text="__('No changes to save')"
 						:hoverDelay="0.1"
 					>
-						<Button variant="solid" :disabled="true">
-							{{ __('Save') }}
+						<Button
+							variant="solid"
+							:disabled="true"
+							:class="isMobile ? '!size-9' : ''"
+						>
+							<span v-if="isMobile" class="lucide-save size-4" />
+							<span v-else>{{ __('Save') }}</span>
 						</Button>
 					</Tooltip>
 					<ShortcutTooltip v-else :label="__('Save')" combo="Mod+S">
-						<Button variant="solid" @click="courseFormRef.submitCourse()">
-							{{ __('Save') }}
+						<Button
+							variant="solid"
+							:class="isMobile ? '!size-9' : ''"
+							@click="courseFormRef.submitCourse()"
+						>
+							<span v-if="isMobile" class="lucide-save size-4" />
+							<span v-else>{{ __('Save') }}</span>
 						</Button>
 					</ShortcutTooltip>
 				</template>
@@ -47,6 +74,7 @@
 						<Button
 							variant="ghost"
 							:label="__('Video Statistics')"
+							:class="isMobile ? '!size-9' : ''"
 							@click="courseEditorRef?.openVideoStats()"
 						>
 							<template #icon>
@@ -54,7 +82,9 @@
 							</template>
 						</Button>
 					</Tooltip>
-					<Tooltip :text="__('How to edit a lesson')">
+					<!-- The help affordance is the first thing to go at 390px: the
+					     lesson stepper and Student View earn the space instead. -->
+					<Tooltip v-if="!isMobile" :text="__('How to edit a lesson')">
 						<Button
 							variant="ghost"
 							:label="__('How to edit a lesson')"
@@ -76,7 +106,15 @@
 							query: { studentView: 1 },
 						}"
 					>
-						<Button variant="outline">
+						<!-- Mobile: the label goes, the hit area stays thumb-sized. -->
+						<Tooltip v-if="isMobile" :text="__('Student View')">
+							<Button variant="outline" class="!size-9">
+								<template #icon>
+									<span class="lucide-eye size-4" />
+								</template>
+							</Button>
+						</Tooltip>
+						<Button v-else variant="outline">
 							<template #prefix>
 								<span class="lucide-eye size-4" />
 							</template>
@@ -85,7 +123,18 @@
 					</router-link>
 				</template>
 				<Button
-					v-if="tabIndex === 1 && course.data"
+					v-if="tabIndex === 1 && course.data && isMobile"
+					variant="outline"
+					class="!size-9"
+					:tooltip="__('Enroll')"
+					@click="courseDashboardRef?.openEnrollModal()"
+				>
+					<template #icon>
+						<span class="lucide-plus size-4" />
+					</template>
+				</Button>
+				<Button
+					v-else-if="tabIndex === 1 && course.data"
 					variant="outline"
 					@click="courseDashboardRef?.openEnrollModal()"
 				>
@@ -94,8 +143,12 @@
 					</template>
 					{{ __('Enroll') }}
 				</Button>
+				<!-- On a phone the publish toggle moves into the ... menu beside it,
+				     where it keeps a written label: an icon-only globe gives no hint
+				     that it publishes the course, and a labelled button does not fit
+				     beside Save and the rest at 390px. -->
 				<Button
-					v-if="tabIndex === 3 && user.data?.is_moderator"
+					v-if="tabIndex === 3 && user.data?.is_moderator && !isMobile"
 					:variant="course.data?.published ? 'outline' : 'solid'"
 					:theme="course.data?.published ? 'red' : 'gray'"
 					:loading="publishToggle.loading"
@@ -111,16 +164,82 @@
 			<CourseOverview v-if="course.data" :course="course" />
 			<SkeletonLoader v-else variant="course-page" />
 		</div>
-		<div v-else class="relative flex flex-1 min-h-0 flex-col">
-			<Tabs :tabs="tabs" v-model="tabIndex">
+		<div
+			v-else
+			class="relative flex flex-1 flex-col"
+			:class="{ 'min-h-0': !flowsWithPage }"
+		>
+			<Tabs
+				:tabs="tabs"
+				v-model="tabIndex"
+				class="course-tabs"
+				:class="{ 'page-flow': flowsWithPage }"
+			>
+				<!-- Mobile: drop the per-tab icon and shorten the editor label so
+				     all four tabs fit the viewport without horizontal scroll. -->
+				<template #tab-item="{ tab }">
+					<button
+						class="flex items-center gap-1.5 whitespace-nowrap py-2.5 text-p-base text-ink-gray-5 duration-300 ease-in-out hover:text-ink-gray-9 data-[state=active]:text-ink-gray-9"
+					>
+						<span
+							v-if="
+								!isMobile &&
+								typeof tab.icon === 'string' &&
+								tab.icon.startsWith('lucide-')
+							"
+							class="size-4"
+							:class="tab.icon"
+						/>
+						{{ tabDisplayLabel(tab.label) }}
+					</button>
+				</template>
 				<template #tab-panel="{ tab }">
 					<template v-if="course.data">
-						<CourseEditor
-							v-if="tab.component === CourseEditor"
-							ref="courseEditorRef"
-							:course="course"
-							v-model:selected="editorSelected"
-						/>
+						<template v-if="tab.component === CourseEditor">
+							<!-- Mobile editor: which lesson you are on, and prev/next.
+							     No completion bar — this is the authoring view, where a
+							     learner's progress means nothing. -->
+							<div
+								v-if="isMobile && editorSelected"
+								class="flex items-center gap-2 border-b bg-surface-base px-3 py-2"
+							>
+								<Button
+									variant="subtle"
+									class="!size-9"
+									:label="__('Previous lesson')"
+									:disabled="!courseEditorRef?.hasPrev"
+									@click="courseEditorRef?.goPrev()"
+								>
+									<template #icon>
+										<span class="lucide-chevron-left size-4" />
+									</template>
+								</Button>
+								<div
+									class="min-w-0 flex-1 text-center text-p-xs font-medium tabular-nums text-ink-gray-5"
+								>
+									<span v-if="courseEditorRef?.lessonTotal">
+										{{ courseEditorRef?.lessonIndex }} /
+										{{ courseEditorRef?.lessonTotal }}
+									</span>
+								</div>
+								<Button
+									variant="subtle"
+									class="!size-9"
+									:label="__('Next lesson')"
+									:disabled="!courseEditorRef?.hasNext"
+									@click="courseEditorRef?.goNext()"
+								>
+									<template #icon>
+										<span class="lucide-chevron-right size-4" />
+									</template>
+								</Button>
+							</div>
+							<CourseEditor
+								ref="courseEditorRef"
+								:course="course"
+								v-model:selected="editorSelected"
+							/>
+						</template>
 						<CourseForm
 							v-else-if="tab.component === CourseForm"
 							ref="courseFormRef"
@@ -135,6 +254,25 @@
 					</template>
 				</template>
 			</Tabs>
+
+			<!-- Chapters as a floating pill rather than a header icon: on a phone
+			     the outline is the control you reach for most while editing, and
+			     the bottom-right corner is where a thumb already is. Uses the
+			     ordinary outline Button so it carries espresso's surface, border
+			     and ink tokens instead of an ad-hoc dark fill. -->
+			<Button
+				v-if="isMobile && tabIndex === 2"
+				variant="outline"
+				size="md"
+				class="absolute bottom-4 end-4 z-10 !h-11 !rounded-full !px-4 !shadow-lg"
+				@click="courseEditorRef?.openChapters()"
+			>
+				<template #prefix>
+					<span class="lucide-layers size-4" />
+				</template>
+				{{ __('Chapters') }}
+			</Button>
+
 			<div
 				v-if="tabIndex === 2 && course.data"
 				class="pointer-events-none absolute inset-x-0 top-0 z-10 hidden md:flex"
@@ -174,6 +312,7 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 import { sessionStore } from '@/stores/session'
+import { useScreenSize } from '@/utils/composables'
 import LayoutHeader from '@/components/Layouts/LayoutHeader.vue'
 import CourseOverview from '@/pages/Courses/CourseOverview.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
@@ -201,6 +340,7 @@ const router: Router = useRouter()
 const route: RouteLocationNormalizedLoadedGeneric = useRoute()
 const user = inject<SessionUser>('$user')!
 const tabIndex: Ref<number> = ref(0)
+const { isMobile } = useScreenSize()
 
 interface EditorSelection {
 	chapterNumber: string
@@ -236,6 +376,13 @@ type CourseEditorApi = {
 	lessonHasVideo: ComputedRef<boolean>
 	openVideoStats: () => void
 	openAddChapter: () => void
+	lessonIndex: ComputedRef<number>
+	lessonTotal: ComputedRef<number>
+	hasPrev: ComputedRef<boolean>
+	hasNext: ComputedRef<boolean>
+	goPrev: () => void
+	goNext: () => void
+	openChapters: () => void
 }
 const courseEditorRef = ref<CourseEditorApi | null>(null)
 const courseDashboardRef = ref<{ openEnrollModal: () => void } | null>(null)
@@ -264,6 +411,23 @@ const publishToggle = createResource({
 		toast.error(msg)
 	},
 }) as Resource<unknown>
+
+// On a phone the publish toggle joins the ... menu, where it keeps a written
+// label — an icon-only globe gave no hint that it publishes the course.
+const courseOptions = computed<CourseMenuItem[]>(() => {
+	const menu = courseFormRef.value?.courseMenu ?? []
+	if (!isMobile.value || !user.data?.is_moderator) return menu
+	return [
+		{
+			label: course.data?.published
+				? __('Unpublish course')
+				: __('Publish course'),
+			icon: course.data?.published ? 'lucide-globe-lock' : 'lucide-globe',
+			onClick: () => togglePublishCourse(),
+		},
+		...menu,
+	]
+})
 
 function togglePublishCourse() {
 	publishToggle.submit()
@@ -332,6 +496,21 @@ const tabs = ref<TabDef[]>([
 	},
 ])
 
+// Overview and Settings are ordinary documents: on a phone they flow with the
+// page so MobileLayout's #scrollContainer stays the only scroller. The editor
+// is excluded — its `flex-1 min-h-0` grid needs a bounded panel to fill — and
+// so is the dashboard, which renders as it does today.
+function tabDisplayLabel(label: string): string {
+	if (isMobile.value && label === __('Course editor')) return __('Editor')
+	return label
+}
+
+const flowsWithPage = computed<boolean>(() => {
+	if (!isMobile.value) return false
+	const active = tabs.value[tabIndex.value]?.component
+	return active === CourseOverview || active === CourseForm
+})
+
 watch(
 	() => props.courseName,
 	() => {
@@ -398,5 +577,29 @@ usePageMeta(() => {
 :deep([role='tabpanel'][data-state='active']) {
 	flex: 1 1 0%;
 	min-height: 0;
+}
+
+/* ...except on the tabs that flow with the page: there the panel must size to
+   its content and let the overflow reach MobileLayout's #scrollContainer, so
+   both TabsRoot's `overflow-hidden` and TabsContent's `overflow-auto` are
+   released too. Without all three the panel stays a nested scroll box and the
+   page itself has no scroll range, which is what pins the URL bar open. */
+.course-tabs.page-flow {
+	overflow: visible;
+}
+
+.course-tabs.page-flow :deep([role='tabpanel'][data-state='active']) {
+	flex: none;
+	min-height: auto;
+	overflow: visible;
+}
+
+/* Mobile: tighten the tablist gap/padding so all four tabs fit the viewport
+   without horizontal scroll. */
+@media (max-width: 639px) {
+	.course-tabs :deep([role='tablist']) {
+		gap: 1rem;
+		padding-inline: 0.75rem;
+	}
 }
 </style>

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -27,7 +27,7 @@
 			</div>
 		</div>
 
-		<aside class="border-s overflow-y-auto">
+		<aside v-if="!isMobile" class="border-s overflow-y-auto">
 			<SkeletonLoader
 				v-if="outline.loading && !outline.data"
 				variant="editor-sidebar"
@@ -46,6 +46,35 @@
 				@chapter-deleted="onChapterDeleted"
 			/>
 		</aside>
+
+		<!-- Mobile: there is no room for a 30% aside, so the outline opens from
+		     the Chapters pill into a sheet instead. -->
+		<BottomSheet v-if="isMobile" v-model="showChapters">
+			<template #header>
+				<div class="text-p-lg-semibold text-ink-gray-9">
+					{{ __('Chapters') }}
+				</div>
+				<Button :label="__('Add chapter')" @click="openAddChapter">
+					<template #icon>
+						<span class="lucide-plus size-4" />
+					</template>
+				</Button>
+			</template>
+			<CourseOutline
+				v-if="props.course?.data"
+				ref="courseOutlineRef"
+				:courseName="props.course.data.name"
+				:title="__('Chapters')"
+				:allowEdit="true"
+				:hideHeader="true"
+				:inlineSelect="true"
+				:selectedLessonNumber="selected?.number"
+				@select-lesson="onSelectLesson"
+				@lesson-deleted="onLessonDeleted"
+				@chapter-deleted="onChapterDeleted"
+			/>
+		</BottomSheet>
+
 		<VideoStatistics
 			v-model="showStats"
 			:lessonName="statsLessonName"
@@ -57,9 +86,11 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { createResource } from 'frappe-ui'
+import { Button, createResource } from 'frappe-ui'
 import { useSidebar } from '@/stores/sidebar'
+import { useScreenSize } from '@/utils/composables'
 import CourseOutline from '@/components/CourseOutline.vue'
+import BottomSheet from '@/components/BottomSheet.vue'
 import SkeletonLoader from '@/components/SkeletonLoader.vue'
 import LessonForm from '@/pages/LessonForm.vue'
 import VideoStatistics from '@/components/Modals/VideoStatistics.vue'
@@ -77,6 +108,8 @@ const props = defineProps({
 const selected = defineModel('selected', { default: null })
 const route = useRoute()
 const router = useRouter()
+const { isMobile } = useScreenSize()
+const showChapters = ref(false)
 
 // Collapse the app sidebar while the lesson editor is open to give the
 // editing surface room, then restore it on leaving the tab. Mirrors the
@@ -191,6 +224,8 @@ function onSelectLesson({ chapterNumber, lessonNumber }) {
 		storeLesson(props.course.data.name, number)
 	}
 	syncSelectedToUrl(number)
+	// On mobile the outline lives in a sheet; dismiss it once a lesson is picked.
+	showChapters.value = false
 }
 
 const outline = createResource({
@@ -318,6 +353,44 @@ function saveSelectedLesson() {
 
 const isDirty = computed(() => Boolean(lessonFormRef.value?.isDirty))
 
+// The phone's lesson stepper. Derived from the outline, which is already
+// loaded, rather than from the LessonForm child — otherwise the buttons
+// flicker out on every hop while the child remounts and refetches.
+const flatLessonNumbers = computed(() =>
+	(outline.data ?? []).flatMap((c) => c.lessons?.map((l) => l.number) ?? [])
+)
+const selectedIndex = computed(() =>
+	selected.value?.number
+		? flatLessonNumbers.value.indexOf(selected.value.number)
+		: -1
+)
+const hasPrev = computed(() => selectedIndex.value > 0)
+const hasNext = computed(
+	() =>
+		selectedIndex.value >= 0 &&
+		selectedIndex.value < flatLessonNumbers.value.length - 1
+)
+const lessonTotal = computed(() => flatLessonNumbers.value.length)
+const lessonIndex = computed(() =>
+	selectedIndex.value >= 0 ? selectedIndex.value + 1 : 0
+)
+
+function selectByNumber(number) {
+	const [chapterNumber, lessonNumber] = number.split('-')
+	onSelectLesson({ chapterNumber, lessonNumber })
+}
+function goPrev() {
+	if (hasPrev.value)
+		selectByNumber(flatLessonNumbers.value[selectedIndex.value - 1])
+}
+function goNext() {
+	if (hasNext.value)
+		selectByNumber(flatLessonNumbers.value[selectedIndex.value + 1])
+}
+function openChapters() {
+	showChapters.value = true
+}
+
 const lessonHasVideo = computed(() =>
 	Boolean(lessonFormRef.value?.lessonHasVideo?.())
 )
@@ -339,5 +412,12 @@ defineExpose({
 	lessonHasVideo,
 	openVideoStats,
 	openAddChapter,
+	lessonIndex,
+	lessonTotal,
+	hasPrev,
+	hasNext,
+	goPrev,
+	goNext,
+	openChapters,
 })
 </script>

--- a/frontend/src/pages/Courses/CourseForm.vue
+++ b/frontend/src/pages/Courses/CourseForm.vue
@@ -4,12 +4,19 @@
 		variant="form"
 		class="flex-1 min-h-0"
 	/>
-	<div v-else class="grid grid-cols-1 md:grid-cols-[70%,30%] flex-1 min-h-0">
-		<div class="overflow-y-auto p-5 space-y-8">
+	<!-- Below `md` the two panes stack, so neither may keep its own scroll box:
+	     the aside's settings have to continue the same scroll the details
+	     started. Everything responsive here hangs off `md`, the width at which
+	     the columns actually split — a narrower cutoff would leave a band where
+	     the panes are stacked but still scroll independently. -->
+	<div v-else class="grid grid-cols-1 flex-1 md:min-h-0 md:grid-cols-[70%,30%]">
+		<div class="space-y-8 p-5 md:overflow-y-auto">
 			<CourseDetailsSection />
 			<CourseOverviewSection />
 		</div>
-		<aside class="border-s overflow-y-auto px-3">
+		<aside
+			class="border-t md:overflow-y-auto md:border-s md:border-t-0 md:px-3"
+		>
 			<CoursePublishSettings />
 		</aside>
 	</div>

--- a/frontend/src/pages/Courses/Courses.vue
+++ b/frontend/src/pages/Courses/Courses.vue
@@ -4,6 +4,7 @@
 		:title="__('All Courses')"
 		:rows="courses.data || []"
 		:loading="courses.list.loading || reloading"
+		:total-count="courseCount"
 		:has-next-page="courses.hasNextPage"
 		v-model:page-length="pageLength"
 		empty-name="Courses"
@@ -97,6 +98,7 @@
 import {
 	Button,
 	createListResource,
+	createResource,
 	Dropdown,
 	FormControl,
 	TabButtons,
@@ -157,6 +159,27 @@ const courses = createListResource({
 	start: start.value,
 })
 
+// The tabs filter on `enrolled`, `created` and `live`, which are not fields,
+// so `frappe.client.get_count` cannot answer this — only the endpoint that
+// resolves them can. Without it the footer can say how many rows it has but
+// not how many there are.
+const courseCountResource = createResource({
+	url: 'lms.lms.utils.get_course_count',
+	makeParams: () => ({ filters: filters.value }),
+	onError: (error) => {
+		console.error(error)
+	},
+})
+
+const courseCount = computed(() => courseCountResource.data ?? null)
+
+const getCourseCount = () => {
+	// Same sequencing hazard as the list: nothing orders the responses, so a
+	// slow count for filters the user has left would overwrite the current one.
+	courseCountResource.abort()
+	courseCountResource.submit()
+}
+
 // `list.loading` goes false mid-request: the aborted fetch's tail resolves
 // after the new reload() has started and clears the flag for it, so the empty
 // state flashes until the reload lands.
@@ -199,6 +222,7 @@ const updateCourses = () => {
 		filters: filters.value,
 	})
 	reloadCourses()
+	getCourseCount()
 }
 
 const updateFilters = () => {

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -1,7 +1,23 @@
 <template>
-	<div class="py-10">
-		<div class="mx-10 space-y-6 px-20">
-			<div class="flex items-center justify-between gap-3">
+	<div class="py-6 sm:py-10">
+		<!-- `mx-10 px-20` left a 390px phone a 150px content well, so the lesson
+		     title wrapped to four lines. It never overflowed, which is why sweeps
+		     passed it. -->
+		<div class="mx-0 space-y-6 px-4 sm:mx-10 sm:px-20">
+			<!-- A full-width settings row costs a phone more than it earns, so the
+			     lesson's settings collapse behind a chip and open in a sheet. The
+			     desk keeps them inline where there is room. -->
+			<button
+				v-if="isMobile"
+				type="button"
+				class="inline-flex h-9 items-center gap-1.5 rounded-full border border-outline-gray-2 px-3.5 text-p-sm-medium text-ink-gray-7 hover:bg-surface-gray-2"
+				@click="showLessonDetails = true"
+			>
+				<span class="lucide-pencil size-3.5" />
+				{{ __('Lesson details') }}
+			</button>
+
+			<div v-else class="flex items-center justify-between gap-3">
 				<div class="flex items-center gap-3">
 					<Switch v-model="lesson.include_in_preview" @change="markDirty" />
 					<div class="flex items-center gap-1.5">
@@ -22,6 +38,30 @@
 					</div>
 				</div>
 			</div>
+
+			<BottomSheet v-model="showLessonDetails" :title="__('Lesson details')">
+				<div class="px-3 pb-2">
+					<div class="flex items-start justify-between gap-4 py-3">
+						<div class="min-w-0">
+							<div class="text-p-base font-medium text-ink-gray-8">
+								{{ __('Include in preview') }}
+							</div>
+							<p class="mt-0.5 text-p-sm text-ink-gray-5">
+								{{
+									__(
+										'When on, anyone can preview this lesson without enrolling. Otherwise it is visible only to enrolled students.'
+									)
+								}}
+							</p>
+						</div>
+						<Switch
+							v-model="lesson.include_in_preview"
+							class="shrink-0"
+							@change="markDirty"
+						/>
+					</div>
+				</div>
+			</BottomSheet>
 
 			<!-- `block`: a textarea is inline-block by default, so it sits on the
 			     parent's line box and carries its descender — 5px of space under
@@ -104,11 +144,16 @@ import {
 import { convertBodyToBlocks as convertToJSON } from '@/utils/lessonMacros'
 import { hasVideoContent } from '@/utils/video'
 import BlockEditor from '@/components/BlockEditor.vue'
+import BottomSheet from '@/components/BottomSheet.vue'
+import { useScreenSize } from '@/utils/composables'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import {
 	useKeyboardShortcuts,
 	saveShortcut,
 } from '@/composables/useKeyboardShortcuts'
+
+const { isMobile } = useScreenSize()
+const showLessonDetails = ref(false)
 
 const editor = ref(null)
 const instructorEditor = ref(null)

--- a/frontend/src/pages/LessonForm.vue
+++ b/frontend/src/pages/LessonForm.vue
@@ -23,13 +23,16 @@
 				</div>
 			</div>
 
+			<!-- `block`: a textarea is inline-block by default, so it sits on the
+			     parent's line box and carries its descender — 5px of space under
+			     the title that belongs to no rule and no gap. -->
 			<textarea
 				ref="titleRef"
 				v-model="lesson.title"
 				:placeholder="__('Lesson title')"
 				:aria-label="__('Lesson title')"
 				rows="1"
-				class="lesson-title w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-2xl font-bold leading-tight text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
+				class="lesson-title block w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-2xl font-bold leading-tight text-ink-gray-9 placeholder:text-ink-gray-4 focus:outline-none focus:ring-0"
 				@input="onTitleInput"
 				@keydown.enter="onTitleEnter"
 			/>

--- a/frontend/src/pages/PersonaForm.vue
+++ b/frontend/src/pages/PersonaForm.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="relative flex min-h-screen flex-col overflow-y-auto bg-surface-white transition-opacity duration-300 ease-out"
+		class="relative flex min-h-dvh flex-col overflow-y-auto bg-surface-white transition-opacity duration-300 ease-out"
 		:class="leaving ? 'opacity-0' : 'opacity-100'"
 	>
 		<div class="flex flex-1 justify-center px-4 pb-16 pt-[105px]">

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -137,9 +137,17 @@
 				</Button>
 			</div>
 
+			<!-- On a phone the strip spans the row, so the pills have to grow
+			     with it or the grey track shows through past the last tab.
+			     `grow` shares the slack out instead of forcing equal columns,
+			     which would truncate the longer labels at 390px. -->
 			<div class="mb-4 mt-10">
 				<TabButtons
-					class="inline-block"
+					:class="
+						isMobile
+							? 'flex w-full [&>div]:w-full [&_button]:min-w-0 [&_button]:grow [&_button>span]:w-full'
+							: 'inline-block'
+					"
 					:options="getTabButtons()"
 					v-model="activeTab"
 				/>
@@ -170,6 +178,7 @@ import { sessionStore } from '@/stores/session'
 import { Github, Linkedin, Twitter } from 'lucide-vue-next'
 import { useRoute, useRouter } from 'vue-router'
 import { convertToTitleCase } from '@/utils'
+import { useScreenSize } from '@/utils/composables'
 import UserAvatar from '@/components/UserAvatar.vue'
 import NoPermission from '@/components/NoPermission.vue'
 import NotFound from '@/pages/NotFound.vue'
@@ -183,6 +192,7 @@ const router = useRouter()
 const activeTab = ref('')
 const showProfileModal = ref(false)
 const readOnlyMode = window.read_only_mode
+const { isMobile } = useScreenSize()
 
 const props = defineProps({
 	username: {

--- a/frontend/src/pages/ProfileEvaluationSchedule.vue
+++ b/frontend/src/pages/ProfileEvaluationSchedule.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="mt-7 mb-20">
-		<div class="flex h-screen flex-col overflow-hidden">
+		<div class="flex h-dvh flex-col overflow-hidden">
 			<Calendar
 				v-if="evaluations.data?.length"
 				:config="{

--- a/frontend/src/pages/Programs/Programs.vue
+++ b/frontend/src/pages/Programs/Programs.vue
@@ -16,7 +16,7 @@
 		:title="__('All Programs')"
 		:rows="programs.data || []"
 		:total-count="programCount"
-		:loading="programs.list.loading"
+		:loading="programs.list.loading || reloading"
 		:has-next-page="programs.hasNextPage"
 		v-model:page-length="pageLength"
 		empty-name="Programs"
@@ -142,6 +142,20 @@ const programs = createListResource({
 	pageLength: 24,
 })
 
+// `list.loading` goes false mid-request: the aborted fetch's tail resolves
+// after the new reload() has started and clears the flag for it, so the empty
+// state flashes until the reload lands.
+const reloading = ref(false)
+
+const reloadPrograms = async () => {
+	reloading.value = true
+	try {
+		await programs.reload()
+	} finally {
+		reloading.value = false
+	}
+}
+
 const pageLength = computed({
 	get: () => programs.pageLength,
 	set: (value) => {
@@ -149,7 +163,7 @@ const pageLength = computed({
 		// of the pages already loaded and then restores start. Resetting start
 		// makes the chosen size the size that is actually requested.
 		programs.update({ pageLength: value, start: 0 })
-		programs.reload()
+		reloadPrograms()
 	},
 })
 
@@ -160,10 +174,15 @@ const setFiltersFromQuery = () => {
 
 const updatePrograms = () => {
 	updateFilters()
+	// createResource keeps no request sequence: every response assigns `data`,
+	// so a slow fetch for filters the user has already left repaints the list
+	// with the wrong programs seconds later. Cancel it first — an aborted fetch
+	// is swallowed and never reaches the list.
+	programs.list.abort()
 	programs.update({
 		filters: filters.value,
 	})
-	programs.reload()
+	reloadPrograms()
 	getProgramCount()
 }
 

--- a/frontend/src/tests/BottomSheet.test.ts
+++ b/frontend/src/tests/BottomSheet.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Stub @vueuse/core so the sheet's scroll-lock / swipe / key-listener helpers
+// don't touch real globals in jsdom. We assert behavior via the component's
+// own emitted events and rendered DOM, not the library internals.
+const keydownHandlers: Array<(e: KeyboardEvent) => void> = []
+vi.mock('@vueuse/core', () => ({
+	useScrollLock: () => ({ value: false }),
+	useSwipe: () => ({ lengthY: { value: 0 }, isSwiping: { value: false } }),
+	useEventListener: (
+		_target: unknown,
+		event: string,
+		handler: (e: KeyboardEvent) => void
+	) => {
+		if (event === 'keydown') keydownHandlers.push(handler)
+	},
+}))
+
+import BottomSheet from '@/components/BottomSheet.vue'
+
+const mountSheet = (props: Record<string, unknown> = {}, slots = {}) =>
+	mount(BottomSheet, {
+		props,
+		slots,
+		attachTo: document.body,
+		global: { stubs: { teleport: true } },
+	})
+
+describe('BottomSheet', () => {
+	it('renders nothing when closed', () => {
+		const wrapper = mountSheet({ modelValue: false }, { default: 'BODY' })
+		expect(wrapper.html()).not.toContain('BODY')
+	})
+
+	it('renders the title and body slot when open', () => {
+		const wrapper = mountSheet(
+			{ modelValue: true, title: 'Contents' },
+			{ default: '<div class="body">BODY</div>' }
+		)
+		expect(wrapper.text()).toContain('Contents')
+		expect(wrapper.find('.body').text()).toBe('BODY')
+	})
+
+	it('prefers the header slot over the title prop', () => {
+		const wrapper = mountSheet(
+			{ modelValue: true, title: 'Ignored' },
+			{ header: '<div class="hdr">Custom</div>' }
+		)
+		expect(wrapper.find('.hdr').exists()).toBe(true)
+		expect(wrapper.text()).not.toContain('Ignored')
+	})
+
+	it('emits update:modelValue=false when the backdrop is tapped', async () => {
+		const wrapper = mountSheet({ modelValue: true })
+		// The backdrop is the first fixed-inset element.
+		await wrapper.find('.bg-black\\/40').trigger('click')
+		expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false])
+	})
+
+	it('closes on Escape while open', () => {
+		keydownHandlers.length = 0
+		const wrapper = mountSheet({ modelValue: true })
+		keydownHandlers.forEach((h) =>
+			h(new KeyboardEvent('keydown', { key: 'Escape' }))
+		)
+		expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false])
+	})
+})

--- a/frontend/src/tests/coursesFilters.test.ts
+++ b/frontend/src/tests/coursesFilters.test.ts
@@ -64,15 +64,26 @@ function makeCoursesResource() {
 	return { resource, requests }
 }
 
-const { coursesResource, requests, mobile } = vi.hoisted(() => ({
+const { coursesResource, requests, mobile, countAborts } = vi.hoisted(() => ({
 	coursesResource: { current: null as any },
 	requests: { current: [] as any[] },
 	mobile: { value: false },
+	countAborts: { value: 0 },
 }))
 
 vi.mock('frappe-ui', () => ({
 	call: vi.fn(() => Promise.resolve(0)),
 	usePageMeta: vi.fn(),
+	// The footer's total. It is aborted and resubmitted alongside the list, so
+	// the counter below is what proves the two stay in step.
+	createResource: () =>
+		reactive({
+			data: 0,
+			abort: () => {
+				countAborts.value += 1
+			},
+			submit: vi.fn(),
+		}),
 	createListResource: (options: { url: string }) => {
 		if (options.url.includes('get_course_categories')) {
 			return reactive({ data: [], list: { loading: false }, reload: vi.fn() })
@@ -180,6 +191,7 @@ const checkedTab = (wrapper: any) =>
 
 beforeEach(() => {
 	mobile.value = false
+	countAborts.value = 0
 	window.history.replaceState({}, '', '/lms/courses')
 	const fake = makeCoursesResource()
 	coursesResource.current = fake.resource
@@ -211,6 +223,19 @@ describe('Courses list filters', () => {
 
 		expect(checkedTab(wrapper)).toBe('tab-unpublished')
 		expect(cards(wrapper)).toBe(0)
+	})
+
+	// The footer's total comes from its own endpoint, because the tabs filter on
+	// `enrolled`, `created` and `live`, which are not fields. It has to be
+	// re-asked on every filter change, and cancelled first for the same reason
+	// the list is: nothing orders the responses.
+	it('re-asks for the total whenever the filters change, cancelling the last', async () => {
+		const wrapper = await mountCourses({ data: { ...MODERATOR } })
+		expect(countAborts.value).toBe(1)
+
+		await wrapper.find('[data-testid="tab-unpublished"]').trigger('click')
+		await nextTick()
+		expect(countAborts.value).toBe(2)
 	})
 
 	it('keeps the selected tab when the user resource resolves again', async () => {

--- a/frontend/src/tests/listPage.test.ts
+++ b/frontend/src/tests/listPage.test.ts
@@ -4,8 +4,9 @@
  * Every list page in the app declares what it filters and what a row looks
  * like; ListPage / ListPageHeader / ToggleFilter / ResponsiveListView own how
  * that reads at each breakpoint. The invariants worth pinning down are the ones
- * a page can no longer see for itself: that the controls strip pins under the
- * app header on a phone and nowhere else, that one click on a boolean filter
+ * a page can no longer see for itself: that a phone leaves the scrolling to the
+ * page rather than a box inside it, that the footer holds the bottom edge while
+ * the filters above the rows never pin, that one click on a boolean filter
  * causes exactly one reload, and that the desk row and the phone card are fed
  * by the same #cell slot.
  */
@@ -115,23 +116,40 @@ async function mountListPage(props: Record<string, unknown> = {}, slots = {}) {
 	return wrapper
 }
 
-// LayoutHeader's own `<header>` is legitimately `sticky top-0` and stays that
-// way. What must never come back is a second pinned box inside the page body:
-// that was a strip re-pinned at a measured offset, and any drift between the
-// measurement and the header's real height showed as a band of content
+// Two things legitimately pin: LayoutHeader's own `<header>`, and the footer,
+// which holds the bottom edge so the page size and Load More stay put. What
+// must never come back is a pinned strip *above* the rows — that was the
+// filters re-pinned at a measured offset, and any drift between the
+// measurement and the app header's real height showed as a band of content
 // scrolling between the two.
-const pinnedInsideBody = (wrapper: any) =>
-	wrapper
+const pinnedAboveRows = (wrapper: any) => {
+	const footer = wrapper.get('[data-testid="footer"]').element
+	return wrapper
 		.findAll('*')
 		.filter(
 			(node: any) =>
-				node.element.tagName !== 'HEADER' && node.classes().includes('sticky')
+				node.element.tagName !== 'HEADER' &&
+				!node.element.contains(footer) &&
+				node.classes().includes('sticky')
 		)
+}
 
-const scrollers = (wrapper: any) =>
+// Below `sm` the page itself is the scroller, so a scroll box inside the body
+// is the thing that must not exist: it leaves the page with no scroll range,
+// and a browser only retracts its URL bar when the root scroller moves.
+const mobileScrollers = (wrapper: any) =>
 	wrapper
 		.findAll('*')
 		.filter((node: any) => node.classes().includes('overflow-y-auto'))
+
+// Above it the desk arrangement returns: exactly one box scrolls the rows so
+// the header and footer around it hold their place.
+const deskScrollers = (wrapper: any) =>
+	wrapper
+		.findAll('*')
+		.filter((node: any) => node.classes().includes('sm:overflow-y-auto'))
+
+const headerBlock = (wrapper: any) => wrapper.get('h1').element.parentElement!
 
 describe('ListPage', () => {
 	it('hands every row to the page card slot', async () => {
@@ -174,38 +192,64 @@ describe('ListPage', () => {
 })
 
 describe('ListPageHeader', () => {
-	// The title and filters used to scroll away on a phone while a measured
-	// sticky offset re-pinned the filters under the app header. Nothing scrolls
-	// but the rows now, so there is no offset left to get wrong — these pin that
-	// down by the two properties that make it true.
+	// On a desk the header holds because it sits outside the box that scrolls
+	// the rows. On a phone the page is the scroller and it travels with it —
+	// it must not try to pin itself there. LayoutHeader is already `sticky
+	// top-0` in that scroller, so a second one lands underneath it, and the
+	// offset that would clear it is the app header's own content height: the
+	// measured offset that drifted and opened a band the last time.
 	it.each([true, false])(
-		'keeps the header block out of the scroll, at isMobile=%s',
+		'never pins the header block inside the page, at isMobile=%s',
 		async (isMobile) => {
 			mobile.value = isMobile
 			const wrapper = await mountListPage({ title: 'All Courses' })
 
 			// The page title's parent is the header block itself. Anchoring on the
 			// rendered DOM rather than the component keeps this honest: it is the
-			// element the browser lays out that has to hold still.
-			const block = wrapper.get('h1').element.parentElement
-			const classes = block?.className.split(/\s+/) ?? []
+			// element the browser lays out.
+			const classes = headerBlock(wrapper).className.split(/\s+/)
 
 			// It cannot be squeezed away by a long list, and it neither pins nor
 			// scrolls on its own — the three ways the old strip went wrong.
 			expect(classes).toContain('shrink-0')
 			expect(classes).not.toContain('sticky')
-			expect(classes.filter((name) => name.startsWith('overflow'))).toEqual([])
-			expect(pinnedInsideBody(wrapper)).toHaveLength(0)
+			expect(
+				classes.filter((name: string) => name.startsWith('overflow'))
+			).toEqual([])
+			expect(pinnedAboveRows(wrapper)).toHaveLength(0)
 		}
 	)
 
+	// The counts and Load More are how you work a long list, so they hold the
+	// bottom edge while the rows pass underneath. On a desk being the last child
+	// of a bounded column does that; on a phone the page scrolls, so it takes
+	// `sticky` and a background of its own.
+	it('keeps the footer against the bottom edge while the rows scroll', async () => {
+		mobile.value = true
+		const wrapper = await mountListPage({ title: 'All Courses' })
+		const footer = wrapper.get('[data-testid="footer"]').element.parentElement!
+		const classes = footer.className.split(/\s+/)
+
+		expect(classes).toContain('sticky')
+		expect(classes).toContain('bottom-0')
+		expect(classes).toContain('sm:static')
+		expect(classes).toContain('bg-surface-elevation-1')
+		expect(classes).toContain('shrink-0')
+		expect(classes).toContain('mt-auto')
+		expect(classes).toContain('sm:mt-0')
+	})
+
 	it.each([true, false])(
-		'leaves the rows the only thing that scrolls, at isMobile=%s',
+		'leaves the page itself the scroller on a phone, at isMobile=%s',
 		async (isMobile) => {
 			mobile.value = isMobile
 			const wrapper = await mountListPage({ title: 'All Courses' })
 
-			expect(scrollers(wrapper)).toHaveLength(1)
+			// Nothing inside the page may scroll below `sm`, or the page has no
+			// scroll range and the URL bar never retracts.
+			expect(mobileScrollers(wrapper)).toHaveLength(0)
+			// Above it, exactly one box scrolls the rows.
+			expect(deskScrollers(wrapper)).toHaveLength(1)
 		}
 	)
 
@@ -217,7 +261,20 @@ describe('ListPageHeader', () => {
 		const wrapper = await mountListPage({ rows: [], loading: true })
 
 		expect(wrapper.find('[data-testid="skeleton"]').exists()).toBe(true)
-		expect(scrollers(wrapper)).toHaveLength(1)
+		expect(mobileScrollers(wrapper)).toHaveLength(0)
+		expect(deskScrollers(wrapper)).toHaveLength(1)
+	})
+
+	// On a phone the filters run the full width and the rows begin straight
+	// under them, so without a rule the two blocks read as one. On a desk the
+	// scroll box's own edge already separates them.
+	it('rules the filters off from the rows only on a phone', async () => {
+		mobile.value = true
+		const wrapper = await mountListPage({ title: 'All Courses' })
+		const classes = headerBlock(wrapper).className.split(/\s+/)
+
+		expect(classes).toContain('border-b')
+		expect(classes).toContain('sm:border-b-0')
 	})
 })
 

--- a/frontend/src/tests/mobileNav.test.ts
+++ b/frontend/src/tests/mobileNav.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	buildMenuSections,
+	hasMoreTab,
+	pickPrimaryTabs,
+	sectionFor,
+	subtitleFor,
+	type NavLink,
+} from '@/utils/mobileNav'
+
+const link = (label: string, icon = 'Circle'): NavLink => ({ label, icon })
+
+// Mirrors what MobileLayout assembles at runtime: getSidebarLinks() output with
+// Programs spliced in, plus the moderator extras and session actions that
+// addOtherLinks()/addQuizzes() append to the separate `otherLinks` array.
+const sidebarLinks = [
+	link('Home'),
+	link('Programs'),
+	link('Courses'),
+	link('Batches'),
+	link('Jobs'),
+	link('Statistics'),
+	link('Certifications'),
+]
+const otherLinks = [
+	link('Quizzes'),
+	link('Assignments'),
+	link('Programming Exercises'),
+	link('Notifications'),
+	link('Profile'),
+	link('Settings'),
+	link('Log out'),
+]
+
+const sectionTitles = (sections: { title: string }[]) =>
+	sections.map((s) => s.title)
+
+const labelsIn = (
+	sections: { title: string; items: NavLink[] }[],
+	title: string
+) => sections.find((s) => s.title === title)?.items.map((i) => i.label) ?? []
+
+describe('pickPrimaryTabs', () => {
+	it('picks the curated primaries out of the admin-configured links', () => {
+		const tabs = pickPrimaryTabs(sidebarLinks, true)
+		expect(tabs.map((t) => t.label)).toEqual([
+			'Home',
+			'Courses',
+			'Certifications',
+			'Profile',
+		])
+	})
+
+	it('drops a primary the admin has disabled', () => {
+		const withoutCertifications = sidebarLinks.filter(
+			(l) => l.label !== 'Certifications'
+		)
+		expect(
+			pickPrimaryTabs(withoutCertifications, true).map((t) => t.label)
+		).toEqual(['Home', 'Courses', 'Profile'])
+	})
+
+	it('never exceeds four tabs, leaving room for More', () => {
+		expect(pickPrimaryTabs(sidebarLinks, true)).toHaveLength(4)
+	})
+
+	it('falls back to Profile alone when the links have not loaded yet', () => {
+		expect(pickPrimaryTabs([], true).map((t) => t.label)).toEqual(['Profile'])
+	})
+})
+
+describe('pickPrimaryTabs for a signed-out visitor', () => {
+	const guestLabels = ['Courses', 'Batches', 'Jobs', 'Statistics', 'Log in']
+
+	it('shows the whole bar before any sidebar link has loaded', () => {
+		// Regression: the guest bar used to be matched out of `sidebarLinks`,
+		// which are admin-configured and arrive asynchronously. Until that
+		// resolved — and sometimes it never did — nothing matched and the bar
+		// rendered with the More button as its only entry.
+		expect(pickPrimaryTabs([], false).map((t) => t.label)).toEqual(guestLabels)
+	})
+
+	it('stays put once the admin-configured links arrive', () => {
+		expect(pickPrimaryTabs(sidebarLinks, false)).toEqual(
+			pickPrimaryTabs([], false)
+		)
+	})
+
+	it('gives every tab an icon, and a route unless it leaves the SPA', () => {
+		const tabs = pickPrimaryTabs([], false)
+		expect(tabs.every((t) => t.icon)).toBe(true)
+		expect(tabs.filter((t) => t.to).map((t) => t.to)).toEqual([
+			'Courses',
+			'Batches',
+			'Jobs',
+			'Statistics',
+		])
+	})
+})
+
+describe('hasMoreTab', () => {
+	it('keeps More for a signed-in user, whose nav overflows the bar', () => {
+		expect(hasMoreTab(true)).toBe(true)
+	})
+
+	it('drops More for a signed-out visitor, who has no overflow', () => {
+		expect(hasMoreTab(false)).toBe(false)
+	})
+})
+
+describe('sectionFor', () => {
+	it('files course content under LEARN wherever it came from', () => {
+		expect(sectionFor('Quizzes')).toBe('LEARN')
+		expect(sectionFor('Assignments')).toBe('LEARN')
+		expect(sectionFor('Programming Exercises')).toBe('LEARN')
+	})
+
+	it('files session actions under ACCOUNT', () => {
+		expect(sectionFor('Notifications')).toBe('ACCOUNT')
+		expect(sectionFor('Log out')).toBe('ACCOUNT')
+		expect(sectionFor('Settings')).toBe('ACCOUNT')
+	})
+
+	it('falls back to MORE for an unrecognised destination', () => {
+		expect(sectionFor('Some New Page')).toBe('MORE')
+	})
+})
+
+describe('buildMenuSections', () => {
+	const primaryLabels = ['Home', 'Courses', 'Certifications', 'Profile']
+	const build = (search = '') =>
+		buildMenuSections(sidebarLinks, otherLinks, primaryLabels, search)
+
+	it('groups the moderator extras under LEARN, not ACCOUNT', () => {
+		// Regression: these arrive via `otherLinks`, which used to be hardcoded
+		// to ACCOUNT, so Quizzes/Assignments/Programming Exercises showed up
+		// under the account heading in the More sheet.
+		expect(labelsIn(build(), 'LEARN')).toEqual([
+			'Programs',
+			'Batches',
+			'Quizzes',
+			'Assignments',
+			'Programming Exercises',
+		])
+		// Profile is absent because it is already a bottom-bar tab. Settings is
+		// present because the desk sidebar that normally opens it is not
+		// rendered on a phone, leaving the More sheet as the only way in.
+		expect(labelsIn(build(), 'ACCOUNT')).toEqual([
+			'Notifications',
+			'Settings',
+			'Log out',
+		])
+	})
+
+	it('shows a destination once when it appears in both link lists', () => {
+		// Regression: a re-entrant sidebar reload left Programs in both arrays
+		// and the sheet rendered it twice.
+		const duplicated = buildMenuSections(
+			[...sidebarLinks, link('Programs')],
+			[link('Programs'), ...otherLinks],
+			primaryLabels,
+			''
+		)
+		expect(
+			labelsIn(duplicated, 'LEARN').filter((l) => l === 'Programs')
+		).toEqual(['Programs'])
+	})
+
+	it('leaves out anything already on the bottom bar', () => {
+		const all = build().flatMap((s) => s.items.map((i) => i.label))
+		expect(all).not.toContain('Home')
+		expect(all).not.toContain('Courses')
+		expect(all).not.toContain('Certifications')
+		expect(all).not.toContain('Profile')
+	})
+
+	it('orders sections LEARN, DISCOVER, then ACCOUNT', () => {
+		expect(sectionTitles(build())).toEqual(['LEARN', 'DISCOVER', 'ACCOUNT'])
+	})
+
+	it('drops sections the search has emptied', () => {
+		const sections = build('quiz')
+		expect(sectionTitles(sections)).toEqual(['LEARN'])
+		expect(labelsIn(sections, 'LEARN')).toEqual(['Quizzes'])
+	})
+
+	it('matches the search case-insensitively and ignores padding', () => {
+		expect(labelsIn(build('  BATCH  '), 'LEARN')).toEqual(['Batches'])
+	})
+
+	it('returns no sections when nothing matches', () => {
+		expect(build('nothing here')).toEqual([])
+	})
+
+	it('returns no sections before the links have loaded', () => {
+		expect(buildMenuSections([], [], primaryLabels, '')).toEqual([])
+	})
+})
+
+describe('subtitleFor', () => {
+	it('describes a known destination', () => {
+		expect(subtitleFor('Batches')).toBe('Cohort-based sessions')
+	})
+
+	it('is empty for a destination with no description', () => {
+		expect(subtitleFor('Log out')).toBe('')
+	})
+})

--- a/frontend/src/tests/mobileNav.test.ts
+++ b/frontend/src/tests/mobileNav.test.ts
@@ -87,6 +87,67 @@ describe('pickPrimaryTabs for a signed-out visitor', () => {
 		)
 	})
 
+	it('hides a destination the admin has switched off', () => {
+		// Greptile P1 on #2630: the guest bar was hardcoded, so a visitor could
+		// see and open Batches or Jobs after LMS Settings had turned them off.
+		const visibility = { courses: 1, batches: 0, jobs: 0, statistics: 1 }
+		expect(pickPrimaryTabs([], false, visibility).map((t) => t.label)).toEqual([
+			'Courses',
+			'Statistics',
+			'Log in',
+		])
+	})
+
+	it('keeps every tab while the settings are still unresolved', () => {
+		// An empty bar is worse than one showing a destination for a moment, so
+		// nothing is hidden until the call actually answers.
+		for (const unresolved of [undefined, null]) {
+			expect(
+				pickPrimaryTabs([], false, unresolved).map((t) => t.label)
+			).toEqual(guestLabels)
+		}
+	})
+
+	it('keeps a tab the settings say nothing about', () => {
+		// Log in has no flag either way, and an object with no keys is still a
+		// settled answer about the seven items it does not mention.
+		expect(pickPrimaryTabs([], false, {}).map((t) => t.label)).toEqual(
+			guestLabels
+		)
+		expect(
+			pickPrimaryTabs([], false, { courses: 0 }).map((t) => t.label)
+		).toContain('Log in')
+	})
+
+	it('leaves only Log in when guest access is switched off', () => {
+		// `get_sidebar_settings` returns a bare `[]` — a list, not an object —
+		// to a guest when allow_guest_access is off. Read as "no flags matched"
+		// that kept every destination on the bar for a visitor who may not open
+		// a single one of them.
+		expect(pickPrimaryTabs([], false, []).map((t) => t.label)).toEqual([
+			'Log in',
+		])
+	})
+
+	it('does not confuse an empty object with an empty array', () => {
+		// The two shapes mean opposite things: `{}` is a settled answer that
+		// mentions nothing, `[]` is guest access withdrawn.
+		expect(pickPrimaryTabs([], false, {})).not.toEqual(
+			pickPrimaryTabs([], false, [])
+		)
+	})
+
+	it('reads the flag however the endpoint spells it', () => {
+		// `lms_settings.get(item)` hands back an int, but the resource has been
+		// seen carrying strings; both mean the same thing.
+		expect(
+			pickPrimaryTabs([], false, { jobs: '0' }).map((t) => t.label)
+		).not.toContain('Jobs')
+		expect(
+			pickPrimaryTabs([], false, { jobs: '1' }).map((t) => t.label)
+		).toContain('Jobs')
+	})
+
 	it('gives every tab an icon, and a route unless it leaves the SPA', () => {
 		const tabs = pickPrimaryTabs([], false)
 		expect(tabs.every((t) => t.icon)).toBe(true)

--- a/frontend/src/tests/programsFilters.test.ts
+++ b/frontend/src/tests/programsFilters.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Programs.vue list state.
+ *
+ * Same two hazards Courses.vue was fixed for. frappe-ui's `createResource` keeps
+ * no request sequence, so a slow response from a tab the user has already left
+ * repaints the list with the wrong programs; and `list.loading` belongs to the
+ * resource rather than to a request, so the aborted fetch's tail clears the flag
+ * for the reload that replaced it and the empty state flashes.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { nextTick, reactive } from 'vue'
+import { mount } from '@vue/test-utils'
+
+type Rows = { name: string }[]
+
+interface FakeRequest {
+	filters: Record<string, unknown>
+	aborted: boolean
+	respond: (rows: Rows) => void
+	finish: () => void
+}
+
+/**
+ * Mirrors frappe-ui's list resource closely enough to expose ordering bugs:
+ * responses are settled by hand, `abort()` cancels the fetch in flight, an
+ * un-aborted response always wins, and `finish()` runs the request tail that
+ * clears the shared `loading` flag — including an aborted request's tail.
+ */
+function makeProgramsResource() {
+	const requests: FakeRequest[] = []
+	let inFlight: FakeRequest | null = null
+
+	const resource = reactive({
+		data: null as Rows | null,
+		hasNextPage: false,
+		pageLength: 24,
+		filters: {} as Record<string, unknown>,
+		list: {
+			loading: false,
+			abort: () => {
+				if (inFlight) inFlight.aborted = true
+			},
+		},
+		update({ filters }: { filters?: Record<string, unknown> }) {
+			if (filters) resource.filters = JSON.parse(JSON.stringify(filters))
+		},
+		reload() {
+			let settle: () => void
+			const settled = new Promise<void>((resolve) => (settle = resolve))
+			const request: FakeRequest = {
+				filters: JSON.parse(JSON.stringify(resource.filters)),
+				aborted: false,
+				respond(rows: Rows) {
+					if (!request.aborted) resource.data = rows
+				},
+				finish() {
+					resource.list.loading = false
+					settle()
+				},
+			}
+			inFlight = request
+			requests.push(request)
+			resource.list.loading = true
+			return settled
+		},
+		next: vi.fn(),
+	})
+
+	return { resource, requests }
+}
+
+const { programsResource, requests, countAborts } = vi.hoisted(() => ({
+	programsResource: { current: null as any },
+	requests: { current: [] as any[] },
+	countAborts: { value: 0 },
+}))
+
+vi.mock('frappe-ui', () => ({
+	usePageMeta: vi.fn(),
+	createListResource: () => programsResource.current,
+	createResource: () =>
+		reactive({
+			data: 0,
+			abort: () => {
+				countAborts.value += 1
+			},
+			submit: vi.fn(),
+		}),
+	Breadcrumbs: { template: '<nav />' },
+	Button: { template: '<button><slot /></button>' },
+	FormControl: {
+		inheritAttrs: false,
+		props: ['modelValue', 'type', 'label', 'placeholder'],
+		emits: ['update:modelValue'],
+		template: `<input v-bind="$attrs" :type="type" :value="modelValue" />`,
+	},
+	TabButtons: {
+		props: ['options', 'modelValue'],
+		emits: ['update:modelValue'],
+		template: `<div>
+			<button
+				v-for="option in options"
+				:key="option.value"
+				:data-testid="'tab-' + option.value"
+				:data-state="option.value === modelValue ? 'checked' : 'unchecked'"
+				@click="$emit('update:modelValue', option.value)"
+			>{{ option.label }}</button>
+		</div>`,
+	},
+}))
+
+vi.mock('@/stores/session', () => ({ sessionStore: () => ({ brand: {} }) }))
+
+const stub = (template: string) => ({ default: { template } })
+vi.mock('@/pages/Programs/ProgramForm.vue', () => stub('<div />'))
+vi.mock('@/pages/Programs/StudentPrograms.vue', () => stub('<div />'))
+vi.mock('@/components/Layouts/LayoutHeader.vue', () => stub('<header />'))
+
+// Stands in for the whole page shell, so this file stays about list state. The
+// loading prop is surfaced so the flash-of-empty-state fix can be asserted.
+vi.mock('@/components/Layouts/ListPage.vue', () => ({
+	default: {
+		props: ['rows', 'breadcrumbs', 'title', 'loading'],
+		template: `<div :data-loading="String(loading)">
+			<slot name="actions" />
+			<slot name="tabs" />
+			<slot name="filters" />
+			<slot v-for="row in rows" :key="row.name" name="card" :row="row" />
+		</div>`,
+	},
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const MODERATOR = { name: 'admin@test.com', is_moderator: true }
+const PUBLISHED_PROGRAMS = [{ name: 'program-a' }, { name: 'program-b' }]
+
+async function mountPrograms() {
+	const { default: Programs } = await import('@/pages/Programs/Programs.vue')
+	const wrapper = mount(Programs, {
+		global: {
+			provide: { $user: { data: { ...MODERATOR } } },
+			mocks: { __: (s: string) => s },
+		},
+	})
+	await nextTick()
+	return wrapper
+}
+
+const cards = (wrapper: any) => wrapper.findAll('button[type="button"]').length
+const loading = (wrapper: any) =>
+	wrapper.find('[data-loading]').attributes('data-loading')
+
+beforeEach(() => {
+	window.history.replaceState({}, '', '/lms/programs')
+	const fake = makeProgramsResource()
+	programsResource.current = fake.resource
+	requests.current = fake.requests
+	countAborts.value = 0
+	vi.resetModules()
+})
+
+describe('Programs list', () => {
+	it('drops a slow response from the tab the user has already left', async () => {
+		const wrapper = await mountPrograms()
+
+		expect(requests.current).toHaveLength(1)
+		expect(requests.current[0].filters).toMatchObject({ published: 1 })
+
+		await wrapper.find('[data-testid="tab-unpublished"]').trigger('click')
+		await nextTick()
+		expect(requests.current).toHaveLength(2)
+		expect(requests.current[1].filters).toMatchObject({ published: 0 })
+
+		// Unpublished answers first: there are none.
+		requests.current[1].respond([])
+		await nextTick()
+		expect(cards(wrapper)).toBe(0)
+
+		// The Published fetch finally lands. It must not repaint the list.
+		requests.current[0].respond(PUBLISHED_PROGRAMS)
+		await nextTick()
+		expect(cards(wrapper)).toBe(0)
+	})
+
+	it('stays loading when the aborted fetch tail clears the shared flag', async () => {
+		const wrapper = await mountPrograms()
+
+		await wrapper.find('[data-testid="tab-unpublished"]').trigger('click')
+		await nextTick()
+		expect(requests.current).toHaveLength(2)
+
+		// The replacement fetch is in flight; the aborted one only now unwinds
+		// and drops `list.loading` on its way out.
+		requests.current[0].finish()
+		await nextTick()
+		expect(requests.current[0].aborted).toBe(true)
+		expect(programsResource.current.list.loading).toBe(false)
+		expect(loading(wrapper)).toBe('true')
+
+		// Only the replacement settling ends the loading state.
+		requests.current[1].respond([])
+		requests.current[1].finish()
+		await nextTick()
+		await nextTick()
+		expect(loading(wrapper)).toBe('false')
+	})
+
+	it('cancels the in-flight count before asking for a new one', async () => {
+		const wrapper = await mountPrograms()
+		expect(countAborts.value).toBe(1)
+
+		await wrapper.find('[data-testid="tab-unpublished"]').trigger('click')
+		await nextTick()
+		expect(countAborts.value).toBe(2)
+	})
+})

--- a/frontend/src/tests/responsiveListView.test.ts
+++ b/frontend/src/tests/responsiveListView.test.ts
@@ -79,7 +79,17 @@ vi.mock('frappe-ui', async () => {
 			expose({ selections, toggleRow, toggleAllRows })
 			return {}
 		},
-		template: '<div data-testid="listview" v-bind="$attrs"><slot /></div>',
+		// Both wrappers are copied verbatim from frappe-ui's ListView.vue, class
+		// lists included. The inner one is the reason the cards need a scroll box
+		// of their own: it clips them, and the class a caller passes lands on it
+		// rather than replacing anything.
+		template: `<div class="relative flex w-full flex-1 flex-col overflow-x-auto">
+			<div
+				class="flex w-max min-w-full flex-col overflow-y-hidden"
+				data-testid="listview"
+				v-bind="$attrs"
+			><slot /></div>
+		</div>`,
 	})
 
 	const ListSelectBanner = defineComponent({
@@ -362,5 +372,54 @@ describe('ResponsiveListView without selection', () => {
 		expect(wrapper.find('[data-testid="list-rows"]').exists()).toBe(true)
 		expect(wrapper.find('ul').exists()).toBe(false)
 		expect(wrapper.find('[data-testid="row-checkbox"]').exists()).toBe(false)
+	})
+})
+
+/**
+ * frappe-ui hands its rows a box it has already clipped (`overflow-y-hidden`),
+ * and supplies the scrolling itself in ListRows. The card shape replaces
+ * ListRows, so it has to supply that scrolling too — without it the cards past
+ * the first screenful are painted and unreachable, which is what a phone with
+ * 24 quizzes on it actually showed. jsdom has no layout to measure, so what is
+ * pinned here is the structure that produces it; the measurement lives in the
+ * handover.
+ */
+describe('ResponsiveListView card scrolling', () => {
+	const SCROLLS = 'overflow-y-auto'
+
+	// The cards must not scroll inside anything of their own. The page body owns
+	// the single scroll box, and on a phone even that is released so the page
+	// itself scrolls — a box here would take the page's scroll range away, and a
+	// browser only retracts its URL bar when the root scroller moves.
+	//
+	// It is worth stating because frappe-ui makes it easy to get wrong twice
+	// over: the box it hands these rows is `overflow-y-hidden`, and it supplies
+	// the scrolling in ListRows, which the card shape replaces. Give the cards
+	// nothing and they are clipped; give them a scroller and the page is.
+	it('never scrolls the cards inside a box of their own', async () => {
+		mobile.value = true
+		const { wrapper } = await mountList(routedOptions)
+
+		const list = wrapper.find('ul').element
+		const clipped = wrapper.find('[data-testid="listview"]').element
+		expect(clipped.className).toContain('overflow-y-hidden')
+
+		for (let el = list.parentElement; el && el !== clipped; el = el.parentElement) {
+			expect(el.className.includes(SCROLLS)).toBe(false)
+		}
+		// And nothing may bound their height either, or the clip bites instead.
+		for (let el = list.parentElement; el && el !== clipped; el = el.parentElement) {
+			expect(el.className.includes('min-h-0')).toBe(false)
+		}
+	})
+
+	it('leaves the selection banner outside the rows, so it does not scroll away', async () => {
+		mobile.value = true
+		const { wrapper } = await mountList(routedOptions)
+		await selectFirstRow(wrapper)
+
+		const banner = wrapper.find('[data-testid="select-banner"]').element
+		const list = wrapper.find('ul').element
+		expect(banner.contains(list)).toBe(false)
 	})
 })

--- a/frontend/src/utils/mobileNav.ts
+++ b/frontend/src/utils/mobileNav.ts
@@ -1,0 +1,185 @@
+// Nav taxonomy for the phone layout: which destinations stay on the fixed
+// bottom bar, and how the rest are grouped inside the More sheet.
+
+export interface NavLink {
+	label: string
+	icon: string
+	to?: string
+	activeFor?: string[]
+}
+
+export interface NavSection {
+	title: string
+	items: NavLink[]
+}
+
+// Primaries are picked out of the admin-configured sidebar links, so disabling
+// a link in settings drops its tab too.
+export const PRIMARY_LABELS: readonly string[] = [
+	'Home',
+	'Courses',
+	'Certifications',
+]
+
+// A signed-out visitor's whole destination set fits on the bar, so these are
+// hardcoded instead of matched against `sidebarLinks`. Those links are
+// admin-configured and arrive asynchronously; matching against them left the
+// guest bar holding nothing but the More button until the settings call
+// resolved — and sometimes it never did. Static list mirrors CRM's
+// `components/Mobile/MobileSidebar.vue`.
+export const GUEST_TABS: readonly NavLink[] = [
+	{
+		label: 'Courses',
+		icon: 'BookOpen',
+		to: 'Courses',
+		activeFor: ['Courses', 'CourseDetail', 'Lesson'],
+	},
+	{
+		label: 'Batches',
+		icon: 'Users',
+		to: 'Batches',
+		activeFor: ['Batches', 'BatchDetail'],
+	},
+	{
+		label: 'Jobs',
+		icon: 'Briefcase',
+		to: 'Jobs',
+		activeFor: ['Jobs', 'JobDetail'],
+	},
+	{
+		label: 'Statistics',
+		icon: 'TrendingUp',
+		to: 'Statistics',
+		activeFor: ['Statistics'],
+	},
+	// No route: MobileLayout sends this one to Frappe's server-rendered
+	// /login, the same way the More sheet's Log in entry does.
+	{ label: 'Log in', icon: 'LogIn' },
+]
+
+export const PROFILE_TAB: NavLink = {
+	label: 'Profile',
+	icon: 'UserRound',
+	to: 'Profile',
+	activeFor: ['Profile'],
+}
+
+const MAX_PRIMARY_TABS = 4
+
+const SECTION_MAP: Record<string, readonly string[]> = {
+	LEARN: [
+		'Programs',
+		'Batches',
+		'Quizzes',
+		'Assignments',
+		'Programming Exercises',
+	],
+	DISCOVER: ['Jobs', 'Statistics'],
+}
+
+// Session actions belong to the account group no matter which list they
+// arrived in — Quizzes and friends reach us through the same `otherLinks`
+// array, and they are course content, not account settings.
+const ACCOUNT_LABELS: readonly string[] = [
+	'Notifications',
+	'Profile',
+	'Settings',
+	'Log in',
+	'Log out',
+]
+
+const SUBTITLES: Record<string, string> = {
+	Programs: 'Multi-course learning tracks',
+	Batches: 'Cohort-based sessions',
+	Quizzes: 'Across all your courses',
+	Assignments: 'Due, in review, submitted',
+	'Programming Exercises': 'Coding practice & solutions',
+	Jobs: 'Open roles, hiring partners',
+	Statistics: 'Your learning trends',
+	Settings: 'Branding, members, payments',
+}
+
+const SECTION_ORDER: readonly string[] = [
+	'LEARN',
+	'DISCOVER',
+	'MORE',
+	'ACCOUNT',
+]
+
+export function sectionFor(label: string): string {
+	if (ACCOUNT_LABELS.includes(label)) return 'ACCOUNT'
+	for (const [section, labels] of Object.entries(SECTION_MAP)) {
+		if (labels.includes(label)) return section
+	}
+	return 'MORE'
+}
+
+export function subtitleFor(label: string): string {
+	return SUBTITLES[label] || ''
+}
+
+// Five equal-width tabs leave roughly 78px each. "Certifications" fills its
+// column edge to edge while "Home" floats in the middle of one, which reads as
+// uneven spacing — the design's own label for this tab is the shorter word.
+const SHORT_TAB_LABELS: Record<string, string> = {
+	Certifications: 'Certified',
+	'Programming Exercises': 'Exercises',
+}
+
+export function tabLabel(label: string): string {
+	return SHORT_TAB_LABELS[label] || label
+}
+
+// The bar only needs a More tab when there are destinations left to overflow
+// into the sheet. A signed-out visitor's five fit exactly.
+export function hasMoreTab(isSignedIn: boolean): boolean {
+	return isSignedIn
+}
+
+export function pickPrimaryTabs(
+	sidebarLinks: readonly NavLink[],
+	isSignedIn: boolean
+): NavLink[] {
+	if (!isSignedIn) return [...GUEST_TABS]
+
+	const picked: NavLink[] = []
+	for (const label of PRIMARY_LABELS) {
+		const link = sidebarLinks.find((item) => item.label === label)
+		if (link) picked.push(link)
+	}
+	picked.push(PROFILE_TAB)
+	return picked.slice(0, MAX_PRIMARY_TABS)
+}
+
+// `sidebarLinks` and `otherLinks` overlap — Programs is spliced into the
+// sidebar list while the moderator extras are appended to the other list, and
+// a re-entrant reload can leave the same label in both. Dedupe by label so the
+// sheet never shows a destination twice.
+export function buildMenuSections(
+	sidebarLinks: readonly NavLink[],
+	otherLinks: readonly NavLink[],
+	primaryLabels: readonly string[],
+	// The sheet no longer offers a search box; the filter stays because the
+	// grouping is what it exists to test and a caller may want it back.
+	search = ''
+): NavSection[] {
+	const primary = new Set(primaryLabels)
+	const seen = new Set<string>()
+	const items: NavLink[] = []
+
+	for (const link of [...sidebarLinks, ...otherLinks]) {
+		if (primary.has(link.label) || seen.has(link.label)) continue
+		seen.add(link.label)
+		items.push(link)
+	}
+
+	const query = search.trim().toLowerCase()
+	const matched = query
+		? items.filter((item) => item.label.toLowerCase().includes(query))
+		: items
+
+	return SECTION_ORDER.map((title) => ({
+		title,
+		items: matched.filter((item) => sectionFor(item.label) === title),
+	})).filter((section) => section.items.length > 0)
+}

--- a/frontend/src/utils/mobileNav.ts
+++ b/frontend/src/utils/mobileNav.ts
@@ -27,6 +27,9 @@ export const PRIMARY_LABELS: readonly string[] = [
 // guest bar holding nothing but the More button until the settings call
 // resolved — and sometimes it never did. Static list mirrors CRM's
 // `components/Mobile/MobileSidebar.vue`.
+//
+// Static is the starting set, not the final one: `pickPrimaryTabs` still hides
+// any of these the admin has switched off, once the settings actually arrive.
 export const GUEST_TABS: readonly NavLink[] = [
 	{
 		label: 'Courses',
@@ -136,11 +139,47 @@ export function hasMoreTab(isSignedIn: boolean): boolean {
 	return isSignedIn
 }
 
+// What `get_sidebar_settings` can hand back, and what each shape means.
+export type SidebarVisibility = Record<string, unknown> | unknown[] | null
+
+// `get_sidebar_settings` returns a bare `[]` — a list, where the settled case
+// is an object — when the caller is a guest and guest access is off. That is an
+// answer, not a silence: nothing in the app is browsable at all, so it must not
+// be read as "no flags matched, keep everything".
+export function isGuestAccessRevoked(visibility?: SidebarVisibility): boolean {
+	return Array.isArray(visibility)
+}
+
+// Otherwise the flags are keyed by the lowercased, underscored label — the same
+// convention MobileLayout's `filterLinksToShow` uses to drop a link from the
+// sheet. A label the settings say nothing about always stays, and so does
+// everything while `visibility` is still unresolved: an empty bar is worse than
+// one showing a destination for a moment.
+export function isLinkEnabled(
+	label: string,
+	visibility?: SidebarVisibility
+): boolean {
+	if (!visibility || isGuestAccessRevoked(visibility)) return true
+	const key = label.toLowerCase().split(' ').join('_')
+	if (!(key in visibility)) return true
+	return Boolean(parseInt(String((visibility as Record<string, unknown>)[key])))
+}
+
 export function pickPrimaryTabs(
 	sidebarLinks: readonly NavLink[],
-	isSignedIn: boolean
+	isSignedIn: boolean,
+	// Signed-in tabs are matched against `sidebarLinks`, which the caller has
+	// already filtered; only the guest set needs this.
+	visibility?: SidebarVisibility
 ): NavLink[] {
-	if (!isSignedIn) return [...GUEST_TABS]
+	if (!isSignedIn) {
+		// Guest access withdrawn: every in-app destination goes. Only Log in
+		// survives, because it leaves the SPA for Frappe's own /login and is the
+		// one thing such a visitor can still do.
+		if (isGuestAccessRevoked(visibility))
+			return GUEST_TABS.filter((tab) => !tab.to)
+		return GUEST_TABS.filter((tab) => isLinkEnabled(tab.label, visibility))
+	}
 
 	const picked: NavLink[] = []
 	for (const label of PRIMARY_LABELS) {

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -774,9 +774,25 @@ def guest_access_allowed():
 	return True
 
 
+DEFAULT_PAGE_LENGTH = 24
+MAX_PAGE_LENGTH = 120
+
+
+def resolve_page_length(limit_page_length=None) -> int:
+	"""How many rows a list endpoint returns for a client-supplied page size.
+
+	`createListResource` sends `limit_page_length` and advances `start` by the
+	same number, so an endpoint that ignores it hands back a page of a different
+	size and the next page repeats rows. Bounded because these endpoints are
+	open to guests and an unbounded page size is a cheap way to ask for a table.
+	"""
+	page_length = cint(limit_page_length) or DEFAULT_PAGE_LENGTH
+	return min(max(page_length, 1), MAX_PAGE_LENGTH)
+
+
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=500, seconds=60 * 60)
-def get_courses(filters: dict = None, start: int = 0) -> list:
+def get_courses(filters: dict = None, start: int = 0, limit_page_length=None) -> list:
 	"""Returns the list of courses."""
 
 	if not guest_access_allowed():
@@ -795,7 +811,7 @@ def get_courses(filters: dict = None, start: int = 0) -> list:
 		or_filters=or_filters,
 		order_by="enrollments desc",
 		start=start,
-		page_length=30,
+		page_length=resolve_page_length(limit_page_length),
 	)
 	if show_featured and start == 0:
 		courses = get_featured_courses(filters, or_filters, fields) + courses
@@ -2526,7 +2542,12 @@ def validate_program_enrollment(program: str):
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=500, seconds=60 * 60)
-def get_batches(filters: dict = None, start: int = 0, order_by: str = "start_date"):
+def get_batches(
+	filters: dict = None,
+	start: int = 0,
+	order_by: str = "start_date",
+	limit_page_length=None,
+):
 	if not guest_access_allowed():
 		return []
 
@@ -2562,7 +2583,7 @@ def get_batches(filters: dict = None, start: int = 0, order_by: str = "start_dat
 		],
 		order_by=order_by,
 		start=start,
-		page_length=20,
+		page_length=resolve_page_length(limit_page_length),
 	)
 
 	batches = filter_batches_based_on_start_time(batches, filters)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -23,6 +23,7 @@ from frappe.utils import (
 	getdate,
 	nowtime,
 	rounded,
+	to_timedelta,
 	validate_email_address,
 )
 from frappe.utils.html_utils import sanitize_html
@@ -790,9 +791,9 @@ def resolve_page_length(limit_page_length=None) -> int:
 	return min(max(page_length, 1), MAX_PAGE_LENGTH)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @rate_limit(limit=500, seconds=60 * 60)
-def get_courses(filters: dict = None, start: int = 0, limit_page_length=None) -> list:
+def get_courses(filters: dict = None, start: int = 0, limit_page_length: int | str = None) -> list:
 	"""Returns the list of courses."""
 
 	if not guest_access_allowed():
@@ -803,22 +804,80 @@ def get_courses(filters: dict = None, start: int = 0, limit_page_length=None) ->
 
 	filters, or_filters, show_featured = update_course_filters(filters)
 	fields = get_course_fields()
+	page_length = resolve_page_length(limit_page_length)
+	start = cint(start)
 
-	courses = frappe.get_all(
-		"LMS Course",
-		filters=filters,
-		fields=fields,
-		or_filters=or_filters,
-		order_by="enrollments desc",
-		start=start,
-		page_length=resolve_page_length(limit_page_length),
+	# Featured courses lead the list, and the query below excludes them, so the
+	# two together are one sequence the caller pages through. Slicing has to
+	# treat it that way: prepending them to a full page returned a page longer
+	# than the one asked for, and since the caller advances `start` by the size
+	# it asked for, the next page then repeated whatever the extras pushed past
+	# the end.
+	# Read only as far as the window: `len(featured)` below is the offset the rest
+	# of the sequence starts at, and it is only needed when the window runs past
+	# the featured rows — which is exactly when this read returned all of them.
+	featured = (
+		get_featured_courses(filters.copy(), or_filters, fields, start + page_length) if show_featured else []
 	)
-	if show_featured and start == 0:
-		courses = get_featured_courses(filters, or_filters, fields) + courses
+	courses = featured[start : start + page_length]
+	remaining = page_length - len(courses)
+
+	if remaining > 0:
+		courses = courses + frappe.get_all(
+			"LMS Course",
+			filters=filters,
+			fields=fields,
+			or_filters=or_filters,
+			order_by="enrollments desc",
+			start=max(start - len(featured), 0),
+			page_length=remaining,
+		)
 
 	courses = get_enrollment_details(courses)
 	courses = get_course_card_details(courses)
 	return courses
+
+
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+@rate_limit(limit=500, seconds=60 * 60)
+def get_course_count(filters: dict = None) -> int:
+	"""How many courses the same filters `get_courses` takes actually match.
+
+	The list footer cannot ask `frappe.client.get_count` for this: the tabs
+	filter on `enrolled`, `created` and `live`, which are not fields, and the
+	title search is an or_filter. Both only exist once `update_course_filters`
+	has resolved them.
+	"""
+	if not guest_access_allowed():
+		return 0
+
+	if not filters:
+		filters = {}
+
+	filters, or_filters, show_featured = update_course_filters(filters)
+	total = count_matching("LMS Course", filters, or_filters)
+	if show_featured:
+		# `update_course_filters` narrowed the query to featured=0 for the live
+		# tab, so the featured rows it leads with are counted separately.
+		total += count_matching("LMS Course", {**filters, "featured": 1}, or_filters)
+	return total
+
+
+def count_matching(doctype: str, filters: dict | list, or_filters: dict = None) -> int:
+	"""Row count for filters that include or_filters, which db.count cannot take."""
+	rows = frappe.get_all(doctype, filters=filters, or_filters=or_filters, fields=[{"COUNT": "*"}])
+	return cint(next(iter(rows[0].values()))) if rows else 0
+
+
+def as_filter_conditions(filters: dict) -> list:
+	"""The same filters as a list of conditions, which can hold two per field."""
+	conditions = []
+	for field, value in filters.items():
+		if isinstance(value, list | tuple):
+			conditions.append([field, value[0], value[1]])
+		else:
+			conditions.append([field, "=", value])
+	return conditions
 
 
 @frappe.whitelist(allow_guest=True)
@@ -919,7 +978,7 @@ def get_enrollment_details(courses: list) -> list:
 	return courses
 
 
-def get_featured_courses(filters: dict, or_filters: dict, fields: list) -> list:
+def get_featured_courses(filters: dict, or_filters: dict, fields: list, page_length: int) -> list:
 	filters.update({"featured": 1})
 	featured_courses = frappe.get_all(
 		"LMS Course",
@@ -927,6 +986,7 @@ def get_featured_courses(filters: dict, or_filters: dict, fields: list) -> list:
 		fields=fields,
 		or_filters=or_filters,
 		order_by="enrollments desc",
+		page_length=page_length,
 	)
 	return featured_courses
 
@@ -2540,13 +2600,13 @@ def validate_program_enrollment(program: str):
 		frappe.throw(_("You cannot enroll in an unpublished program."))
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @rate_limit(limit=500, seconds=60 * 60)
 def get_batches(
 	filters: dict = None,
 	start: int = 0,
 	order_by: str = "start_date",
-	limit_page_length=None,
+	limit_page_length: int | str = None,
 ):
 	if not guest_access_allowed():
 		return []
@@ -2554,12 +2614,7 @@ def get_batches(
 	if not filters:
 		filters = {}
 
-	if filters.get("enrolled"):
-		enrolled_batches = frappe.get_all(
-			"LMS Batch Enrollment", {"member": frappe.session.user}, pluck="batch"
-		)
-		filters.update({"name": ["in", enrolled_batches]})
-		del filters["enrolled"]
+	update_batch_filters(filters)
 
 	batches = frappe.get_all(
 		"LMS Batch",
@@ -2591,22 +2646,82 @@ def get_batches(
 	return batches
 
 
+def update_batch_filters(filters: dict) -> None:
+	"""Turns the pseudo-filters the batch list offers into real ones, in place."""
+	if filters.get("enrolled"):
+		enrolled_batches = frappe.get_all(
+			"LMS Batch Enrollment", {"member": frappe.session.user}, pluck="batch"
+		)
+		filters.update({"name": ["in", enrolled_batches]})
+		del filters["enrolled"]
+
+
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+@rate_limit(limit=500, seconds=60 * 60)
+def get_batch_count(filters: dict = None) -> int:
+	"""How many batches the same filters `get_batches` takes actually match.
+
+	The list footer cannot ask `frappe.client.get_count` for this: the Upcoming
+	and Archived tabs turn on the time of day, and the query only settles the
+	date, so `filter_batches_based_on_start_time` decides the rest in Python.
+
+	Counted as two COUNTs rather than by fetching the rows and repeating that
+	pass over them: the endpoint is open to guests, so the work it does must not
+	grow with the number of batches on the site.
+	"""
+	if not guest_access_allowed():
+		return 0
+
+	if not filters:
+		filters = {}
+
+	update_batch_filters(filters)
+	total = count_matching("LMS Batch", filters)
+
+	batch_type = get_batch_type(filters)
+	if batch_type:
+		total -= count_batches_the_clock_decides(filters, batch_type)
+
+	return total
+
+
+def count_batches_the_clock_decides(filters: dict, batch_type: str) -> int:
+	"""How many matching batches `filter_batches_based_on_start_time` drops.
+
+	Only today's are ever in question — every other date the query has already
+	settled. Upcoming drops the ones already under way; Archived, the ones still
+	to come. Both conditions are added rather than replacing the caller's date
+	filter, so a tab asking for `start_date > today` still counts nothing today.
+	"""
+	started = "<" if batch_type == "upcoming" else ">="
+	conditions = as_filter_conditions(filters) + [
+		["start_date", "=", getdate()],
+		["start_time", started, nowtime()],
+	]
+	return count_matching("LMS Batch", conditions)
+
+
+def has_started_today(batch) -> bool:
+	"""Whether a batch dated today has already begun.
+
+	Compared as times rather than as strings. `start_time` comes back from the
+	database as a timedelta, and `str()` renders a single-digit hour without a
+	leading zero — so "9:00:00" sorted above "14:30:00" and a batch that began
+	at nine that morning still counted as upcoming at half past two.
+	"""
+	if getdate(batch.start_date) != getdate():
+		return False
+	return to_timedelta(str(batch.start_time)) < to_timedelta(nowtime())
+
+
 def filter_batches_based_on_start_time(batches: list, filters: dict) -> list:
 	batchType = get_batch_type(filters)
 	if batchType == "upcoming":
-		batches_to_remove = [
-			batch
-			for batch in batches
-			if getdate(batch.start_date) == getdate() and str(batch.start_time) < nowtime()
-		]
-		batches = [batch for batch in batches if batch not in batches_to_remove]
+		batches = [batch for batch in batches if not has_started_today(batch)]
 	elif batchType == "archived":
-		batches_to_remove = [
-			batch
-			for batch in batches
-			if getdate(batch.start_date) == getdate() and str(batch.start_time) >= nowtime()
+		batches = [
+			batch for batch in batches if getdate(batch.start_date) != getdate() or has_started_today(batch)
 		]
-		batches = [batch for batch in batches if batch not in batches_to_remove]
 	return batches
 
 

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 from datetime import datetime
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import UnitTestCase
@@ -14,11 +15,16 @@ from lms.lms.utils import (
 	MAX_PAGE_LENGTH,
 	create_user,
 	get_average_rating,
+	get_batch_count,
 	get_batch_details,
+	get_batches,
 	get_chapters,
 	get_course_categories,
+	get_course_count,
 	get_course_details,
+	get_courses,
 	get_evaluator,
+	get_featured_courses,
 	get_instructors,
 	get_lesson_index,
 	get_lesson_url,
@@ -423,3 +429,168 @@ class TestResolvePageLength(UnitTestCase):
 
 	def test_negative_page_size_never_reaches_the_query(self):
 		self.assertEqual(resolve_page_length(-5), 1)
+
+
+class TestListEndpointPaging(BaseTestUtils):
+	"""
+	`createListResource` asks for a page size and then advances `start` by that
+	same number, so an endpoint that answers with a different number of rows
+	makes the next page overlap the last one.
+
+	The courses list is the awkward one: featured courses lead it and come from
+	a second query, so they have to be counted against the same page budget.
+	These build their own category so the assertions are about a known four
+	courses rather than whatever the site happens to hold.
+	"""
+
+	CATEGORY = "Paging Test Category"
+	STARTED_TODAY = "Paging Batch Already Started"
+
+	def setUp(self):
+		super().setUp()
+		if not frappe.db.exists("LMS Category", self.CATEGORY):
+			frappe.get_doc({"doctype": "LMS Category", "category": self.CATEGORY}).insert(
+				ignore_permissions=True
+			)
+			self.cleanup_items.append(("LMS Category", self.CATEGORY))
+
+		self.featured_titles = ["Paging Featured A", "Paging Featured B"]
+		self.plain_titles = ["Paging Plain A", "Paging Plain B"]
+		for title in self.featured_titles + self.plain_titles:
+			self._create_paging_course(title, featured=title in self.featured_titles)
+
+	def _create_paging_course(self, title, featured):
+		if frappe.db.exists("LMS Course", {"title": title}):
+			return
+		course = frappe.new_doc("LMS Course")
+		course.update(
+			{
+				"title": title,
+				"short_introduction": "Paging fixture",
+				"description": "Paging fixture",
+				"category": self.CATEGORY,
+				"published": 1,
+				"featured": 1 if featured else 0,
+				"instructors": [{"instructor": "Administrator"}],
+			}
+		)
+		course.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Course", course.name))
+
+	def _filters(self):
+		# `live` is the Published tab: it excludes featured from the main query
+		# and leads the list with them instead.
+		return {"published": 1, "live": 1, "category": self.CATEGORY}
+
+	def _page(self, start, size):
+		return get_courses(filters=self._filters(), start=start, limit_page_length=size)
+
+	def test_featured_courses_come_out_of_the_page_budget(self):
+		# The regression: two featured courses were prepended to an already-full
+		# page, so asking for three returned four.
+		self.assertEqual(len(self._page(0, 3)), 3)
+
+	def test_the_featured_courses_still_lead_the_list(self):
+		titles = [course.title for course in self._page(0, 4)]
+		self.assertEqual(set(titles[:2]), set(self.featured_titles))
+
+	def test_the_second_page_carries_on_where_the_first_stopped(self):
+		first = [course.name for course in self._page(0, 3)]
+		second = [course.name for course in self._page(3, 3)]
+		self.assertEqual(len(second), 1)
+		self.assertEqual(set(first) & set(second), set())
+
+	def test_every_course_appears_exactly_once_across_the_pages(self):
+		seen = [course.title for course in self._page(0, 3)] + [course.title for course in self._page(3, 3)]
+		self.assertEqual(sorted(seen), sorted(self.featured_titles + self.plain_titles))
+
+	def test_the_featured_read_stops_at_the_window(self):
+		"""The featured rows lead the list, but only the ones the page shows are
+		read: this is open to guests too, and there is no ceiling on how many
+		courses a site marks featured."""
+		with patch("lms.lms.utils.get_featured_courses", wraps=get_featured_courses) as read:
+			self._page(3, 3)
+		self.assertEqual(read.call_args.args[3], 6)
+
+	def test_the_count_includes_the_featured_courses(self):
+		self.assertEqual(get_course_count(filters=self._filters()), 4)
+
+	def test_the_batch_count_agrees_with_the_batch_list(self):
+		filters = {"published": 1}
+		listed = get_batches(filters=filters.copy(), start=0, limit_page_length=MAX_PAGE_LENGTH)
+		self.assertEqual(get_batch_count(filters=filters.copy()), len(listed))
+
+	def test_the_batch_count_drops_the_batches_the_list_drops(self):
+		"""
+		Upcoming is settled in Python, not in the query: a batch that started
+		earlier today still matches `start_date >= today` but is already under
+		way, so the list removes it. A count taken straight from the query would
+		keep it, and the footer would promise a row that is not there.
+		"""
+		self._create_started_today_batch()
+		filters = {"published": 1, "start_date": [">=", getdate()]}
+
+		listed = get_batches(filters=filters.copy(), start=0, limit_page_length=MAX_PAGE_LENGTH)
+		titles = [batch.title for batch in listed]
+
+		self.assertNotIn(self.STARTED_TODAY, titles)
+		self.assertEqual(get_batch_count(filters=filters.copy()), len(listed))
+
+	def test_the_archived_batch_count_agrees_with_the_archived_list(self):
+		"""The other side of the same boundary: a batch that started earlier today
+		is archived, and the query's `start_date <= today` cannot say so."""
+		self._create_started_today_batch()
+		filters = {"published": 1, "start_date": ["<=", getdate()]}
+
+		listed = get_batches(filters=filters.copy(), start=0, limit_page_length=MAX_PAGE_LENGTH)
+
+		self.assertIn(self.STARTED_TODAY, [batch.title for batch in listed])
+		self.assertEqual(get_batch_count(filters=filters.copy()), len(listed))
+
+	def test_the_batch_count_never_walks_the_rows(self):
+		"""The count is open to guests, so it must stay a COUNT.
+
+		It used to fetch every matching batch and run the list's Python pass over
+		the lot, which made an anonymous request cost as much as the site has
+		batches. Nothing may call that pass on the counting path again.
+		"""
+		self._create_started_today_batch()
+		filters = {"published": 1, "start_date": [">=", getdate()]}
+		expected = get_batch_count(filters=filters.copy())
+
+		with patch("lms.lms.utils.filter_batches_based_on_start_time") as walked:
+			walked.side_effect = AssertionError("the count fetched and filtered the rows")
+			self.assertEqual(get_batch_count(filters=filters.copy()), expected)
+
+	def _create_started_today_batch(self):
+		if frappe.db.exists("LMS Batch", {"title": self.STARTED_TODAY}):
+			return
+		batch = frappe.new_doc("LMS Batch")
+		batch.update(
+			{
+				"title": self.STARTED_TODAY,
+				"start_date": getdate(),
+				"end_date": getdate(),
+				# Before any wall clock this test can run at, so the list always
+				# treats it as already under way.
+				"start_time": "00:00:00",
+				"end_time": "00:00:01",
+				"timezone": "Asia/Kolkata",
+				"published": 1,
+				"description": "Paging fixture",
+				"batch_details": "Paging fixture",
+				"instructors": [{"instructor": "Administrator"}],
+			}
+		)
+		batch.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Batch", batch.name))
+
+	def test_a_guest_with_no_access_is_counted_as_nothing(self):
+		frappe.db.set_single_value("LMS Settings", "allow_guest_access", 0)
+		frappe.set_user("Guest")
+		try:
+			self.assertEqual(get_course_count(filters=self._filters()), 0)
+			self.assertEqual(get_batch_count(filters={"published": 1}), 0)
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.set_single_value("LMS Settings", "allow_guest_access", 1)

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -4,11 +4,14 @@
 from datetime import datetime
 
 import frappe
+from frappe.tests import UnitTestCase
 from frappe.utils import getdate, to_timedelta
 
 from lms.lms.doctype.lms_certificate.lms_certificate import is_certified
 from lms.lms.test_helpers import BaseTestUtils
 from lms.lms.utils import (
+	DEFAULT_PAGE_LENGTH,
+	MAX_PAGE_LENGTH,
 	create_user,
 	get_average_rating,
 	get_batch_details,
@@ -28,6 +31,7 @@ from lms.lms.utils import (
 	has_moderator_role,
 	has_student_role,
 	is_instructor,
+	resolve_page_length,
 	slugify,
 )
 
@@ -383,3 +387,39 @@ class TestGetLessonIcon(unittest.TestCase):
 		):
 			with self.subTest(block=block):
 				self.assertEqual(get_lesson_icon("", _content(block)), "icon-list")
+
+
+class TestResolvePageLength(UnitTestCase):
+	"""
+	`createListResource` sends `limit_page_length` and then advances `start` by
+	the same number. An endpoint that ignores it returns a page of a different
+	size, so the next page either repeats rows or skips them. These endpoints
+	are open to guests, so the value is also bounded.
+	"""
+
+	def test_client_page_size_is_honoured(self):
+		self.assertEqual(resolve_page_length(60), 60)
+
+	def test_missing_page_size_falls_back_to_the_default(self):
+		for empty in (None, "", 0):
+			with self.subTest(value=empty):
+				self.assertEqual(resolve_page_length(empty), DEFAULT_PAGE_LENGTH)
+
+	def test_numeric_strings_are_accepted(self):
+		self.assertEqual(resolve_page_length("60"), 60)
+
+	def test_unparseable_values_fall_back_rather_than_raise(self):
+		for junk in ("abc", "12; DROP TABLE", [], {}):
+			with self.subTest(value=junk):
+				self.assertEqual(resolve_page_length(junk), DEFAULT_PAGE_LENGTH)
+
+	def test_a_guest_cannot_ask_for_the_whole_table(self):
+		self.assertEqual(resolve_page_length(10_000), MAX_PAGE_LENGTH)
+
+	def test_boundaries(self):
+		self.assertEqual(resolve_page_length(1), 1)
+		self.assertEqual(resolve_page_length(MAX_PAGE_LENGTH), MAX_PAGE_LENGTH)
+		self.assertEqual(resolve_page_length(MAX_PAGE_LENGTH + 1), MAX_PAGE_LENGTH)
+
+	def test_negative_page_size_never_reaches_the_query(self):
+		self.assertEqual(resolve_page_length(-5), 1)


### PR DESCRIPTION

Makes the LMS _usable_ on a phone. Desktop is unchanged throughout, everything here is behind isMobile (<640px) or an md: breakpoint.

### Navigation

- The phone got the desk sidebar squeezed into a strip: nine icon-only buttons across 390px and a floating corner dropdown. Now four labelled tabs plus More, with the overflow in a grouped bottom sheet. A signed-out visitor gets a fixed set and no More button.

| Before | After |
| ---- | ---- |
| <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 37 42" src="https://github.com/user-attachments/assets/26dd2dbe-b72c-4581-9d69-99ec3fb025e2" /> | <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 37 38" src="https://github.com/user-attachments/assets/62cd2fc4-481c-4fb1-838c-d31e32d42533" /> |

### Scrolling

- Every list page put its rows in a box inside the page, so the page itself had no scroll range and the phone URL bar could never retract. Each list page is now one scroller: the title and filters scroll with the rows, only the header and footer hold.

| Before | After |
| ---- | ---- |
| <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 39 02" src="https://github.com/user-attachments/assets/dc4e76df-f08b-4773-ad45-a9b96ecd8560" /> | <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 38 55" src="https://github.com/user-attachments/assets/e549891b-fa38-4694-9b05-8b7d770ff2c3" /> |

### Course tabs

- Overview and Settings scrolled inside their tab panel — a second scroller nested in the page. Settings had two. They now flow with the page. The four tabs also overflowed 390px sideways; the icons are dropped and "Course editor" shortened to "Editor".

| Before | After |
| ---- | ---- |
| <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 39 36" src="https://github.com/user-attachments/assets/9b7a3490-e197-4445-9060-67748bddd545" /> | <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 39 33" src="https://github.com/user-attachments/assets/8dfa5892-5399-413f-bed6-9c7a44ffedd5" /> |

### Course editor

- The editor put a 30% outline beside a 70% editing surface, leaving neither room to work. On a phone the outline moves into a sheet behind a Chapters pill, and a stepper — prev, "2 / 5", next — sits above the editing surface.
- The lesson form was mx-10 px-20, so at 390px the content well was 150px and the title wrapped to four lines. It's 358px now, one line.

| Before | After (lesson editor) | After (open chapter navigation) |
| ---- | ---- | ---- |
| <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 43 37" src="https://github.com/user-attachments/assets/105efbe6-a1ff-4624-96f4-5f2884995454" /> | <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 43 42" src="https://github.com/user-attachments/assets/5a9ae48c-3847-4887-b5ab-036535c2f70f" /> | <img width="1440" height="3044" alt="Screen Shot 2026-07-30 at 18 45 14" src="https://github.com/user-attachments/assets/1a681081-868a-4d55-9f8e-383ad6c03941" /> |


### Also fixed
- The list footer said "30" when the page size was 24, for two separate reasons: the endpoints hardcoded their page length and ignored what the client asked for, and featured courses were prepended on top of an already-full page. Both fixed. Courses and Batches now have real totals, so the footer reads "24 of 44".
- Guest tabs ignored LMS Settings — turning Batches or Jobs off left the tab there and openable. Turning guest access off left the whole bar up.
- Programs repainted from a fetch the user had already navigated away from.
- A batch that started at 9am still read as "upcoming" at 2:30pm: str() of a timedelta drops the leading zero, so "9:00:00" > "14:30:00".