### PR TITLE
fix(lessons): serve the inline PDF viewer only on WebKit, and stop it hanging

### DIFF
--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -10,7 +10,14 @@
 			allowfullscreen
 		></iframe>
 	</div>
-	<div v-for="(block, index) in content?.split('\n\n')" :key="index">
+	<!-- Keyed on the block text, not just the index: position N of the outgoing
+	     lesson and position N of the incoming one share an index, so Vue reuses
+	     the instance and hands a <PdfBlock> a new `file` — which it only reads
+	     once, at setup. Including the text forces a fresh instance. -->
+	<div
+		v-for="(block, index) in content?.split('\n\n')"
+		:key="`${index}:${block}`"
+	>
 		<div v-if="block.includes('{{ YouTubeVideo')">
 			<iframe
 				class="youtube-video"
@@ -36,7 +43,16 @@
 			</video>
 		</div>
 		<div v-else-if="block.includes('{{ PDF')">
-			<PdfBlock :file="getId(block)" />
+			<PdfBlock v-if="inlinePdf" :file="getId(block)" />
+			<iframe
+				v-else
+				:src="getId(block)"
+				:title="__('PDF document')"
+				width="100%"
+				height="700px"
+				class="mb-4"
+				type="application/pdf"
+			></iframe>
 		</div>
 		<div v-else-if="block.includes('{{ Audio')">
 			<audio width="100%" controls controlsList="nodownload">
@@ -67,8 +83,10 @@ import MarkdownIt from 'markdown-it'
 import { useScreenSize } from '@/utils/composables'
 import { getMacroArg } from '@/utils/lessonMacros'
 import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
+import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
 
 const screenSize = useScreenSize()
+const inlinePdf = usesWebkitPdfViewer()
 
 const markdown = new MarkdownIt({
 	html: true,

--- a/frontend/src/components/PdfBlock.vue
+++ b/frontend/src/components/PdfBlock.vue
@@ -11,12 +11,9 @@
 				>
 					<ChevronLeft :size="18" :stroke-width="1.5" />
 				</button>
-				<span class="pdf-page-indicator">
-					<template v-if="numPages"
-						>{{ currentPage }} / {{ numPages }}</template
-					>
-					<template v-else>—</template>
-				</span>
+				<span class="pdf-page-indicator">{{
+					numPages ? currentPage + ' / ' + numPages : '—'
+				}}</span>
 				<button
 					type="button"
 					class="pdf-btn"
@@ -139,6 +136,7 @@ let canvasEls = []
 let renderTasks = [] // active RenderTask per page index
 let rendered = [] // bool per page index
 let rafId = null
+let task = null // in-flight PDFDocumentLoadingTask
 
 // --- shared, ref-counted worker (multi-instance safe; terminated on last unmount) ---
 // A leaked pdf.js worker is worse than a leaked <audio>, so we always release it.
@@ -160,16 +158,27 @@ async function load() {
 		// fold ~144kB gzip of pdf.js into the main entry that every LMS page pays.
 		pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs')
 		if (disposed) return
-		if (sharedWorker) pdfjsLib.GlobalWorkerOptions.workerPort = sharedWorker
+		// Wrap the raw port in our own PDFWorker and pass it explicitly. Via
+		// GlobalWorkerOptions.workerPort, pdf.js hands each loading task
+		// ownership of the shared worker, so one viewer's pdfDoc.destroy()
+		// tears down the port-level message handler every *sibling* viewer is
+		// still listening on — their getDocument() then never settles and the
+		// spinner runs forever. Passing `worker` keeps ownership here.
+		if (sharedWorker && !sharedPdfWorker) {
+			sharedPdfWorker = new pdfjsLib.PDFWorker({ port: sharedWorker })
+		}
 
 		const base = import.meta.env.BASE_URL || '/'
 		const loadingTask = pdfjsLib.getDocument({
 			url: props.file,
+			worker: sharedPdfWorker || undefined,
 			cMapUrl: `${base}pdfjs/cmaps/`,
 			cMapPacked: true,
 			standardFontDataUrl: `${base}pdfjs/standard_fonts/`,
 		})
+		task = loadingTask
 		pdfDoc = await loadingTask.promise
+		task = null
 		if (disposed) return
 		numPages.value = pdfDoc.numPages
 
@@ -222,10 +231,14 @@ function releaseWorker() {
 	if (!heldWorker) return
 	heldWorker = false
 	sharedWorkerRefs = Math.max(0, sharedWorkerRefs - 1)
-	if (sharedWorkerRefs === 0 && sharedWorker) {
-		sharedWorker.terminate()
+	// Not guarded on the per-instance `pdfjsLib`: an instance that unmounts
+	// before its dynamic import resolves would otherwise strand a terminated
+	// worker in module scope.
+	if (sharedWorkerRefs === 0) {
+		sharedPdfWorker?.destroy()
+		sharedPdfWorker = null
+		sharedWorker?.terminate()
 		sharedWorker = null
-		if (pdfjsLib) pdfjsLib.GlobalWorkerOptions.workerPort = null
 	}
 }
 
@@ -375,10 +388,13 @@ onBeforeUnmount(() => {
 	renderTasks = []
 	try {
 		pdfDoc?.destroy()
+		// A load that never resolved leaves pdfDoc null, so cancel the task too.
+		task?.destroy()
 	} catch (e) {
 		/* noop */
 	}
 	pdfDoc = null
+	task = null
 	releaseWorker()
 })
 
@@ -389,6 +405,9 @@ defineExpose({ fitWidth, goToPage })
 // Module-scoped so every PdfBlock instance shares one pdf.js worker.
 let sharedWorker = null
 let sharedWorkerRefs = 0
+// The pdf.js-side wrapper for `sharedWorker`. Owned here, never by a loading
+// task, so one document's destroy() can't tear it out from under another's.
+let sharedPdfWorker = null
 </script>
 
 <style scoped>

--- a/frontend/src/js-sfc-shims.d.ts
+++ b/frontend/src/js-sfc-shims.d.ts
@@ -1,0 +1,12 @@
+// PdfBlock.vue is still a plain-JS SFC (`<script setup>` with no `lang="ts"`),
+// so under `strict` it has no declaration and every TS test that imports it
+// trips TS7016. Declaring it as what it is — a Vue component — costs nothing at
+// runtime and keeps the type baseline from drifting.
+//
+// DELETE this file the moment PdfBlock.vue gains `lang="ts"`: a wildcard-free
+// module declaration would otherwise shadow the SFC's real, inferred types.
+declare module '@/components/PdfBlock.vue' {
+	import type { Component } from 'vue'
+	const component: Component
+	export default component
+}

--- a/frontend/src/tests/PdfBlock.test.ts
+++ b/frontend/src/tests/PdfBlock.test.ts
@@ -1,5 +1,40 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
+
+// `new pdfjsLib.PDFWorker({ port })` reaches the REAL pdf.js class here even
+// though `getDocument` is mocked, so pdf.js spins up its in-process fallback
+// worker and rejects "Worker was terminated" when the port is torn down. That
+// rejection is unobservable from our code and would fail the whole run despite
+// every assertion passing. Absorb only that one message, and fail loudly on
+// anything else so this cannot hide a real defect.
+const EXPECTED_TEARDOWN_REJECTION = 'Worker was terminated'
+const unexpectedRejections: string[] = []
+const onRejection = (reason: unknown) => {
+	const message = (reason as Error)?.message
+	if (message !== EXPECTED_TEARDOWN_REJECTION) {
+		unexpectedRejections.push(String(message ?? reason))
+	}
+}
+// Reached via globalThis because this tsconfig sets `types: []`, so there are
+// no @types/node globals to declare `process`.
+const proc = (globalThis as { process?: NodeEventTarget }).process
+type NodeEventTarget = {
+	on(event: string, listener: (reason: unknown) => void): void
+	off(event: string, listener: (reason: unknown) => void): void
+}
+proc?.on('unhandledRejection', onRejection)
+afterAll(() => {
+	proc?.off('unhandledRejection', onRejection)
+	expect(unexpectedRejections).toEqual([])
+})
 
 // pdf.js can't be imported in vitest+jsdom (ReferenceError: DOMMatrix), and it
 // needs no real rendering to test the lifecycle — mock it. A shared `state`
@@ -9,6 +44,10 @@ const state = vi.hoisted(() => ({
 	destroy: vi.fn(),
 	cancel: vi.fn(),
 	workerPort: null as unknown,
+	// The PDFWorker PdfBlock owns itself, plus the loading task it cancels.
+	pdfWorkerDestroy: vi.fn(),
+	taskDestroy: vi.fn(),
+	pdfWorkers: 0,
 }))
 
 const makePdf = () => ({
@@ -25,7 +64,16 @@ vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
 		promise: state.shouldReject
 			? Promise.reject(new Error('boom'))
 			: Promise.resolve(makePdf()),
+		destroy: state.taskDestroy,
 	})),
+	// PdfBlock wraps the shared port in its own PDFWorker and passes it to
+	// getDocument, so no loading task can destroy the port other viewers share.
+	PDFWorker: class {
+		destroy = state.pdfWorkerDestroy
+		constructor() {
+			state.pdfWorkers++
+		}
+	},
 	GlobalWorkerOptions: {
 		set workerPort(v: unknown) {
 			state.workerPort = v
@@ -44,13 +92,29 @@ const createPdfWorker = vi.hoisted(() => vi.fn())
 vi.mock('@/utils/pdfWorker', () => ({ createPdfWorker }))
 
 beforeEach(() => {
+	// jsdom's rAF fires on a ~16ms timer, so `nextFrame()` outlives
+	// flushPromises() and load() is still mid-flight when a test ends. Running
+	// the callback synchronously lets load() finish inside the test instead of
+	// leaving pdf.js work pending across teardown (which surfaces as an
+	// unhandled "Worker was terminated" rejection and fails the whole run).
+	vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+		cb(0)
+		return 0
+	})
+	vi.stubGlobal('cancelAnimationFrame', () => {})
 	state.shouldReject = false
 	state.destroy.mockClear()
 	state.cancel.mockClear()
 	state.workerPort = null
+	state.pdfWorkerDestroy.mockClear()
+	state.taskDestroy.mockClear()
+	state.pdfWorkers = 0
 	terminate.mockClear()
 	createPdfWorker.mockReset()
-	createPdfWorker.mockImplementation(() => ({ terminate, postMessage: vi.fn() }))
+	createPdfWorker.mockImplementation(() => ({
+		terminate,
+		postMessage: vi.fn(),
+	}))
 })
 afterEach(() => {
 	vi.resetModules()
@@ -88,8 +152,11 @@ describe('PdfBlock', () => {
 		expect(state.destroy).not.toHaveBeenCalled()
 		wrapper.unmount()
 		expect(state.destroy).toHaveBeenCalledTimes(1)
-		// last holder released -> worker terminated + port cleared
+		// last holder released -> our PDFWorker destroyed, then the port
+		expect(state.pdfWorkerDestroy).toHaveBeenCalledTimes(1)
 		expect(terminate).toHaveBeenCalledTimes(1)
+		// The pdf.js global is never written, so no viewer can strand a
+		// terminated port there for the next one to pick up.
 		expect(state.workerPort).toBeNull()
 	})
 
@@ -116,9 +183,55 @@ describe('PdfBlock', () => {
 		// one worker shared by both
 		expect(createPdfWorker).toHaveBeenCalledTimes(1)
 
+		// ...and one PDFWorker wrapping it, owned by the module, not by either
+		// loading task — so a's teardown can't strand b on the spinner forever.
+		expect(state.pdfWorkers).toBe(1)
+
 		a.unmount()
 		expect(terminate).not.toHaveBeenCalled() // b still holds it
+		expect(state.pdfWorkerDestroy).not.toHaveBeenCalled()
 		b.unmount()
 		expect(terminate).toHaveBeenCalledTimes(1) // last holder released
+		expect(state.pdfWorkerDestroy).toHaveBeenCalledTimes(1)
+	})
+
+	// The bug this pins: via GlobalWorkerOptions.workerPort, pdf.js records the
+	// SHARED worker on each document's loading task, so one viewer's
+	// pdfDoc.destroy() tears down the port-level message handler its siblings
+	// are still listening on — their load then never resolves *and never
+	// rejects*, leaving a permanent "Loading PDF…". Passing `worker` explicitly
+	// makes pdf.js skip that ownership assignment.
+	it('passes the shared worker explicitly instead of via the pdf.js global', async () => {
+		const pdf = await import('pdfjs-dist/legacy/build/pdf.mjs')
+		const a = await mountPdf() // fully settled: leaves no pending load()
+		const arg = vi.mocked(pdf.getDocument).mock.calls[0][0] as {
+			worker?: unknown
+		}
+		expect(arg.worker).toBeTruthy() // ours, not the loading task's
+		expect(state.pdfWorkers).toBe(1)
+		expect(state.workerPort).toBeNull() // the global is never written
+		a.unmount()
+	})
+
+	it('cancels a loading task that has not resolved yet', async () => {
+		const { default: PdfBlock } = await import('@/components/PdfBlock.vue')
+		const pdf = await import('pdfjs-dist/legacy/build/pdf.mjs')
+		// A load still in flight at unmount: pdfDoc is null, so pdfDoc.destroy()
+		// is a no-op and only task.destroy() can cancel it. Settled at the end of
+		// the test rather than left dangling — a pending load that outlives
+		// vi.resetModules() re-imports the REAL pdf.js and leaks a rejection.
+		let settle: (v: unknown) => void = () => {}
+		vi.mocked(pdf.getDocument).mockReturnValueOnce({
+			promise: new Promise((r) => {
+				settle = r
+			}),
+			destroy: state.taskDestroy,
+		} as unknown as ReturnType<typeof pdf.getDocument>)
+		const wrapper = mount(PdfBlock, { props: { file: '/files/slow.pdf' } })
+		await flushPromises()
+		wrapper.unmount()
+		expect(state.taskDestroy).toHaveBeenCalledTimes(1)
+		settle(makePdf())
+		await flushPromises()
 	})
 })

--- a/frontend/src/tests/pdfViewer.test.ts
+++ b/frontend/src/tests/pdfViewer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
+
+const nav = (userAgent: string, platform = 'Win32', maxTouchPoints = 0) => {
+	return { userAgent, platform, maxTouchPoints } as unknown as Navigator
+}
+
+const IOS_SAFARI =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+const IOS_CHROME =
+	'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/122.0.0.0 Mobile/15E148 Safari/604.1'
+const MAC_SAFARI =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15'
+const CHROME =
+	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+const FIREFOX =
+	'Mozilla/5.0 (X11; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0'
+const EDGE =
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0'
+
+describe('usesWebkitPdfViewer', () => {
+	it('uses the inline viewer on iOS Safari', () => {
+		expect(usesWebkitPdfViewer(nav(IOS_SAFARI, 'iPhone'))).toBe(true)
+	})
+
+	// Every iOS browser is WebKit under the skin, so they share the bug.
+	it('uses the inline viewer on iOS Chrome', () => {
+		expect(usesWebkitPdfViewer(nav(IOS_CHROME, 'iPhone'))).toBe(true)
+	})
+
+	it('uses the inline viewer on iPadOS, which claims to be a Mac', () => {
+		expect(usesWebkitPdfViewer(nav(MAC_SAFARI, 'MacIntel', 5))).toBe(true)
+	})
+
+	it('uses the inline viewer on desktop Safari', () => {
+		expect(usesWebkitPdfViewer(nav(MAC_SAFARI, 'MacIntel', 0))).toBe(true)
+	})
+
+	it.each([
+		['Chrome', CHROME],
+		['Firefox', FIREFOX],
+		['Edge', EDGE],
+	])('keeps the native iframe plugin on %s', (_name, ua) => {
+		expect(usesWebkitPdfViewer(nav(ua))).toBe(false)
+	})
+
+	it('keeps the native plugin on a desktop Mac running Chrome', () => {
+		expect(usesWebkitPdfViewer(nav(CHROME, 'MacIntel', 0))).toBe(false)
+	})
+})

--- a/frontend/src/utils/pdfViewer.ts
+++ b/frontend/src/utils/pdfViewer.ts
@@ -1,0 +1,17 @@
+// WebKit refuses to scroll a PDF inside an <iframe> — on iOS/iPadOS every
+// browser is WebKit, so the lesson PDF shows page 1 or nothing. Those engines
+// get the inline pdf.js viewer (PdfBlock.vue); everywhere else keeps the native
+// <iframe> plugin, which is faster, has the browser's own toolbar, and doesn't
+// ship ~144kB of pdf.js.
+export function usesWebkitPdfViewer(nav: Navigator = navigator): boolean {
+	const ua = nav.userAgent || ''
+	// iPadOS 13+ reports itself as MacIntel, so touch points disambiguate it.
+	const isIOS =
+		/iP(hone|ad|od)/.test(ua) ||
+		(nav.platform === 'MacIntel' && nav.maxTouchPoints > 1)
+	// Blink and Gecko both carry "AppleWebKit" in their UA for legacy reasons;
+	// their own engine tokens are what actually rule Safari out.
+	const isSafari =
+		/AppleWebKit/.test(ua) && !/Chrom(e|ium)|Edg\/|OPR\//.test(ua)
+	return isIOS || isSafari
+}

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -5,6 +5,7 @@ import UploadPlugin from '@/components/UploadPlugin.vue'
 import { h, createApp } from 'vue'
 import { Upload as UploadIcon } from 'lucide-vue-next'
 import { createDialog } from '@/utils/dialogs'
+import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
 import translationPlugin from '../translation'
 
 export class Upload {
@@ -67,9 +68,18 @@ export class Upload {
 			app.mount(this.wrapper)
 			return
 		} else if (file.file_type == 'PDF') {
-			// iOS Safari (all WebKit browsers) refuses to scroll a PDF in an
-			// <iframe>, so render it inline via pdf.js. mount()/unmount() is tracked
-			// so destroy() can tear the pdf.js worker + render tasks down.
+			// WebKit refuses to scroll a PDF in an <iframe>, so it gets the inline
+			// pdf.js viewer. mount()/unmount() is tracked so destroy() can tear the
+			// pdf.js worker + render tasks down. Everywhere else keeps the native
+			// plugin. See utils/pdfViewer.
+			if (!usesWebkitPdfViewer()) {
+				this.wrapper.innerHTML = `<iframe src="${
+					window.location.origin
+				}${encodeURI(
+					file.file_url
+				)}" width='100%' height='700px' class="mb-4" type="application/pdf"></iframe>`
+				return
+			}
 			this.app = createApp(PdfBlock, {
 				file: file.file_url,
 			})


### PR DESCRIPTION
## Summary
### The problem

- On iPhone/iPad (and Safari generally), a PDF inside a lesson wouldn't scroll — you'd see page 1 or a blank box. WebKit just refuses to scroll a PDF in an <iframe>. The earlier fix swapped that iframe for a built-in pdf.js viewer, but it did so for every browser: Chrome/Firefox/Edge users lost the browser's own faster native PDF toolbar and paid ~144 KB of extra JavaScript for no reason. And when a lesson had two or more PDFs, one of them being torn down could leave the others stuck on "Loading PDF…" forever.

### Solution

- Right viewer per browser. New usesWebkitPdfViewer() helper: Safari, iOS and iPadOS get the inline pdf.js viewer; everyone else keeps the native iframe. It correctly handles iPadOS (which reports itself as a Mac) and iOS Chrome (WebKit under the skin, so it has the same bug). Applied in both the lesson renderer and the editor's PDF block.
- Added tests