### PR TITLE
feat(raven): let Moderators manage the Raven integration

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -295,3 +295,9 @@ require_type_annotated_api_methods = True
 # LMS contributes its rule types + evaluator to the standalone `raven_integration`
 # app via the `raven_membership_providers` hook. See lms/raven_provider.py.
 raven_membership_providers = ["lms.raven_provider.get_provider"]
+
+# Settings > Integrations > Raven sits inside the Settings modal, which is open to
+# any Moderator, so the endpoints behind it have to be too. raven_integration gates
+# on System Manager plus whatever this hook names, and grants the named roles the
+# permissions its own doctypes need on install/migrate.
+raven_integration_manager_roles = ["Moderator"]


### PR DESCRIPTION
- Settings is open to any Moderator and the Raven item carries no extra condition, but every endpoint behind it gated on System Manager — so a Moderator who is not also a System Manager saw the panel and got a bare PermissionError from its first call.
- raven_integration now reads a manager-role hook from its host app; declaring Moderator both widens the gate and gets the role the DocPerms those endpoints need. No frontend change: the UI already assumed this.