### PR TITLE
fix(settings): stop Settings > Raven dumping a traceback when raven_integration is absent

### DIFF
--- a/frontend/src/components/Settings/Raven/RavenSettings.vue
+++ b/frontend/src/components/Settings/Raven/RavenSettings.vue
@@ -99,8 +99,11 @@ defineProps<{ label: string; description: string }>()
 // state, else they get the "not set up" card telling them to fix what they can't.
 const notPermitted = ref(false)
 
+// LMS, not raven_integration: calling a method of an app that is not installed
+// raises AppNotInstalledError, and frappe-ui dumps the server traceback and
+// rethrows before onError runs. See lms.raven_provider.get_raven_setup.
 const setup = createResource<RavenSetupState>({
-	url: 'raven_integration.api.is_setup',
+	url: 'lms.raven_provider.get_raven_setup',
 	auto: true,
 	onError(err: { exc_type?: string }) {
 		notPermitted.value = err?.exc_type === 'PermissionError'

--- a/frontend/src/tests/ravenSetupGate.test.ts
+++ b/frontend/src/tests/ravenSetupGate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Settings > Raven must not call into raven_integration to find out whether
+ * raven_integration is installed. Frappe answers a method of an uninstalled app
+ * with AppNotInstalledError (HTTP 417), and frappe-ui logs the whole server
+ * traceback and rethrows before any `onError` can matter — an uncatchable console
+ * dump plus an unhandled rejection every time the panel opens. LMS answers the
+ * install question instead (lms.raven_provider.get_raven_setup).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RavenSettings from '@/components/Settings/Raven/RavenSettings.vue'
+import type { RavenSetupState } from '@/types'
+
+const LMS_SETUP = 'lms.raven_provider.get_raven_setup'
+
+const state = vi.hoisted(() => ({
+	setup: null as RavenSetupState | null,
+	requested: [] as string[],
+}))
+
+vi.mock('frappe-ui', () => ({
+	// Close enough to the real resource for the gate: `auto` fetches on creation,
+	// and every fetch/reload is recorded.
+	createResource: (options: { url: string; auto?: boolean }) => {
+		const resource = {
+			url: options.url,
+			data: null as RavenSetupState | null,
+			loading: false,
+			fetched: false,
+			fetch() {
+				state.requested.push(options.url)
+				resource.fetched = true
+				if (options.url === LMS_SETUP) resource.data = state.setup
+			},
+			reload() {
+				resource.fetch()
+			},
+			submit() {},
+		}
+		if (options.auto) resource.fetch()
+		return resource
+	},
+	Button: {
+		props: ['variant', 'loading'],
+		emits: ['click'],
+		template: `<button @click="$emit('click')"><slot name="prefix" /><slot /></button>`,
+	},
+	toast: { error: vi.fn() },
+}))
+
+vi.mock('@/components/Layouts/SettingsLayout.vue', () => ({
+	default: {
+		name: 'SettingsLayout',
+		props: ['title', 'description'],
+		template: `<div class="settings-layout"><slot name="header-actions" /><slot /></div>`,
+	},
+}))
+
+vi.mock('@/components/Settings/Raven/RavenNotInstalledBanner.vue', () => ({
+	default: {
+		name: 'RavenNotInstalledBanner',
+		props: ['missing'],
+		template: `<div data-testid="not-installed">{{ missing }}</div>`,
+	},
+}))
+
+vi.mock('@/components/Settings/Raven/WorkspaceList.vue', () => ({
+	default: {
+		name: 'WorkspaceList',
+		template: `<div data-testid="workspace-list" />`,
+	},
+}))
+
+vi.mock('@/components/Settings/Raven/ChannelsView.vue', () => ({
+	default: { name: 'ChannelsView', template: `<div class="channels-view" />` },
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+function mountPanel() {
+	return mount(RavenSettings, {
+		props: { label: 'Raven', description: 'Sync membership' },
+		global: { mocks: { __: (s: string) => s } },
+	})
+}
+
+beforeEach(() => {
+	state.requested = []
+	state.setup = null
+})
+
+describe('Settings > Raven setup gate', () => {
+	it('asks LMS for the setup state, never the app that may be missing', () => {
+		state.setup = { raven: false, raven_integration: false, enabled: false }
+
+		mountPanel()
+
+		expect(state.requested).toEqual([LMS_SETUP])
+		expect(
+			state.requested.some((url) => url.startsWith('raven_integration.'))
+		).toBe(false)
+	})
+
+	it('reports raven_integration as missing without calling it', () => {
+		state.setup = { raven: true, raven_integration: false, enabled: false }
+
+		const wrapper = mountPanel()
+
+		expect(wrapper.get('[data-testid="not-installed"]').text()).toBe(
+			'raven_integration'
+		)
+	})
+
+	it('reports Raven itself as missing', () => {
+		state.setup = { raven: false, raven_integration: true, enabled: false }
+
+		const wrapper = mountPanel()
+
+		expect(wrapper.get('[data-testid="not-installed"]').text()).toBe('raven')
+	})
+
+	it('manages workspaces once both apps are installed and enabled', () => {
+		state.setup = { raven: true, raven_integration: true, enabled: true }
+
+		const wrapper = mountPanel()
+
+		expect(wrapper.find('[data-testid="not-installed"]').exists()).toBe(false)
+		expect(wrapper.find('[data-testid="workspace-list"]').exists()).toBe(true)
+	})
+})

--- a/lms/lms/test_raven_provider.py
+++ b/lms/lms/test_raven_provider.py
@@ -813,3 +813,27 @@ class TestGetRavenSetup(UnitTestCase):
 		state = raven_provider.get_raven_setup()
 
 		self.assertTrue(state["enabled"])
+
+	def test_gate_follows_the_manager_roles_hook(self):
+		"""The Settings modal is open to Moderators, so this must be too — and the role
+		list has to come from the hook, or it drifts from raven_integration's own gate.
+		"""
+		self._patch_apps(["frappe", "lms"])
+		real_only_for = frappe.only_for
+		real_get_hooks = frappe.get_hooks
+		seen = []
+
+		def fake_hooks(hook=None, *args, **kwargs):
+			if hook == "raven_integration_manager_roles":
+				return ["Moderator"]
+			return real_get_hooks(hook, *args, **kwargs)
+
+		frappe.only_for = lambda roles, *a, **k: seen.append(roles)
+		frappe.get_hooks = fake_hooks
+		try:
+			raven_provider.get_raven_setup()
+		finally:
+			frappe.only_for = real_only_for
+			frappe.get_hooks = real_get_hooks
+
+		self.assertEqual(seen, [["System Manager", "Moderator"]])

--- a/lms/lms/test_raven_provider.py
+++ b/lms/lms/test_raven_provider.py
@@ -1,6 +1,7 @@
 import importlib.util
 import sys
 import time
+import types
 
 import frappe
 from frappe.tests import UnitTestCase
@@ -758,3 +759,57 @@ class TestRulePerformance(FrappeTestCase):
 			f"default_evaluator took {elapsed * 1000:.1f}ms — exceeds {self._THRESHOLD_SEC * 1000:.0f}ms "
 			f"threshold. Check that lms.patches.v2_0.add_batch_enrollment_index has run.",
 		)
+
+
+class TestGetRavenSetup(UnitTestCase):
+	"""Settings > Raven asks LMS, not raven_integration, whether raven_integration is
+	there — a method of an uninstalled app raises AppNotInstalledError, and the panel
+	that exists to say "install it" cannot render off an exception. Schema-free, so
+	UnitTestCase.
+	"""
+
+	def setUp(self):
+		self._installed = frappe.get_installed_apps
+
+	def tearDown(self):
+		frappe.get_installed_apps = self._installed
+		sys.modules.pop("raven_integration.api", None)
+
+	def _patch_apps(self, apps):
+		frappe.get_installed_apps = lambda *a, **k: apps
+
+	def test_reports_missing_apps_without_importing_them(self):
+		self._patch_apps(["frappe", "lms"])
+		blocked = ("raven_integration", "raven_integration.api")
+		saved = {name: sys.modules.get(name) for name in blocked}
+		# A None entry makes the import machinery raise ImportError, exactly as an
+		# uninstalled app does — so the test fails loudly if the delegation runs.
+		for name in blocked:
+			sys.modules[name] = None
+		try:
+			state = raven_provider.get_raven_setup()
+		finally:
+			for name, original in saved.items():
+				if original is None:
+					sys.modules.pop(name, None)
+				else:
+					sys.modules[name] = original
+
+		self.assertEqual(state, {"raven": False, "raven_integration": False, "enabled": False})
+
+	def test_reports_raven_missing_on_its_own(self):
+		self._patch_apps(["frappe", "lms", "raven_integration"])
+		state = raven_provider.get_raven_setup()
+		self.assertFalse(state["raven"])
+		self.assertTrue(state["raven_integration"])
+		self.assertFalse(state["enabled"])
+
+	def test_delegates_once_both_apps_are_installed(self):
+		self._patch_apps(["frappe", "lms", "raven", "raven_integration"])
+		stub = types.ModuleType("raven_integration.api")
+		stub.is_setup = lambda: {"raven": True, "raven_integration": True, "enabled": True}
+		sys.modules["raven_integration.api"] = stub
+
+		state = raven_provider.get_raven_setup()
+
+		self.assertTrue(state["enabled"])

--- a/lms/raven_provider.py
+++ b/lms/raven_provider.py
@@ -141,10 +141,13 @@ def get_raven_setup() -> dict:
 	answers the install half itself and delegates the rest only when it can be
 	served.
 
-	System Manager only, matching `raven_integration.api.is_setup`: the reply
-	enumerates installed apps.
+	Managers only, matching `raven_integration.api.is_setup`: the reply enumerates
+	installed apps. The role list is derived from the same
+	`raven_integration_manager_roles` hook that widens the gate on that side, so the
+	two cannot drift — and it is read from the hook rather than imported from
+	raven_integration, which is the app this function exists to work without.
 	"""
-	frappe.only_for("System Manager")
+	frappe.only_for(["System Manager", *(frappe.get_hooks("raven_integration_manager_roles") or [])])
 	apps = frappe.get_installed_apps()
 	state = {
 		"raven": "raven" in apps,

--- a/lms/raven_provider.py
+++ b/lms/raven_provider.py
@@ -129,6 +129,35 @@ def get_provider() -> dict:
 	}
 
 
+@frappe.whitelist()
+def get_raven_setup() -> dict:
+	"""Setup state behind Settings > Raven: are both apps installed, and is the
+	integration enabled?
+
+	The panel cannot ask raven_integration this directly. Frappe answers a method of
+	an app that is not installed with AppNotInstalledError, and frappe-ui prints the
+	server traceback and rethrows it before any `onError` runs — an error no caller
+	can quiet, on a screen whose whole job is to say "install the app". So LMS
+	answers the install half itself and delegates the rest only when it can be
+	served.
+
+	System Manager only, matching `raven_integration.api.is_setup`: the reply
+	enumerates installed apps.
+	"""
+	frappe.only_for("System Manager")
+	apps = frappe.get_installed_apps()
+	state = {
+		"raven": "raven" in apps,
+		"raven_integration": "raven_integration" in apps,
+		"enabled": False,
+	}
+	if state["raven"] and state["raven_integration"]:
+		from raven_integration.api import is_setup
+
+		state.update(is_setup())
+	return state
+
+
 def _as_list(value: str | list | None) -> list[str]:
 	"""Coerce a rule's course/batch field into a flat list of names (JSON list, JSON string, or a legacy list of ``{"course"/"batch": name}`` dicts)."""
 	if not value:


### PR DESCRIPTION
Summary
- Opening Settings > Raven called raven_integration.api.is_setup. When that app isn't installed, Frappe answers 417 and frappe-ui logs the full server traceback and rethrows it before onError can run — so the screen whose whole job is to say "install the app" dumped a traceback instead, and nothing could suppress it. (pollutes the console even though it is by design)
- LMS now answers the "is it installed?" half itself via lms.raven_provider.get_raven_setup, and only calls into raven_integration once that call can actually be served.
- That endpoint is gated on manager roles, not System Manager. It's the panel's first call and Settings is open to Moderators, so a System-Manager-only gate would fail immediately. The roles come from the raven_integration_manager_roles hook rather than an import, so the gate can't drift from raven_integration's — and still works when raven_integration is absent, which is the only reason this function exists.
- Adds a frontend gate test and TestGetRavenSetup.