### PR TITLE
feat(evaluations): show slot times in the batch's timezone

### DIFF
--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -20,36 +20,53 @@
 					:options="getCourses()"
 				/>
 				<div v-if="slots.data?.length" class="space-y-4 overflow-y-auto mt-4">
-					<div class="text-ink-gray-9 font-medium">
-						{{ __('Available Slots') }}
+					<div class="flex items-baseline justify-between gap-x-3">
+						<div class="text-ink-gray-9 font-medium">
+							{{ __('Available Slots') }}
+						</div>
+						<div v-if="scheduleTimezone" class="text-sm text-ink-gray-5">
+							{{ __('All times in {0}').format(scheduleTimezone) }}
+						</div>
 					</div>
 					<div class="space-y-5">
-						<div v-for="row in slots.data" :key="row.date" class="space-y-2">
+						<div
+							v-for="row in slots.data"
+							:key="row.display_date"
+							class="space-y-2"
+						>
 							<div class="flex items-center text-ink-gray-7 gap-x-2">
 								<span class="lucide-calendar size-3" />
 								<div class="text-ink-gray-9">
-									{{ dayjs(row.date).format('DD MMMM YYYY') }}
+									{{ dayjs(row.display_date).format('DD MMMM YYYY') }}
 								</div>
 								<div>&middot;</div>
 								<div class="text-ink-gray-5">
-									{{ row.day }}
+									{{ row.display_day }}
 								</div>
+								<template
+									v-if="row.display_timezone_label !== scheduleTimezone"
+								>
+									<div>&middot;</div>
+									<div class="text-ink-gray-5">
+										{{ row.display_timezone_label }}
+									</div>
+								</template>
 							</div>
 							<div class="grid grid-cols-3 gap-2">
 								<button
 									v-for="slot in row.slots"
-									:key="slot.start_time"
+									:key="`${slot.date}-${slot.start_time}`"
 									type="button"
 									class="text-base text-center border rounded-md text-ink-gray-8 p-2 cursor-pointer text-ink-gray-7 hover:bg-surface-gray-2 hover:border-outline-gray-3"
-									@click="saveSlot(slot, row)"
+									@click="saveSlot(slot)"
 									:class="{
 										'border-outline-gray-4 text-ink-gray-9':
-											evaluation.date == row.date &&
+											evaluation.date == slot.date &&
 											evaluation.start_time == slot.start_time,
 									}"
 								>
-									{{ formatTime(slot.start_time) }} -
-									{{ formatTime(slot.end_time) }}
+									{{ formatTime(slot.display_start_time) }} -
+									{{ formatTime(slot.display_end_time) }}
 								</button>
 							</div>
 						</div>
@@ -67,8 +84,8 @@
 </template>
 <script setup>
 import { call, createResource, Dialog, FormControl, toast } from 'frappe-ui'
-import { ref, watch, inject } from 'vue'
-import { formatTime } from '@/utils/'
+import { computed, ref, watch, inject } from 'vue'
+import { formatTime } from '@/utils'
 
 const dayjs = inject('$dayjs')
 const user = inject('$user')
@@ -159,10 +176,21 @@ watch(
 	}
 )
 
-const saveSlot = (slot, row) => {
+/* get_schedule spans 60 days, so the header label is wrong for later days once a
+   DST transition falls inside the range. Each day carries its own label and only
+   the ones that disagree with the header repeat it. */
+const scheduleTimezone = computed(
+	() => slots.data?.[0]?.display_timezone_label ?? ''
+)
+
+/* Displayed times are converted; the booking submits the system values the slot
+   was stored with. Both live on the slot, not the day: converting can move a
+   slot into the previous or next day, so one rendered day can hold slots from
+   two different stored dates. */
+const saveSlot = (slot) => {
 	evaluation.value.start_time = slot.start_time
 	evaluation.value.end_time = slot.end_time
-	evaluation.value.date = row.date
-	evaluation.value.day = row.day
+	evaluation.value.date = slot.date
+	evaluation.value.day = slot.day
 }
 </script>

--- a/frontend/src/components/Modals/EvaluationModal.vue
+++ b/frontend/src/components/Modals/EvaluationModal.vue
@@ -59,6 +59,8 @@
 									type="button"
 									class="text-base text-center border rounded-md text-ink-gray-8 p-2 cursor-pointer text-ink-gray-7 hover:bg-surface-gray-2 hover:border-outline-gray-3"
 									@click="saveSlot(slot)"
+									:title="slotLabel(slot, row)"
+									:aria-label="slotLabel(slot, row)"
 									:class="{
 										'border-outline-gray-4 text-ink-gray-9':
 											evaluation.date == slot.date &&
@@ -67,6 +69,12 @@
 								>
 									{{ formatTime(slot.display_start_time) }} -
 									{{ formatTime(slot.display_end_time) }}
+									<sup
+										v-if="endsOnAnotherDay(slot, row)"
+										class="text-ink-gray-5 ms-0.5"
+									>
+										+1
+									</sup>
 								</button>
 							</div>
 						</div>
@@ -182,6 +190,24 @@ watch(
 const scheduleTimezone = computed(
 	() => slots.data?.[0]?.display_timezone_label ?? ''
 )
+
+/* Conversion can push a slot's end past midnight while its start stays on the
+   rendered day — 17:00-19:00 Asia/Kolkata is 23:30-01:30 in Pacific/Auckland.
+   "23:30 - 01:30" alone would not say which day it ends on. */
+const endsOnAnotherDay = (slot, row) =>
+	Boolean(slot.display_end_date) && slot.display_end_date !== row.display_date
+
+const slotLabel = (slot, row) => {
+	const start = formatTime(slot.display_start_time)
+	const end = formatTime(slot.display_end_time)
+	if (!endsOnAnotherDay(slot, row)) return `${start} - ${end}`
+
+	return __('{0} until {1} on {2}').format(
+		start,
+		end,
+		dayjs(slot.display_end_date).format('DD MMMM YYYY')
+	)
+}
 
 /* Displayed times are converted; the booking submits the system values the slot
    was stored with. Both live on the slot, not the day: converting can move a

--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -59,6 +59,14 @@
 								</span>
 							</div>
 						</Tooltip>
+						<Tooltip v-if="event.timezone" :text="__('Timezone')">
+							<div class="flex items-center gap-x-2 w-fit">
+								<span class="lucide-globe h-4 w-4" />
+								<span>
+									{{ formatTimezone(event.timezone, event.date) }}
+								</span>
+							</div>
+						</Tooltip>
 					</div>
 					<div class="flex items-center gap-x-2 mt-auto">
 						<Button
@@ -180,6 +188,7 @@ import {
 import BooleanSwitch from '@/components/Controls/BooleanSwitch.vue'
 import { inject, reactive, watch, ref, computed } from 'vue'
 import { formatTime } from '@/utils'
+import { formatTimezone } from '@/utils/timezone'
 import Link from '@/components/Controls/Link.vue'
 
 const show = defineModel()

--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -76,6 +76,12 @@
 								{{ formatTime(evl.start_time) }}
 							</span>
 						</div>
+						<div v-if="evl.timezone" class="flex items-center mb-2">
+							<span class="lucide-globe w-4 h-4" />
+							<span class="ms-2">
+								{{ formatTimezone(evl.timezone, evl.date) }}
+							</span>
+						</div>
 						<div class="flex items-center">
 							<span class="lucide-graduation-cap w-4 h-4" />
 							<span class="ms-2">
@@ -112,6 +118,7 @@
 <script setup>
 import { inject, ref, getCurrentInstance, computed } from 'vue'
 import { formatTime } from '@/utils'
+import { formatTimezone } from '@/utils/timezone'
 import { Button, createListResource, call, Dropdown, toast } from 'frappe-ui'
 import EvaluationModal from '@/components/Modals/EvaluationModal.vue'
 
@@ -155,6 +162,7 @@ const upcoming_evals = createListResource({
 		'name',
 		'date',
 		'start_time',
+		'timezone',
 		'evaluator_name',
 		'course_title',
 		'member',

--- a/frontend/src/pages/Batches/components/BatchCard.vue
+++ b/frontend/src/pages/Batches/components/BatchCard.vue
@@ -50,7 +50,12 @@
 			>
 				<span class="lucide-globe h-4 w-4 me-2 text-ink-gray-5" />
 				<span>
-					{{ batch.timezone }}
+					{{
+						formatTimezone(
+							batch.timezone,
+							nextOccurrence(batch.start_date, batch.end_date)
+						)
+					}}
 				</span>
 			</div>
 		</div>
@@ -75,6 +80,7 @@
 <script setup>
 import { Badge } from 'frappe-ui'
 import { formatTime } from '@/utils'
+import { formatTimezone, nextOccurrence } from '@/utils/timezone'
 import DateRange from '@/components/Common/DateRange.vue'
 import CourseInstructors from '@/components/CourseInstructors.vue'
 import UserAvatar from '@/components/UserAvatar.vue'

--- a/frontend/src/pages/Batches/components/BatchOverlay.vue
+++ b/frontend/src/pages/Batches/components/BatchOverlay.vue
@@ -57,7 +57,12 @@
 			<div v-if="batch.data.timezone" class="flex items-center text-ink-gray-7">
 				<span class="lucide-globe h-4 w-4 me-2" />
 				<span>
-					{{ batch.data.timezone }}
+					{{
+						formatTimezone(
+							batch.data.timezone,
+							nextOccurrence(batch.data.start_date, batch.data.end_date)
+						)
+					}}
 				</span>
 			</div>
 
@@ -108,6 +113,7 @@
 import { inject, computed } from 'vue'
 import { Badge, Button, createResource, toast } from 'frappe-ui'
 import { formatNumberIntoCurrency, formatTime } from '@/utils'
+import { formatTimezone, nextOccurrence } from '@/utils/timezone'
 import DateRange from '@/components/Common/DateRange.vue'
 import VideoPreview from '@/components/VideoPreview.vue'
 

--- a/frontend/src/pages/Home/AdminHome.vue
+++ b/frontend/src/pages/Home/AdminHome.vue
@@ -34,6 +34,12 @@
 									{{ formatTime(evaluation.start_time) }}
 								</span>
 							</div>
+							<div v-if="evaluation.timezone" class="flex items-center mb-3">
+								<span class="lucide-globe size-4" />
+								<span class="ms-2">
+									{{ formatTimezone(evaluation.timezone, evaluation.date) }}
+								</span>
+							</div>
 							<div class="flex items-center">
 								<span class="lucide-graduation-cap size-4" />
 								<span class="ms-2">
@@ -208,6 +214,7 @@
 import { Button, createResource, Tooltip } from 'frappe-ui'
 import { inject } from 'vue'
 import { formatTime } from '@/utils'
+import { formatTimezone } from '@/utils/timezone'
 import { profileRoute } from '@/utils/routes'
 import CourseCard from '@/components/CourseCard.vue'
 import BatchCard from '@/pages/Batches/components/BatchCard.vue'

--- a/frontend/src/pages/ProfileEvaluationSchedule.vue
+++ b/frontend/src/pages/ProfileEvaluationSchedule.vue
@@ -75,6 +75,7 @@ const evaluations = createListResource({
 		'date',
 		'start_time',
 		'end_time',
+		'timezone',
 		'google_meet_link',
 	],
 	auto: true,

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -1,8 +1,15 @@
 <template>
 	<div class="mt-7 mb-20">
-		<h2 class="mb-4 text-md font-semibold text-ink-gray-9">
-			{{ __('My availability') }}
-		</h2>
+		<div class="mb-4">
+			<h2 class="text-md font-semibold text-ink-gray-9">
+				{{ __('My availability') }}
+			</h2>
+			<!-- These slots are stored as bare wall-clock times and read as system
+			     time everywhere downstream, so the editor has to name the clock. -->
+			<p v-if="evaluator.data?.timezone" class="text-sm text-ink-gray-6">
+				{{ __('Times are in {0}').format(evaluator.data.timezone) }}
+			</p>
+		</div>
 
 		<div
 			v-if="readOnlyMode"

--- a/frontend/src/tests/evaluationSlotPicker.test.ts
+++ b/frontend/src/tests/evaluationSlotPicker.test.ts
@@ -75,6 +75,7 @@ const SCHEDULE = [
 				end_time: '23:30:00',
 				display_start_time: '10:30:00',
 				display_end_time: '11:00:00',
+				display_end_date: '2026-08-02',
 			},
 			{
 				date: '2026-08-03',
@@ -83,6 +84,7 @@ const SCHEDULE = [
 				end_time: '10:00:00',
 				display_start_time: '20:30:00',
 				display_end_time: '21:30:00',
+				display_end_date: '2026-08-02',
 			},
 		],
 	},
@@ -175,6 +177,39 @@ describe('evaluation slot picker', () => {
 			start_time: '09:00:00',
 			end_time: '10:00:00',
 		})
+	})
+
+	it('marks a slot whose converted end falls on the next day', async () => {
+		// 17:00-19:00 Asia/Kolkata is 23:30-01:30 in Pacific/Auckland: one system
+		// day, two display days. "23:30 - 01:30" alone would not say which.
+		const wrapper = await mountPicker([
+			{
+				...SCHEDULE[0],
+				slots: [
+					{
+						date: '2026-08-03',
+						day: 'Monday',
+						start_time: '17:00:00',
+						end_time: '19:00:00',
+						display_start_time: '23:30:00',
+						display_end_time: '01:30:00',
+						display_end_date: '2026-08-03',
+					},
+				],
+			},
+		])
+
+		const button = wrapper.find('.grid button')
+		expect(button.find('sup').exists()).toBe(true)
+		expect(button.attributes('aria-label')).toContain('2026-08-03')
+	})
+
+	it('does not mark a slot that ends on the day it is rendered under', async () => {
+		const wrapper = await mountPicker()
+		const buttons = wrapper.findAll('.grid button')
+
+		expect(buttons.every((b) => !b.find('sup').exists())).toBe(true)
+		expect(buttons[0].attributes('aria-label')).toBe('10:30 - 11:00')
 	})
 
 	it('repeats the zone on days whose offset differs from the header', async () => {

--- a/frontend/src/tests/evaluationSlotPicker.test.ts
+++ b/frontend/src/tests/evaluationSlotPicker.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for EvaluationModal.vue — the evaluation slot picker.
+ *
+ * Slots are stored in the system timezone and converted server-side into the
+ * batch's zone for display. The picker therefore renders `display_*` and
+ * submits the system values it was handed: submitting the converted clock would
+ * break `validate_slot`, past-slot rejection, completion marking and the
+ * calendar event at once.
+ *
+ * Conversion also moves slots between days, so one rendered day can hold slots
+ * from two different stored dates — the date a booking submits has to come from
+ * the slot, never from the day it was rendered under.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const { resources, calls } = vi.hoisted(() => ({
+	resources: { value: [] as any[] },
+	calls: { value: [] as any[] },
+}))
+
+vi.mock('frappe-ui', () => ({
+	createResource: (config: any) => {
+		const res: any = { loading: false, config, data: null }
+		res.reload = vi.fn()
+		resources.value.push(res)
+		return res
+	},
+	call: vi.fn((method: string, args: any) => {
+		calls.value.push({ method, args })
+		return Promise.resolve({})
+	}),
+	toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+	Dialog: {
+		props: ['open', 'title', 'size', 'actions'],
+		template: `<div>
+			<slot />
+			<button
+				v-for="action in actions"
+				:key="action.label"
+				class="dialog-action"
+				@click="action.onClick({ close: () => {} })"
+			>{{ action.label }}</button>
+		</div>`,
+	},
+	FormControl: {
+		props: ['modelValue', 'type', 'label', 'options'],
+		emits: ['update:modelValue'],
+		template: `<input :value="modelValue"
+			@input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+}))
+
+vi.mock('@/utils', () => ({
+	formatTime: (time: string) => (time ? time.slice(0, 5) : ''),
+}))
+
+const COURSE = 'course-1'
+
+/**
+ * A Monday 09:00 Asia/Kolkata slot is Sunday 20:30 in America/Los_Angeles, so
+ * the group is Sunday and holds slots stored on two different dates.
+ */
+const SCHEDULE = [
+	{
+		display_date: '2026-08-02',
+		display_day: 'Sunday',
+		display_timezone: 'America/Los_Angeles',
+		display_timezone_label: 'America/Los_Angeles (GMT-7:00)',
+		slots: [
+			{
+				date: '2026-08-02',
+				day: 'Sunday',
+				start_time: '23:00:00',
+				end_time: '23:30:00',
+				display_start_time: '10:30:00',
+				display_end_time: '11:00:00',
+			},
+			{
+				date: '2026-08-03',
+				day: 'Monday',
+				start_time: '09:00:00',
+				end_time: '10:00:00',
+				display_start_time: '20:30:00',
+				display_end_time: '21:30:00',
+			},
+		],
+	},
+]
+
+function findResource(url: string) {
+	return resources.value.find((r) => r.config.url === url)
+}
+
+async function mountPicker(schedule = SCHEDULE) {
+	resources.value = []
+	calls.value = []
+	const wrapper = mount(
+		await import('@/components/Modals/EvaluationModal.vue').then(
+			(m) => m.default
+		),
+		{
+			props: {
+				modelValue: true,
+				reloadEvals: { reload: vi.fn() },
+				courses: [{ course: COURSE, title: 'A Course', evaluator: 'eva' }],
+				batch: 'batch-1',
+			},
+			global: {
+				provide: {
+					$dayjs: (date: string) => ({ format: () => date }),
+					$user: { data: { name: 'student@example.com' } },
+				},
+				mocks: { __: translate },
+			},
+		}
+	)
+
+	const slots = findResource(
+		'lms.lms.doctype.course_evaluator.course_evaluator.get_schedule'
+	)
+	slots.data = schedule
+	await flushPromises()
+	return wrapper
+}
+
+/** `__` returns a String carrying `.format`, as frappe-ui's does for messages
+    with placeholders — a plain string would make `.format` a TypeError. */
+function translate(message: string) {
+	const translated = new String(message) as any
+	translated.format = (...args: any[]) =>
+		message.replace(/\{(\d+)\}/g, (_, index) => args[Number(index)])
+	return translated
+}
+
+describe('evaluation slot picker', () => {
+	beforeEach(() => {
+		vi.stubGlobal('__', translate)
+	})
+
+	it('renders the converted times, not the stored ones', async () => {
+		const wrapper = await mountPicker()
+		const labels = wrapper.findAll('.grid button').map((b) => b.text())
+
+		expect(labels).toEqual(['10:30 - 11:00', '20:30 - 21:30'])
+		expect(wrapper.text()).not.toContain('09:00')
+		expect(wrapper.text()).not.toContain('23:00')
+	})
+
+	it('labels the range with the display timezone', async () => {
+		const wrapper = await mountPicker()
+		expect(wrapper.text()).toContain('America/Los_Angeles (GMT-7:00)')
+	})
+
+	it('heads each day with the converted day, not the stored one', async () => {
+		const wrapper = await mountPicker()
+		expect(wrapper.text()).toContain('Sunday')
+		expect(wrapper.text()).toContain('2026-08-02')
+	})
+
+	it('submits the stored date and time of the slot that was picked', async () => {
+		const wrapper = await mountPicker()
+		// The second slot renders under Sunday but is stored on Monday.
+		await wrapper.findAll('.grid button')[1].trigger('click')
+		await wrapper.find('.dialog-action').trigger('click')
+
+		expect(calls.value).toHaveLength(1)
+		expect(calls.value[0].method).toBe('frappe.client.insert')
+		expect(calls.value[0].args.doc).toMatchObject({
+			doctype: 'LMS Certificate Request',
+			batch_name: 'batch-1',
+			course: COURSE,
+			date: '2026-08-03',
+			day: 'Monday',
+			start_time: '09:00:00',
+			end_time: '10:00:00',
+		})
+	})
+
+	it('repeats the zone on days whose offset differs from the header', async () => {
+		const wrapper = await mountPicker([
+			SCHEDULE[0],
+			{
+				...SCHEDULE[0],
+				display_date: '2026-11-02',
+				display_timezone_label: 'America/Los_Angeles (GMT-8:00)',
+			},
+		])
+		expect(wrapper.text()).toContain('America/Los_Angeles (GMT-8:00)')
+	})
+})

--- a/frontend/src/tests/timezone.test.ts
+++ b/frontend/src/tests/timezone.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatTimezone, nextOccurrence } from '@/utils/timezone'
+
+describe('formatTimezone', () => {
+	it('appends the offset to an IANA zone name', () => {
+		expect(formatTimezone('Asia/Kolkata', '2026-07-29')).toBe(
+			'Asia/Kolkata (GMT+5:30)'
+		)
+		expect(formatTimezone('Europe/Berlin', '2026-07-29')).toBe(
+			'Europe/Berlin (GMT+2:00)'
+		)
+	})
+
+	it('strips the leading zero from the hour', () => {
+		expect(formatTimezone('America/New_York', '2026-01-15')).toBe(
+			'America/New_York (GMT-5:00)'
+		)
+	})
+
+	it('resolves the offset for the given date, not today', () => {
+		// America/New_York is GMT-5 in January and GMT-4 in July. A single label
+		// computed once would be wrong for half the 60-day slot window.
+		expect(formatTimezone('America/New_York', '2026-01-15')).toContain(
+			'GMT-5:00'
+		)
+		expect(formatTimezone('America/New_York', '2026-07-29')).toContain(
+			'GMT-4:00'
+		)
+	})
+
+	it('echoes legacy free-text values unchanged', () => {
+		expect(formatTimezone('IST (GMT+5:30)', '2026-07-29')).toBe(
+			'IST (GMT+5:30)'
+		)
+		expect(formatTimezone('Pacific Time', '2026-07-29')).toBe('Pacific Time')
+	})
+
+	it('does not throw on a hostile value', () => {
+		expect(formatTimezone('../../etc/passwd', '2026-07-29')).toBe(
+			'../../etc/passwd'
+		)
+	})
+
+	it('returns an empty string for a missing zone', () => {
+		expect(formatTimezone('')).toBe('')
+		expect(formatTimezone(null)).toBe('')
+		expect(formatTimezone(undefined)).toBe('')
+	})
+
+	it('renders UTC as a zero offset', () => {
+		expect(formatTimezone('UTC', '2026-07-29')).toBe('UTC (GMT+0:00)')
+	})
+})
+
+describe('formatTimezone date anchoring', () => {
+	it('reads a date-only value on that date, not the day before', () => {
+		// America/Santiago moves GMT-4 -> GMT-3 overnight on 2026-09-05.
+		// `new Date('2026-09-06')` is UTC midnight, which is still 2026-09-05
+		// there — the wrong side of the transition.
+		expect(formatTimezone('America/Santiago', '2026-09-06')).toBe(
+			'America/Santiago (GMT-3:00)'
+		)
+		expect(formatTimezone('America/Santiago', '2026-09-05')).toBe(
+			'America/Santiago (GMT-4:00)'
+		)
+	})
+
+	it('accepts a full timestamp', () => {
+		expect(formatTimezone('Europe/Berlin', '2026-07-29 06:30:00')).toBe(
+			'Europe/Berlin (GMT+2:00)'
+		)
+	})
+})
+
+describe('nextOccurrence', () => {
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	const freeze = (date: string) => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date(`${date}T09:00:00`))
+	}
+
+	it('is the start date before the batch begins', () => {
+		freeze('2026-07-01')
+		expect(nextOccurrence('2026-08-01', '2026-09-01')).toBe('2026-08-01')
+	})
+
+	it('is today while the batch is running', () => {
+		freeze('2026-08-15')
+		expect(nextOccurrence('2026-08-01', '2026-09-01')).toBe('2026-08-15')
+	})
+
+	it('is the end date once the batch is over', () => {
+		freeze('2026-10-01')
+		expect(nextOccurrence('2026-08-01', '2026-09-01')).toBe('2026-09-01')
+	})
+
+	it('is today for an open-ended batch that has started', () => {
+		freeze('2026-08-15')
+		expect(nextOccurrence('2026-08-01', null)).toBe('2026-08-15')
+	})
+
+	it('is undefined without a start date', () => {
+		expect(nextOccurrence(null, '2026-09-01')).toBeUndefined()
+	})
+})

--- a/frontend/src/utils/timezone.ts
+++ b/frontend/src/utils/timezone.ts
@@ -1,0 +1,95 @@
+/**
+ * Batch, live class and evaluation timezones are free-text `Data` fields. New
+ * records hold an IANA zone name picked from `get_country_timezone_info`
+ * ("Asia/Kolkata"), but older rows predate that control and can hold anything
+ * ("IST (GMT+5:30)"). Rendering the raw value therefore reads differently from
+ * one record to the next, so every surface goes through here instead.
+ *
+ * Evaluation slots are the exception: `get_schedule` formats its own labels
+ * server-side, so the picker and the confirmation email cannot drift apart.
+ */
+
+/** "GMT+05:30" -> "GMT+5:30", "GMT-04:00" -> "GMT-4:00", "GMT" -> "GMT+0:00" */
+function tidyOffset(offset: string): string {
+	if (offset === 'GMT' || offset === 'UTC') return 'GMT+0:00'
+	return offset.replace(/^GMT([+-])0?(\d+)/, 'GMT$1$2')
+}
+
+/**
+ * `new Date('2026-08-03')` is UTC midnight, which is the previous day in every
+ * westward zone — enough to report the wrong side of a DST transition. A
+ * date-only value is anchored at local midday instead, which no transition
+ * crosses.
+ */
+function toInstant(at?: string | Date): Date {
+	if (!at) return new Date()
+	if (at instanceof Date) return at
+
+	const parts = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?/.exec(at)
+	if (!parts) return new Date(at)
+
+	const [, year, month, day, hour, minute] = parts
+	return new Date(
+		Number(year),
+		Number(month) - 1,
+		Number(day),
+		hour ? Number(hour) : 12,
+		minute ? Number(minute) : 0
+	)
+}
+
+/**
+ * The UTC offset of `timezone` is not constant — it shifts across DST — so the
+ * instant being labelled has to be passed in.
+ */
+function offsetOn(timezone: string, at?: string | Date): string {
+	const parts = new Intl.DateTimeFormat('en-US', {
+		timeZone: timezone,
+		timeZoneName: 'longOffset',
+	}).formatToParts(toInstant(at))
+
+	return parts.find((part) => part.type === 'timeZoneName')?.value ?? ''
+}
+
+/**
+ * "Asia/Kolkata" -> "Asia/Kolkata (GMT+5:30)".
+ *
+ * Mirrors `lms.lms.utils.format_timezone`. `at` is the instant to read the
+ * offset at, defaulting to now.
+ *
+ * Values Intl does not recognise as a zone are legacy free text and are echoed
+ * unchanged — they already read as a timezone to a human, and there is no safe
+ * way to parse them back into a zone.
+ */
+export function formatTimezone(
+	timezone?: string | null,
+	at?: string | Date
+): string {
+	if (!timezone) return ''
+
+	try {
+		const offset = offsetOn(timezone, at)
+		return offset ? `${timezone} (${tidyOffset(offset)})` : timezone
+	} catch {
+		// RangeError: invalid time zone specified
+		return timezone
+	}
+}
+
+/**
+ * The date a batch's timezone should be labelled at. A batch spanning a DST
+ * transition has two offsets, and the one worth showing is the one in force at
+ * the next class a learner could attend: the first day before the batch starts,
+ * the last day after it ends, today in between.
+ */
+export function nextOccurrence(
+	startDate?: string | null,
+	endDate?: string | null
+): string | undefined {
+	if (!startDate) return undefined
+
+	const today = new Date().toLocaleDateString('en-CA')
+	if (today < startDate) return startDate
+	if (endDate && today > endDate) return endDate
+	return today
+}

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -24,6 +24,7 @@ from frappe.utils import (
 	flt,
 	format_date,
 	get_datetime,
+	get_system_timezone,
 	get_time,
 	getdate,
 	now,
@@ -40,6 +41,7 @@ from lms.lms.utils import (
 	LMS_ROLES,
 	can_modify_batch,
 	can_modify_course,
+	format_timezone,
 	get_batch_details,
 	get_course_details,
 	get_editorjs_blocks,
@@ -445,6 +447,9 @@ def get_evaluator_details(evaluator: str):
 		"slots": doc.as_dict(),
 		"calendar": calendar.name if calendar else None,
 		"is_authorized": calendar.authorization_code if calendar else None,
+		# Evaluator Schedule holds bare wall-clock times and the whole booking
+		# pipeline reads them as system time, so the editor has to say so.
+		"timezone": format_timezone(get_system_timezone()),
 	}
 
 
@@ -2463,6 +2468,7 @@ def get_admin_evals():
 			"name",
 			"date",
 			"start_time",
+			"timezone",
 			"course",
 			"evaluator",
 			"google_meet_link",

--- a/lms/lms/doctype/course_evaluator/course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/course_evaluator.py
@@ -179,7 +179,7 @@ def group_slots_by_display_date(all_slots, timezone):
 	groups = {}
 	for slot in all_slots:
 		display_date, display_start = convert_from_system_timezone(slot.date, slot.start_time, timezone)
-		_, display_end = convert_from_system_timezone(slot.date, slot.end_time, timezone)
+		display_end_date, display_end = convert_from_system_timezone(slot.date, slot.end_time, timezone)
 		date_str = display_date.strftime("%Y-%m-%d")
 
 		if date_str not in groups:
@@ -201,6 +201,12 @@ def group_slots_by_display_date(all_slots, timezone):
 				"end_time": slot.end_time,
 				"display_start_time": display_start.strftime("%H:%M:%S"),
 				"display_end_time": display_end.strftime("%H:%M:%S"),
+				# A slot that sits inside one system day can straddle midnight once
+				# converted — 17:00-19:00 Asia/Kolkata is 23:30-01:30 in
+				# Pacific/Auckland. Without this the picker would render
+				# "23:30 - 01:30" under one date and say nothing about which day the
+				# slot ends on.
+				"display_end_date": display_end_date.strftime("%Y-%m-%d"),
 			}
 		)
 

--- a/lms/lms/doctype/course_evaluator/course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/course_evaluator.py
@@ -8,7 +8,12 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, get_time, getdate, nowdate
 
-from lms.lms.utils import get_evaluator
+from lms.lms.utils import (
+	convert_from_system_timezone,
+	format_timezone,
+	get_evaluation_display_timezone,
+	get_evaluator,
+)
 
 
 class CourseEvaluator(Document):
@@ -89,8 +94,8 @@ def get_schedule(course: str, batch: str = None):
 	end_date = get_schedule_range_end_date(start_date, batch)
 	all_slots = get_all_slots(evaluator, start_date, end_date)
 	booked_slots = get_booked_slots(evaluator, start_date, end_date)
-	all_slots = remove_booked_slots(all_slots, booked_slots)
-	return all_slots
+	available = remove_booked_slots(all_slots, booked_slots)
+	return group_slots_by_display_date(available, get_evaluation_display_timezone(course, batch))
 
 
 def get_all_slots(evaluator, start_date, end_date):
@@ -155,27 +160,54 @@ def remove_booked_slots(all_slots, booked_slots):
 	for slot in slots_to_remove:
 		all_slots.remove(slot)
 
-	return group_slots_by_date(all_slots)
+	return all_slots
 
 
-def group_slots_by_date(all_slots):
-	slots_by_date = []
-	dates_included = set()
+def group_slots_by_display_date(all_slots, timezone):
+	"""Group by the date each slot falls on *in the display timezone*.
+
+	Grouping has to happen after conversion, not before: an evaluator's Monday
+	09:00 in Asia/Kolkata is Sunday 20:30 in America/Los_Angeles, so a Monday
+	schedule row legitimately produces Sunday slots for a US-West batch.
+
+	Each slot carries both clocks. `date`/`start_time`/`end_time` are the system
+	values the booking is submitted with — everything downstream (`validate_slot`,
+	past-slot rejection, completion, the calendar event) reads system time.
+	`display_*` is what the learner sees. One display group can hold slots from
+	two different system dates, so the system date lives on the slot, not the group.
+	"""
+	groups = {}
 	for slot in all_slots:
-		date_str = slot.get("date").strftime("%Y-%m-%d")
-		if date_str not in dates_included:
-			slots_by_date.append({"date": date_str, "day": slot.day, "slots": []})
-			dates_included.add(date_str)
+		display_date, display_start = convert_from_system_timezone(slot.date, slot.start_time, timezone)
+		_, display_end = convert_from_system_timezone(slot.date, slot.end_time, timezone)
+		date_str = display_date.strftime("%Y-%m-%d")
 
-		for date_slot in slots_by_date:
-			if date_slot.get("date") == date_str:
-				date_slot.get("slots").append(
-					{
-						"start_time": slot.get("start_time"),
-						"end_time": slot.get("end_time"),
-					}
-				)
-	return slots_by_date
+		if date_str not in groups:
+			groups[date_str] = {
+				"display_date": date_str,
+				"display_day": display_date.strftime("%A"),
+				"display_timezone": timezone,
+				"display_timezone_label": format_timezone(
+					timezone, datetime.combine(display_date, display_start)
+				),
+				"slots": [],
+			}
+
+		groups[date_str]["slots"].append(
+			{
+				"date": slot.date.strftime("%Y-%m-%d"),
+				"day": slot.day,
+				"start_time": slot.start_time,
+				"end_time": slot.end_time,
+				"display_start_time": display_start.strftime("%H:%M:%S"),
+				"display_end_time": display_end.strftime("%H:%M:%S"),
+			}
+		)
+
+	for group in groups.values():
+		group["slots"].sort(key=lambda slot: slot["display_start_time"])
+
+	return [groups[date_str] for date_str in sorted(groups)]
 
 
 def get_evaluator_availability(evaluator):

--- a/lms/lms/doctype/course_evaluator/test_course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/test_course_evaluator.py
@@ -160,6 +160,27 @@ class TestSlotGrouping(UnitTestCase):
 		labels = [row["display_timezone_label"] for row in groups]
 		self.assertEqual(labels, ["America/Santiago (GMT-4:00)", "America/Santiago (GMT-3:00)"])
 
+	def test_end_carries_its_own_display_date_when_it_crosses_midnight(self, _system_timezone):
+		# 17:00-19:00 Asia/Kolkata is 23:30-01:30 in Pacific/Auckland: the slot sits
+		# inside one system day but straddles midnight once converted, so the end
+		# needs its own date or the picker cannot say which day it finishes on.
+		groups = group_slots_by_display_date(
+			[self._slot("2026-08-03", "17:00:00", "19:00:00", "Monday")], "Pacific/Auckland"
+		)
+		self.assertEqual(groups[0]["display_date"], "2026-08-03")
+
+		slot = groups[0]["slots"][0]
+		self.assertEqual(slot["display_start_time"], "23:30:00")
+		self.assertEqual(slot["display_end_time"], "01:30:00")
+		self.assertEqual(slot["display_end_date"], "2026-08-04")
+
+	def test_end_date_matches_the_group_when_it_does_not_cross_midnight(self, _system_timezone):
+		groups = group_slots_by_display_date(
+			[self._slot("2026-08-03", "09:00:00", "10:00:00", "Monday")], "America/Los_Angeles"
+		)
+		slot = groups[0]["slots"][0]
+		self.assertEqual(slot["display_end_date"], groups[0]["display_date"])
+
 	def test_legacy_free_text_zone_labels_without_converting(self, _system_timezone):
 		groups = group_slots_by_display_date(
 			[self._slot("2026-08-03", "10:00:00", "12:00:00", "Monday")], "IST (GMT+5:30)"

--- a/lms/lms/doctype/course_evaluator/test_course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/test_course_evaluator.py
@@ -1,11 +1,18 @@
 # Copyright (c) 2022, Frappe and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
-from frappe.utils import add_days, format_time, getdate
+from frappe.tests import UnitTestCase
+from frappe.utils import add_days, format_time, getdate, to_timedelta
 
 from lms.lms.api import save_role
-from lms.lms.doctype.course_evaluator.course_evaluator import get_schedule, get_schedule_range_end_date
+from lms.lms.doctype.course_evaluator.course_evaluator import (
+	get_schedule,
+	get_schedule_range_end_date,
+	group_slots_by_display_date,
+)
 from lms.lms.test_helpers import BaseTestUtils
 
 
@@ -19,27 +26,46 @@ class TestCourseEvaluator(BaseTestUtils):
 		self.evaluator = self._create_evaluator()
 		self.batch = self._create_batch(self.course.name)
 
+	def _slots(self, schedule):
+		"""Every slot, flattened. Groups are keyed by *display* date, so nothing
+		timezone-independent can be asserted about them — the system values each
+		slot carries are what the booking is made of."""
+		return [slot for row in schedule for slot in row.get("slots")]
+
 	def test_schedule_day_and_time(self):
 		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
 		days = ["Monday", "Wednesday"]
 		self.assertGreaterEqual(len(schedule), 14)
-		for row in schedule:
-			self.assertIn(row.get("day"), days)
-			if row.get("day") == "Monday":
-				for slot in row.get("slots"):
-					self.assertEqual(format_time(slot.get("start_time"), "HH:mm:ss"), "10:00:00")
-					self.assertEqual(format_time(slot.get("end_time"), "HH:mm:ss"), "12:00:00")
-			if row.get("day") == "Wednesday":
-				for slot in row.get("slots"):
-					self.assertEqual(format_time(slot.get("start_time"), "HH:mm:ss"), "14:00:00")
-					self.assertEqual(format_time(slot.get("end_time"), "HH:mm:ss"), "16:00:00")
+		for slot in self._slots(schedule):
+			self.assertIn(slot.get("day"), days)
+			if slot.get("day") == "Monday":
+				self.assertEqual(format_time(slot.get("start_time"), "HH:mm:ss"), "10:00:00")
+				self.assertEqual(format_time(slot.get("end_time"), "HH:mm:ss"), "12:00:00")
+			if slot.get("day") == "Wednesday":
+				self.assertEqual(format_time(slot.get("start_time"), "HH:mm:ss"), "14:00:00")
+				self.assertEqual(format_time(slot.get("end_time"), "HH:mm:ss"), "16:00:00")
 
 	def test_schedule_dates(self):
 		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
-		first_date = self.calculated_first_date_of_schedule()
-		last_date = self.calculated_last_date_of_schedule()
-		self.assertEqual(getdate(schedule[0].get("date")), first_date)
-		self.assertEqual(getdate(schedule[-1].get("date")), last_date)
+		dates = sorted({getdate(slot.get("date")) for slot in self._slots(schedule)})
+		self.assertEqual(dates[0], self.calculated_first_date_of_schedule())
+		self.assertEqual(dates[-1], self.calculated_last_date_of_schedule())
+
+	def test_every_slot_carries_both_clocks(self):
+		# The booking submits the system values; the picker renders the display
+		# ones. A slot missing either is unbookable or unlabelled.
+		for slot in self._slots(get_schedule(self.batch.courses[0].course, self.batch.name)):
+			for field in ("date", "day", "start_time", "end_time"):
+				self.assertIsNotNone(slot.get(field))
+			for field in ("display_start_time", "display_end_time"):
+				self.assertRegex(slot.get(field), r"^\d{2}:\d{2}:\d{2}$")
+
+	def test_groups_are_labelled_with_the_display_timezone(self):
+		frappe.db.set_value("LMS Batch", self.batch.name, "timezone", "Europe/Berlin")
+		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
+		for row in schedule:
+			self.assertEqual(row.get("display_timezone"), "Europe/Berlin")
+			self.assertTrue(row.get("display_timezone_label").startswith("Europe/Berlin (GMT"))
 
 	def calculated_first_date_of_schedule(self):
 		today = getdate()
@@ -62,9 +88,85 @@ class TestCourseEvaluator(BaseTestUtils):
 		unavailable_from = getdate(self.evaluator.unavailable_from)
 		unavailable_to = getdate(self.evaluator.unavailable_to)
 		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
-		for row in schedule:
-			schedule_date = getdate(row.get("date"))
+		for slot in self._slots(schedule):
+			schedule_date = getdate(slot.get("date"))
 			self.assertFalse(unavailable_from < schedule_date < unavailable_to)
+
+
+@patch("lms.lms.utils.get_system_timezone", return_value="Asia/Kolkata")
+class TestSlotGrouping(UnitTestCase):
+	"""Grouping runs after conversion, so a schedule row's day is not the day the
+	learner sees it on."""
+
+	def _slot(self, date, start, end, day):
+		return frappe._dict(
+			{
+				"day": day,
+				"date": getdate(date),
+				"start_time": to_timedelta(start),
+				"end_time": to_timedelta(end),
+			}
+		)
+
+	def test_slots_stay_put_within_the_same_zone(self, _system_timezone):
+		groups = group_slots_by_display_date(
+			[self._slot("2026-08-03", "10:00:00", "12:00:00", "Monday")], "Asia/Kolkata"
+		)
+		self.assertEqual(len(groups), 1)
+		self.assertEqual(groups[0]["display_date"], "2026-08-03")
+		self.assertEqual(groups[0]["display_day"], "Monday")
+		self.assertEqual(groups[0]["slots"][0]["display_start_time"], "10:00:00")
+
+	def test_monday_slots_land_on_sunday_for_us_west(self, _system_timezone):
+		groups = group_slots_by_display_date(
+			[self._slot("2026-08-03", "09:00:00", "10:00:00", "Monday")], "America/Los_Angeles"
+		)
+		self.assertEqual(groups[0]["display_date"], "2026-08-02")
+		self.assertEqual(groups[0]["display_day"], "Sunday")
+		self.assertEqual(groups[0]["display_timezone_label"], "America/Los_Angeles (GMT-7:00)")
+
+		slot = groups[0]["slots"][0]
+		self.assertEqual(slot["display_start_time"], "20:30:00")
+		# Untouched: this is what the booking submits.
+		self.assertEqual(slot["date"], "2026-08-03")
+		self.assertEqual(slot["day"], "Monday")
+
+	def test_one_display_day_can_hold_two_system_dates(self, _system_timezone):
+		groups = group_slots_by_display_date(
+			[
+				self._slot("2026-08-03", "09:00:00", "10:00:00", "Monday"),
+				self._slot("2026-08-02", "23:00:00", "23:30:00", "Sunday"),
+			],
+			"America/Los_Angeles",
+		)
+		self.assertEqual(len(groups), 1)
+		self.assertEqual(groups[0]["display_date"], "2026-08-02")
+		self.assertEqual([slot["date"] for slot in groups[0]["slots"]], ["2026-08-02", "2026-08-03"])
+		# Sorted by what is rendered, not by what is stored.
+		self.assertEqual(
+			[slot["display_start_time"] for slot in groups[0]["slots"]],
+			["10:30:00", "20:30:00"],
+		)
+
+	def test_label_follows_dst_across_the_range(self, _system_timezone):
+		# America/Santiago flips GMT-4 -> GMT-3 in September.
+		groups = group_slots_by_display_date(
+			[
+				self._slot("2026-08-03", "12:00:00", "13:00:00", "Monday"),
+				self._slot("2026-10-05", "12:00:00", "13:00:00", "Monday"),
+			],
+			"America/Santiago",
+		)
+		labels = [row["display_timezone_label"] for row in groups]
+		self.assertEqual(labels, ["America/Santiago (GMT-4:00)", "America/Santiago (GMT-3:00)"])
+
+	def test_legacy_free_text_zone_labels_without_converting(self, _system_timezone):
+		groups = group_slots_by_display_date(
+			[self._slot("2026-08-03", "10:00:00", "12:00:00", "Monday")], "IST (GMT+5:30)"
+		)
+		self.assertEqual(groups[0]["display_date"], "2026-08-03")
+		self.assertEqual(groups[0]["display_timezone_label"], "IST (GMT+5:30)")
+		self.assertEqual(groups[0]["slots"][0]["display_start_time"], "10:00:00")
 
 
 class TestEvaluatorRoleCRUD(BaseTestUtils):

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -13,6 +13,7 @@ from frappe.model.document import Document
 from frappe.utils import add_days, cint, format_datetime, get_time, nowdate
 
 from lms.lms.utils import (
+	format_timezone,
 	generate_slug,
 	get_assignment_details,
 	get_instructors,
@@ -191,7 +192,7 @@ def send_email_notification_for_published_batch(batch):
 		"end_date": batch.end_date,
 		"start_time": batch.start_time,
 		"medium": batch.medium,
-		"timezone": batch.timezone,
+		"timezone": format_timezone(batch.timezone, batch.start_date),
 		"instructors": instructors,
 		"batch_url": frappe.utils.get_url(get_lms_route(f"batches/{batch.name}")),
 	}

--- a/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
+++ b/lms/lms/doctype/lms_certificate_request/lms_certificate_request.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+from datetime import datetime
 
 import frappe
 from frappe import _
@@ -19,7 +20,13 @@ from frappe.utils import (
 	nowtime,
 )
 
-from lms.lms.utils import PRIVILEGED_ROLES, get_evaluator
+from lms.lms.utils import (
+	PRIVILEGED_ROLES,
+	convert_from_system_timezone,
+	format_timezone,
+	get_evaluation_display_timezone,
+	get_evaluator,
+)
 
 
 class LMSCertificateRequest(Document):
@@ -128,8 +135,14 @@ class LMSCertificateRequest(Document):
 					)
 
 	def validate_timezone(self):
-		if self.timezone:
-			return
+		"""The zone the stored wall clock is in — never the zone it is shown in.
+
+		date, start_time and end_time are system time: validate_if_existing_requests
+		and mark_eval_as_completed compare them against nowtime(), and create_event
+		hands Google Calendar a naive datetime. Derived, not accepted from the
+		client, so the field cannot come to disagree with what is stored beside it.
+		The display zone comes from the batch or course at render time.
+		"""
 		self.timezone = get_system_timezone()
 
 	def send_notification(self):
@@ -140,12 +153,18 @@ class LMSCertificateRequest(Document):
 			subject = _("Your evaluation slot has been booked")
 			template = "certificate_request_notification"
 
+			# The same instant the learner picked, rendered in the same zone the
+			# picker rendered it in — otherwise the email restates their booking
+			# in a clock they never saw.
+			timezone = get_evaluation_display_timezone(self.course, self.batch_name)
+			date, start_time = convert_from_system_timezone(self.date, self.start_time, timezone)
+
 			args = {
 				"course": self.course_title,
-				"timezone": self.timezone,
-				"date": format_date(self.date, "medium"),
+				"timezone": format_timezone(timezone, datetime.combine(date, start_time)),
+				"date": format_date(date, "medium"),
 				"member_name": self.member_name,
-				"start_time": format_time(self.start_time, "short"),
+				"start_time": format_time(start_time, "short"),
 				"evaluator": self.evaluator_name,
 			}
 

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1,7 +1,9 @@
 import hashlib
 import json
 import re
+from datetime import datetime
 from urllib.parse import quote
+from zoneinfo import ZoneInfo
 
 import frappe
 import requests
@@ -20,6 +22,8 @@ from frappe.utils import (
 	get_datetime,
 	get_frappe_version,
 	get_fullname,
+	get_system_timezone,
+	get_time,
 	getdate,
 	nowtime,
 	rounded,
@@ -701,6 +705,90 @@ def get_evaluator(course: str, batch: str = None):
 	else:
 		evaluator = frappe.db.get_value("LMS Course", course, "evaluator")
 	return evaluator
+
+
+def get_zone(timezone: str) -> ZoneInfo | None:
+	"""None for anything that is not an IANA zone name.
+
+	Every timezone in LMS is a free-text `Data` field. New records hold a name
+	picked from `get_country_timezone_info` ("Asia/Kolkata"), older rows predate
+	that control and can hold anything ("IST (GMT+5:30)").
+	"""
+	if not timezone:
+		return None
+
+	try:
+		return ZoneInfo(timezone)
+	except (KeyError, ValueError):
+		return None
+
+
+def get_evaluation_display_timezone(course: str = None, batch: str = None) -> str:
+	"""The zone evaluation slots are *shown* in. Never the zone they are stored in.
+
+	Slots are authored and stored in the system timezone — `nowtime()`
+	comparisons and the naive datetime handed to Google Calendar all depend on
+	that. The batch declares the zone its cohort works in, so that is what a
+	learner books against; a direct-evaluation course has no batch, and falls
+	back to its own timezone, which is mandatory for a paid certificate.
+	"""
+	if batch:
+		timezone = frappe.db.get_value("LMS Batch", batch, "timezone")
+		if timezone:
+			return timezone
+
+	if course:
+		# Only when paid_certificate is set: the field `depends_on` it, so an
+		# unset course can be carrying a stale value from a toggle.
+		settings = frappe.db.get_value("LMS Course", course, ["paid_certificate", "timezone"], as_dict=True)
+		if settings and settings.paid_certificate and settings.timezone:
+			return settings.timezone
+
+	return get_system_timezone()
+
+
+def convert_from_system_timezone(date, time, timezone: str) -> tuple:
+	"""Move a system-time wall clock into `timezone`. Returns (date, time).
+
+	The date comes back because conversion rolls over: an evaluator's Monday
+	09:00 in Asia/Kolkata is Sunday 20:30 in America/Los_Angeles.
+
+	A zone name we cannot resolve is legacy free text with no offset to convert
+	against, so the wall clock is returned untouched — labelled, not moved.
+	"""
+	zone = get_zone(timezone)
+	system = get_zone(get_system_timezone())
+	if not zone or not system or zone.key == system.key:
+		return getdate(date), get_time(time)
+
+	moment = datetime.combine(getdate(date), get_time(time), tzinfo=system).astimezone(zone)
+	return moment.date(), moment.time()
+
+
+def format_timezone(timezone: str, at=None) -> str:
+	""" "Asia/Kolkata" -> "Asia/Kolkata (GMT+5:30)".
+
+	`at` is the instant to read the offset at — a date, a datetime, or None for
+	now. It matters because the offset shifts across DST, and the slot picker
+	spans 60 days.
+
+	Mirrors frontend/src/utils/timezone.ts so an email reads the same as the
+	screen it was booked from. Values that are not IANA zone names are echoed:
+	they already read as a timezone to a human, and there is no safe way to
+	parse them back into one.
+	"""
+	if not timezone:
+		return ""
+
+	zone = get_zone(timezone)
+	if not zone:
+		return timezone
+
+	moment = get_datetime(at).replace(tzinfo=zone) if at else datetime.now(zone)
+	total_minutes = int(moment.utcoffset().total_seconds() // 60)
+	hours, minutes = divmod(abs(total_minutes), 60)
+	sign = "+" if total_minutes >= 0 else "-"
+	return f"{timezone} (GMT{sign}{hours}:{minutes:02d})"
 
 
 def check_multicurrency(amount: float, currency: str, country: str = None, amount_usd: float = None):

--- a/lms/templates/emails/certificate_request_notification.html
+++ b/lms/templates/emails/certificate_request_notification.html
@@ -1,6 +1,6 @@
 <p> {{ _("Hey {0}").format(member_name) }} </p>
 <br>
-<p> {{ _('Your evaluation for the course {0} has been scheduled on {1} at {2} ({3} time).').format(course, date, start_time, timezone) }}</p>
+<p> {{ _('Your evaluation for the course {0} has been scheduled on {1} at {2} {3}.').format(course, date, start_time, timezone) }}</p>
 <br>
 <p> {{ _("Your evaluator is {0}").format(evaluator) }} </p>
 <br>

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -6,14 +6,16 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests import UnitTestCase
-from frappe.utils import getdate, to_timedelta
+from frappe.utils import get_system_timezone, getdate, to_timedelta
 
 from lms.lms.doctype.lms_certificate.lms_certificate import is_certified
 from lms.lms.test_helpers import BaseTestUtils
 from lms.lms.utils import (
 	DEFAULT_PAGE_LENGTH,
 	MAX_PAGE_LENGTH,
+	convert_from_system_timezone,
 	create_user,
+	format_timezone,
 	get_average_rating,
 	get_batch_count,
 	get_batch_details,
@@ -23,6 +25,7 @@ from lms.lms.utils import (
 	get_course_count,
 	get_course_details,
 	get_courses,
+	get_evaluation_display_timezone,
 	get_evaluator,
 	get_featured_courses,
 	get_instructors,
@@ -594,3 +597,93 @@ class TestListEndpointPaging(BaseTestUtils):
 		finally:
 			frappe.set_user("Administrator")
 			frappe.db.set_single_value("LMS Settings", "allow_guest_access", 1)
+
+
+class TestFormatTimezone(UnitTestCase):
+	def test_iana_zone_gains_its_offset(self):
+		self.assertEqual(format_timezone("Asia/Kolkata", "2026-08-03"), "Asia/Kolkata (GMT+5:30)")
+
+	def test_offset_is_read_at_the_given_instant(self):
+		# America/Santiago is GMT-4 through winter and flips to GMT-3 in September.
+		self.assertEqual(format_timezone("America/Santiago", "2026-08-03"), "America/Santiago (GMT-4:00)")
+		self.assertEqual(format_timezone("America/Santiago", "2026-10-03"), "America/Santiago (GMT-3:00)")
+
+	def test_legacy_free_text_is_echoed(self):
+		self.assertEqual(format_timezone("IST (GMT+5:30)", "2026-08-03"), "IST (GMT+5:30)")
+
+	def test_hostile_value_is_echoed(self):
+		# ZoneInfo resolves keys against the filesystem, so a traversal attempt has
+		# to be rejected as free text rather than raising out of an email.
+		self.assertEqual(format_timezone("../../../etc/passwd", "2026-08-03"), "../../../etc/passwd")
+
+	def test_empty_stays_empty(self):
+		self.assertEqual(format_timezone(None), "")
+		self.assertEqual(format_timezone(""), "")
+
+
+@patch("lms.lms.utils.get_system_timezone", return_value="Asia/Kolkata")
+class TestConvertFromSystemTimezone(UnitTestCase):
+	def test_converts_the_wall_clock(self, _system_timezone):
+		date, time = convert_from_system_timezone("2026-08-03", "10:00:00", "Europe/Berlin")
+		self.assertEqual(date, getdate("2026-08-03"))
+		self.assertEqual(time.strftime("%H:%M"), "06:30")
+
+	def test_rolls_back_into_the_previous_day(self, _system_timezone):
+		date, time = convert_from_system_timezone("2026-08-03", "09:00:00", "America/Los_Angeles")
+		self.assertEqual(date, getdate("2026-08-02"))
+		self.assertEqual(time.strftime("%H:%M"), "20:30")
+
+	def test_accepts_a_timedelta(self, _system_timezone):
+		# Time fields come back from the DB as timedelta, not str.
+		date, time = convert_from_system_timezone(
+			getdate("2026-08-03"), to_timedelta("09:00:00"), "America/New_York"
+		)
+		self.assertEqual(date, getdate("2026-08-02"))
+		self.assertEqual(time.strftime("%H:%M"), "23:30")
+
+	def test_same_zone_is_untouched(self, _system_timezone):
+		date, time = convert_from_system_timezone("2026-08-03", "10:00:00", "Asia/Kolkata")
+		self.assertEqual(date, getdate("2026-08-03"))
+		self.assertEqual(time.strftime("%H:%M"), "10:00")
+
+	def test_legacy_free_text_is_not_converted(self, _system_timezone):
+		# There is no offset to convert against, so the clock is labelled, not moved.
+		date, time = convert_from_system_timezone("2026-08-03", "10:00:00", "IST (GMT+5:30)")
+		self.assertEqual(date, getdate("2026-08-03"))
+		self.assertEqual(time.strftime("%H:%M"), "10:00")
+
+
+class TestEvaluationDisplayTimezone(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		self.admin = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator", "Batch Evaluator"]
+		)
+		self.evaluator = self._create_evaluator()
+		self.course = self._create_course(title="Display Timezone Course")
+
+	def test_batch_timezone_wins(self):
+		batch = self._create_batch(self.course.name, title="Display Timezone Batch")
+		frappe.db.set_value("LMS Batch", batch.name, "timezone", "Europe/Berlin")
+		self.assertEqual(get_evaluation_display_timezone(self.course.name, batch.name), "Europe/Berlin")
+
+	def test_paid_certificate_course_timezone_when_there_is_no_batch(self):
+		frappe.db.set_value(
+			"LMS Course",
+			self.course.name,
+			{"paid_certificate": 1, "timezone": "Europe/Berlin"},
+		)
+		self.assertEqual(get_evaluation_display_timezone(self.course.name), "Europe/Berlin")
+
+	def test_course_timezone_ignored_without_a_paid_certificate(self):
+		# The field `depends_on` paid_certificate, so an unset course can be holding
+		# a stale value from a toggle.
+		frappe.db.set_value(
+			"LMS Course",
+			self.course.name,
+			{"paid_certificate": 0, "timezone": "Europe/Berlin"},
+		)
+		self.assertEqual(get_evaluation_display_timezone(self.course.name), get_system_timezone())
+
+	def test_falls_back_to_the_system_timezone(self):
+		self.assertEqual(get_evaluation_display_timezone(self.course.name), get_system_timezone())


### PR DESCRIPTION
## Summary

When booking an evaluation slot, learners couldn't see timezone, even though the batch page had one which was confusing.

## Why we couldn't just slap batch timezone label on it and call it a day

- Batch has one time zone and System could have another. Evaluator slots are checked against system timezone. So need to account for this.

## What we did instead
We keep the stored time exactly as-is (system timezone) and only **convert it for display**, based on:
- the batch's timezone, if you're booking through a batch
- the course's timezone, if it's a batch-less paid certificate course
- otherwise, system time as before

## Screenshots 

## Other small fixes bundled in
- **Confirmation email** now shows the same converted time as the picker, and we cleaned up a formatting bug where the zone name showed up twice, e.g. `(Europe/Berlin (GMT+2:00) time)`.
- **Certificate request records** now store the zone based on the server's own clock instead of trusting whatever the browser sent — so it can't end up disagreeing with the time stored right next to it.
- **Timezone labels** are now formatted consistently (e.g. `Asia/Kolkata (GMT+5:30)`) instead of showing raw values, while still gracefully falling back for old/legacy data that doesn't fit the expected format.
- **Batch cards** now show the correct offset for the *next upcoming session*, instead of being stuck on whatever the offset was when the batch started — important for batches that run across a daylight saving time change.

## Caution: slots can roll onto a different day
Because of timezone offsets, an evaluator's Monday morning slot (in their zone) can land on Sunday night for someone viewing it in another zone. So one "day" in the picker can actually contain slots from two different underlying dates. We handle this by grouping slots by the *display* day, while still submitting the real underlying date when a booking is made — so this doesn't break anything downstream.

## What we deliberately did NOT change
- We're not converting to *each individual viewer's* browser timezone, the batch's timezone is meant to be the one shared reference point for the whole cohort, so everyone in it is talking about the same slot the same way.
- A few other pages (Upcoming Evaluations, Admin Home, the evaluator's calendar popover) still show the raw system time rather than a converted one. That's a known gap, left as a smaller separate follow-up since those pages pull data differently.