### PR TITLE
fix: align Save button with Not Saved badge in Edit Profile modal

### DIFF
--- a/frontend/src/components/Modals/EditProfile.vue
+++ b/frontend/src/components/Modals/EditProfile.vue
@@ -9,11 +9,9 @@
 					<Badge v-if="isDirty" theme="orange">
 						{{ __('Not Saved') }}
 					</Badge>
-					<div class="pb-5 float-end">
-						<Button variant="solid" @click="saveProfile()">
-							{{ __('Save') }}
-						</Button>
-					</div>
+					<Button variant="solid" @click="saveProfile()">
+						{{ __('Save') }}
+					</Button>
 				</div>
 			</div>
 		</template>


### PR DESCRIPTION
## Problem

In the **Edit Profile** modal, the `Save` button sits noticeably higher than the `Not Saved` badge next to it, so the header row looks misaligned.

<img width="772" height="677" alt="save-button-edit-profile" src="https://github.com/user-attachments/assets/cc99e782-faaf-48d7-bdbf-be2228c406b2" />


## Cause

The button was wrapped in a `div` with `pb-5`. That padding made the wrapper taller than the badge beside it, and the row's `items-center` then centered the taller box — leaving the button offset upward by roughly half the padding.

The same wrapper also carried `float-end`, which has no effect on a flex child.

## Fix

Remove the wrapper so the `Button` is a direct child of the flex row. Both it and the badge then align on the same axis via the existing `items-center`.

No behavior change — purely visual.
