### PR TITLE
fix: align Edit Profile header controls with dialog close button

### DIFF
--- a/frontend/src/components/Modals/EditProfile.vue
+++ b/frontend/src/components/Modals/EditProfile.vue
@@ -1,7 +1,7 @@
 <template>
 	<Dialog v-model:open="show" size="3xl">
 		<template #title>
-			<div class="flex items-center justify-between mb-5">
+			<div class="flex items-center justify-between">
 				<div class="text-3xl-semibold leading-6 text-ink-gray-9">
 					{{ __('Edit Profile') }}
 				</div>
@@ -9,11 +9,9 @@
 					<Badge v-if="isDirty" theme="orange">
 						{{ __('Not Saved') }}
 					</Badge>
-					<div class="pb-5 float-end">
-						<Button variant="solid" @click="saveProfile()">
-							{{ __('Save') }}
-						</Button>
-					</div>
+					<Button variant="solid" @click="saveProfile()">
+						{{ __('Save') }}
+					</Button>
 				</div>
 			</div>
 		</template>


### PR DESCRIPTION
## Problem

In the **Edit Profile** dialog, the header controls don't line up. The dialog's close (`X`) button sits lower than the `Save` button, and the `Not Saved` badge sits lower than `Save`.

<img width="772" height="677" alt="save-button-edit-profile" src="https://github.com/user-attachments/assets/d3137699-e0c7-4723-a14e-d636c0d23d96" />


## Cause

Two independent box-sizing issues in the header, each contributing roughly 10px:

1. **`pb-5` on the Save button's wrapper.** Flex `items-center` centers an item's padded box, so the extra bottom padding lifted the button above the badge beside it. That wrapper also carried `float-end`, which has no effect on a flex child.

2. **`mb-5` on the header row itself.** Flexbox aligns **margin boxes**, so the bottom margin made the title block taller than the close button — which `Dialog` renders as a sibling in the same `items-center` row — lifting the whole left side.

Both offsets push in the same direction, so removing either one alone still leaves the `X` misaligned. Both have to go.

## Fix

- Drop the `pb-5 float-end` wrapper so `Button` is a direct flex child.
- Drop `mb-5` from the header row.

`Dialog` already applies `mb-6` below its header row, so the `mb-5` was also doubling the gap above the form body — which is why the fields start slightly higher in the after shot.

<img width="774" height="615" alt="cancel-button-aligned" src="https://github.com/user-attachments/assets/842fb038-c7b6-4152-a98c-104995e7d821" />


No behavior change — purely visual.
