### PR TITLE
fix(signup): show the signup result on the custom signup form

### DIFF
--- a/lms/lms/user.py
+++ b/lms/lms/user.py
@@ -72,9 +72,9 @@ def sign_up(email: str, full_name: str, verify_terms: bool, user_category: str):
 	set_country_from_ip(None, user.name)
 
 	if user.flags.email_sent:
-		return 1, _("Please check your email for verification")
+		return 1, _("Signup successful. Please check your email for verification.")
 	else:
-		return 2, _("Please ask your administrator to verify your sign-up")
+		return 2, _("Signup successful. Please ask your administrator to verify your sign-up.")
 
 
 def set_country_from_ip(login_manager: object = None, user: str = None):

--- a/lms/templates/signup-form.html
+++ b/lms/templates/signup-form.html
@@ -1,72 +1,139 @@
+{% from "templates/includes/login/macros.html" import alert_banner %}
 {% set custom_signup_content = frappe.db.get_single_value("LMS Settings", "custom_signup_content") %}
-<form class="signup-form" role="form">
-    <div class="page-card-body">
-        <div class="form-group">
-            <label class="form-label sr-only" for="signup_fullname"> {{ _("Full Name") }} </label>
+{% set user_category = frappe.db.get_single_value("LMS Settings", "user_category") %}
+{% set login_link = '<a href="#login">' ~ _("Login") ~ '</a>' %}
+{% set already_registered_message = _("You are already registered. {0} instead.").format(login_link) %}
+<form class="form-signin signup-form flex flex-col gap-8" role="form" novalidate>
+    <div class="page-card-body flex flex-col gap-4">
+        {{ alert_banner("success") }}
+        {{ alert_banner("error") }}
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
+            <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
-            required autofocus>
+                required autofocus autocomplete="name">
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
-        <div class="form-group">
-            <label class="form-label sr-only" for="signup_email"> {{ _("Email") }} </label>
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
+            <label class="text-base text-ink-gray-5 w-full mb-0" for="signup_email">{{ _("Email") }}</label>
             <input type="email" id="signup_email" class="form-control"
-            placeholder="{{ _('jane@example.com') }}" required>
+                placeholder="{{ _('jane@example.com') }}" required autocomplete="email">
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
 
-        {% if frappe.db.get_single_value("LMS Settings", "user_category") %}
-        <div class="form-group">
-            <label class="form-label sr-only"> {{ _("User Category") }} </label>
-            <div class="control-input-wrapper">
-                <div class="control-input flex align-center">
-                    <select type="text" id="user_category" data-fieldname="user_category" style="color: var(--text-light)"
-                    class="input-with-feedback form-control ellipsis" data-fieldtype="Select" required>
-                        <option value=""> {{ _("Category") }} </option>
-                        <option value="Business Owner"> {{ _("Business Owner") }} </option>
-                        <option value="Manager (Sales/Marketing/Customer)"> {{ _("Manager (Sales/Marketing/Customer)") }} </option>
-                        <option value="Employee"> {{ _("Employee") }} </option>
-                        <option value="Student"> {{ _("Student") }} </option>
-                        <option value="Freelancer/Just looking"> {{ _("Freelancer/Just looking") }} </option>
-                        <option value="Others"> {{ _("Others") }} </option>
-                    </select>
+        {% if user_category %}
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
+            <label class="text-base text-ink-gray-5 w-full mb-0" for="user_category">{{ _("User Category") }}</label>
+            <div class="select-input-wrapper">
+                <select id="user_category" class="form-control ellipsis text-base" data-fieldname="user_category"
+                    data-fieldtype="Select" required>
+                    <option value="">{{ _("Category") }}</option>
+                    <option value="Business Owner">{{ _("Business Owner") }}</option>
+                    <option value="Manager (Sales/Marketing/Customer)">{{ _("Manager (Sales/Marketing/Customer)") }}</option>
+                    <option value="Employee">{{ _("Employee") }}</option>
+                    <option value="Student">{{ _("Student") }}</option>
+                    <option value="Freelancer/Just looking">{{ _("Freelancer/Just looking") }}</option>
+                    <option value="Others">{{ _("Others") }}</option>
+                </select>
+                <div class="select-icon">
+                    <svg class="icon icon-sm" aria-hidden="true">
+                        <use href="#icon-chevrons-up-down"></use>
+                    </svg>
                 </div>
             </div>
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
         {% endif %}
 
         {% if custom_signup_content %}
-        <div class="form-group">
-            <div class="checkbox">
-                <label>
-                    <span class="input-area">
-                    <input type="checkbox" autocomplete="off" class="input-with-feedback"
-                        data-fieldtype="Check" data-fieldname="terms" id="signup-terms" required>
-                    </span>
-                    <span class="label-area">
-                    {{ custom_signup_content }}
-                    </span>
-                </label>
-            </div>
+        <div class="form-group flex flex-col items-start gap-1.5 mb-0">
+            <label class="flex items-start gap-2 text-p-sm text-ink-gray-7 mb-0">
+                <input type="checkbox" id="signup-terms" class="shrink-0 mt-1" data-fieldtype="Check"
+                    data-fieldname="terms" autocomplete="off" required>
+                <span>{{ custom_signup_content }}</span>
+            </label>
+            <p class="field-error text-base text-ink-red-8 mb-0"></p>
         </div>
         {% endif %}
     </div>
-    <div class="page-card-actions">
-        <button class="btn btn-sm btn-primary btn-block btn-signup"
-            type="submit">{{ _("Sign up") }}</button>
+    <div class="page-card-actions flex flex-col gap-3">
+        <button class="es-button w-full btn-signup" data-variant="solid"
+            type="submit" disabled>{{ _("Sign up") }}</button>
 
-        <p class="text-center sign-up-message">
-            <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
+        <p class="text-center sign-up-message text-p-sm text-ink-gray-6 mt-auto mb-0">
+            <a href="#login" class="text-p-sm-semibold text-ink-gray-6">{{ _("Have an account? Login") }}</a>
         </p>
     </div>
 </form>
 
+<style>
+    .signup-form .select-input-wrapper {
+        position: relative;
+        width: 100%;
+    }
+
+    .signup-form select.form-control {
+        appearance: none;
+        height: 28px;
+        padding: 2px 8px;
+        padding-inline-end: 28px;
+        border: 1px solid var(--outline-gray-2);
+        border-radius: var(--radius);
+        background-color: var(--surface-base);
+        cursor: pointer;
+    }
+
+    .signup-form .form-group.invalid select.form-control {
+        border-color: var(--outline-red-3);
+    }
+
+    .signup-form .select-icon {
+        position: absolute;
+        top: 50%;
+        inset-inline-end: 8px;
+        transform: translateY(-50%);
+        pointer-events: none;
+        line-height: 0;
+    }
+
+    .signup-form .select-icon use {
+        stroke: var(--ink-gray-5);
+    }
+
+    .signup-form input[type="checkbox"] {
+        accent-color: var(--surface-gray-7);
+    }
+
+    .signup-form .login-error-banner a {
+        color: inherit;
+        font-weight: 600;
+        text-decoration: underline;
+    }
+</style>
+
 <script>
+    let signup_button_label = "";
+
     frappe.ready(function () {
+        signup_button_label = $(".signup-form .btn-signup").text().trim();
+
         $("#user_category").on("change", (e) => {
             style_category(e);
+            clear_field_error("user_category");
+        });
+
+        $("#signup_fullname, #signup_email").on("input", () => {
+            toggle_signup_button();
+        });
+
+        $(window).on("hashchange", () => {
+            reset_signup_form();
         });
 
         $(".signup-form").on("submit", (e) => {
             signup(e);
         });
+
+        toggle_signup_button();
     });
 
     const style_category = (e) => {
@@ -74,13 +141,49 @@
         $("#user_category").css("color", category_color);
     }
 
+    const clear_field_error = (field) => {
+        $("#" + field).closest(".form-group").removeClass("invalid").find(".field-error").text("");
+    }
+
+    const toggle_signup_button = () => {
+        const filled = ($("#signup_fullname").val() || "").trim() && ($("#signup_email").val() || "").trim();
+        $(".signup-form .btn-signup").prop("disabled", !filled);
+    }
+
+    const reset_signup_form = () => {
+        const form = $(".signup-form");
+        form.find("input:not([type='submit'])").val("").prop("checked", false);
+        form.find("#user_category").val("").css("color", "var(--text-muted)");
+        form.find(".form-group").removeClass("invalid").find(".field-error").text("");
+        form.find(".page-card-body").removeClass("invalid");
+        form.find(".login-error-banner, .login-success-banner").addClass("hidden");
+        form.find(".btn-signup").removeAttr("aria-busy").text(signup_button_label);
+        toggle_signup_button();
+    }
+
     const signup = (e) => {
         e.preventDefault();
         const email = ($("#signup_email").val() || "").trim();
         const full_name = frappe.utils.xss_sanitise(($("#signup_fullname").val() || "").trim());
+        const user_category = $("#user_category").length ? $("#user_category").val() : "";
 
-        if (!email || !validate_email(email) || !full_name) {
-            login.set_status('{{ _("Valid email and name required") }}', 'red');
+        if (!full_name) {
+            login.show_field_error("signup_fullname", {{ _("Full name is required.") | tojson }});
+            return false;
+        }
+
+        if (!email || !validate_email(email)) {
+            login.show_field_error("signup_email", {{ _("Please enter a valid email.") | tojson }});
+            return false;
+        }
+
+        if ($("#user_category").length && !user_category) {
+            login.show_field_error("user_category", {{ _("Please select a category.") | tojson }});
+            return false;
+        }
+
+        if ($("#signup-terms").length && !$("#signup-terms").prop("checked")) {
+            login.show_field_error("signup-terms", {{ _("Please accept the terms to continue.") | tojson }});
             return false;
         }
 
@@ -90,10 +193,42 @@
                 "email": email,
                 "full_name": full_name,
                 "verify_terms": $("#signup-terms").prop("checked") ? 1 : 0,
-                "user_category": $("#user_category").length ?  $("#user_category").val() : ""
+                "user_category": user_category
             },
-            statusCode: login.login_handlers
+            statusCode: signup_handlers()
         })
         return false;
+    }
+
+    const signup_handlers = () => {
+        return Object.assign({}, login.login_handlers, {
+            200: (data) => {
+                const [code, message] = data.message;
+                const section = $("section:visible");
+
+                if (cint(code) === 0) {
+                    login.hide_loading();
+                    section.find(".login-success-banner").addClass("hidden");
+                    show_signup_error(message);
+                } else {
+                    login.set_status({{ _("Success") | tojson }}, "green");
+                    section.find(".login-error-banner").addClass("hidden");
+                    login.show_success_banner(message);
+                }
+            }
+        });
+    }
+
+    const show_signup_error = (message) => {
+        const banner = $("section:visible .login-error-banner");
+        const title = banner.find(".es-alert__title");
+
+        if (message === {{ _("Already Registered") | tojson }}) {
+            title.html({{ already_registered_message | tojson }});
+        } else {
+            title.text(message);
+        }
+
+        banner.removeClass("hidden");
     }
 </script>

--- a/lms/tests/test_signup_form.py
+++ b/lms/tests/test_signup_form.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2021, FOSS United and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import UnitTestCase
+
+SIGNUP_FORM = "lms/templates/signup-form.html"
+
+
+class TestSignupForm(UnitTestCase):
+	def render(self, **lms_settings):
+		original = frappe.db.get_single_value
+
+		def get_single_value(doctype, fieldname, *args, **kwargs):
+			if doctype == "LMS Settings":
+				return lms_settings.get(fieldname)
+			return original(doctype, fieldname, *args, **kwargs)
+
+		with patch.object(frappe.db, "get_single_value", side_effect=get_single_value):
+			return frappe.get_template(SIGNUP_FORM).render({})
+
+	def test_renders_the_result_banners(self):
+		html = self.render()
+		self.assertIn("login-error-banner", html)
+		self.assertIn("login-success-banner", html)
+
+	def test_submit_button_is_an_es_button(self):
+		html = self.render()
+		self.assertIn('class="es-button w-full btn-signup"', html)
+
+	def test_does_not_reuse_the_framework_signup_class(self):
+		html = self.render()
+		self.assertIn("signup-form", html)
+		self.assertNotIn("form-signup", html)
+
+	def test_already_registered_message_links_to_login(self):
+		html = self.render()
+		self.assertIn("You are already registered.", html)
+		self.assertIn('href=\\"#login\\"', html)
+
+	def test_optional_fields_render_only_when_configured(self):
+		html = self.render()
+		self.assertNotIn('id="user_category"', html)
+		self.assertNotIn('id="signup-terms"', html)
+
+		html = self.render(user_category=1, custom_signup_content="I agree to the terms")
+		self.assertIn('id="user_category"', html)
+		self.assertIn('id="signup-terms"', html)
+		self.assertIn("I agree to the terms", html)
+		self.assertIn("icon-chevrons-up-down", html)


### PR DESCRIPTION
### Problem

- The LMS custom signup form predates frappe's login page rewrite. 
- It has no alert banner elements and no `es-button`, but `login.js` reports the signup result through `login.show_error_banner()` / `show_success_banner()` and drives the loading state off `.es-button`. Both selectors matched nothing, so "Already Registered" and "Please check your email for verification" were dropped silently and the form just sat there after submit.
- Now fixed

### Changes

- Mirror `frappe/templates/signup.html`: success and error banners, per field error text, `es-button` submit, and the missing gap above "Have an account? Login".
- Already registered now reads "You are already registered. Login instead." with Login linked to `#login`.
- Both success messages now lead with "Signup successful."
- User Category renders as a real dropdown with a chevron, matching desk's `ControlSelect`.
- The form keeps its own class rather than frappe's `form-signup`: `login.js` binds a submit handler to that class, which would double submit to frappe's `sign_up` and drop the LMS only fields.
- Added tests