### PR TITLE
fix: use tab route hash '#editor' instead of display label '#course editor' for lesson links

### DIFF
--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -263,7 +263,7 @@ function lessonRoute(lesson: OutlineLesson): RouteLocationRaw {
 		return {
 			name: 'CourseDetail',
 			params: { courseName: props.courseName },
-			hash: '#course editor',
+			hash: '#editor',
 			query: { editLesson: lesson.number },
 		}
 	}

--- a/frontend/src/components/CourseOutline.vue
+++ b/frontend/src/components/CourseOutline.vue
@@ -334,7 +334,7 @@ function navigateToLesson(lesson: OutlineLesson) {
 		router.push({
 			name: 'CourseDetail',
 			params: { courseName: props.courseName },
-			hash: '#course editor',
+			hash: '#editor',
 			query: { editLesson: lesson.number },
 		})
 	}

--- a/frontend/src/pages/Courses/CourseEditor.vue
+++ b/frontend/src/pages/Courses/CourseEditor.vue
@@ -131,7 +131,7 @@ function syncSelectedToUrl(number) {
 	if (route.query.editLesson === number) return
 	router.replace({
 		query: { ...route.query, editLesson: number },
-		hash: route.hash || '#course editor',
+		hash: route.hash || '#editor',
 	})
 }
 
@@ -285,7 +285,7 @@ watch(
 				const { editLesson, ...rest } = route.query
 				router.replace({
 					query: rest,
-					hash: route.hash || '#course editor',
+					hash: route.hash || '#editor',
 				})
 			}
 		}
@@ -328,7 +328,7 @@ watch(
 		if (lessonMode !== 'preview') {
 			legacyLessonModeHandled = true
 			const { lessonMode: _dropped, ...query } = route.query
-			router.replace({ query, hash: route.hash || '#course editor' })
+			router.replace({ query, hash: route.hash || '#editor' })
 			return
 		}
 		const number = route.query.editLesson || selectedNumber

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -8,7 +8,7 @@
 					:to="{
 						name: 'CourseDetail',
 						params: { courseName: courseName },
-						hash: '#course editor',
+						hash: '#editor',
 						query: { editLesson: `${chapterNumber}-${lessonNumber}` },
 					}"
 				>


### PR DESCRIPTION
**Describe the bug**
When an admin clicks a lesson link in the "Course content" section on the Course Overview tab, the page doesn't navigate to the Course Editor tab. The URL changes but the tab doesn't switch — the user stays on the Overview tab. This happens because the lesson link hash fragment is set to `#course%20editor` (the tab's display label, URL-encoded) instead of `#editor` (the tab's actual route key used by `TabbedDetailPage`).

**To Reproduce**
1. Log in as an Administrator or Course Instructor
2. Go to any published course's detail page (e.g. `/lms/courses/<course-name>`)
3. Stay on the "Overview" tab
4. Under "Course content," click any lesson link (e.g. "Lesson 1 - ...")
5. Observe the URL changes to `?editLesson=1-1#course%20editor` but the page stays on Overview

**Expected behavior**
Clicking a lesson link should navigate to the "Course editor" tab and open that lesson for editing. The URL hash should be `#editor`, matching the tab's route key.

**Screenshots**
Overview link generates:
`https://example.com/lms/courses/course-name?editLesson=1-1#course%20editor`

Course editor direct link (works correctly):
`https://example.com/lms/courses/course-name?editLesson=1-1#editor`

**Desktop (please complete the following information):**
- OS: Windows 11
- Browser: Chrome
- Version: Latest (2026)

**Additional context**
The issue exists in four files where `hash: '#course editor'` is used instead of `hash: '#editor'`:

- `frontend/src/components/CourseOutline.vue` — `navigateToLesson()`
- `frontend/src/components/ChapterRow.vue` — `lessonRoute()`
- `frontend/src/pages/Lesson.vue` — "Editor View" router-link
- `frontend/src/pages/Courses/CourseEditor.vue` — `syncSelectedToUrl()` and `watch()` fallback references

Fix is straightforward: replace all `#course editor` hash references with `#editor` to match `TabbedDetailPage`'s tab key resolution. Only affects admin/instructor view — student-facing lesson navigation is unaffected. Happy to submit a PR with the fix if helpful.