### PR TITLE
fix(profile): require only a first name to save a profile

### DIFF
--- a/frontend/src/pages/Forms/ProfileEditForm.vue
+++ b/frontend/src/pages/Forms/ProfileEditForm.vue
@@ -21,7 +21,6 @@
 					<Uploader
 						v-model="profile.image"
 						:label="__('Profile Image')"
-						:required="true"
 						shape="circle"
 					/>
 					<FormControl
@@ -29,11 +28,7 @@
 						:label="__('First Name')"
 						:required="true"
 					/>
-					<FormControl
-						v-model="profile.last_name"
-						:label="__('Last Name')"
-						:required="true"
-					/>
+					<FormControl v-model="profile.last_name" :label="__('Last Name')" />
 					<FormControl v-model="profile.headline" :label="__('Headline')" />
 					<FormControl v-model="profile.linkedin" :label="__('LinkedIn ID')" />
 					<FormControl v-model="profile.github" :label="__('GitHub ID')" />
@@ -162,8 +157,6 @@ const updateProfile = createResource({
 const validateMandatoryFields = () => {
 	const missingFields = []
 	if (!profile.first_name) missingFields.push(__('First Name'))
-	if (!profile.last_name) missingFields.push(__('Last Name'))
-	if (!profile.image) missingFields.push(__('Profile Image'))
 	if (missingFields.length) {
 		toast.error(
 			__('Please fill the mandatory fields: {0}').format(


### PR DESCRIPTION
## Problem

The Edit Profile form treats **Last Name** and **Profile Image** as mandatory, but on the `User` doctype only `first_name` is `reqd`:

| field | `reqd` |
| --- | --- |
| `first_name` | 1 |
| `last_name` | 0 |
| `user_image` | 0 |

<img width="1915" height="944" alt="image" src="https://github.com/user-attachments/assets/5558d1ac-2b85-412a-8539-c5e6b3f07a27" />

`validateMandatoryFields()` gates the entire submit, so those two extra checks don't just mark fields — they make *every* field in the form uneditable for a user who has no avatar or no last name. The clearest symptom: such a user cannot change their **Language**, which is arguably the setting they most need. They get `Please fill the mandatory fields: Last Name, Profile Image` no matter which field they touched.

Nothing on the server enforces this either, so the restriction exists only in this form.

## Fix

Drop `last_name` and `image` from the validation and remove the matching `:required="true"` markers, leaving First Name as the only gate.

## Rebased onto the form-shell refactor

This PR originally targeted `components/Modals/EditProfile.vue`. #2662 moved the remaining forms onto the shared shell, deleting that modal in favour of the `/user/<username>/edit` route in `pages/Forms/ProfileEditForm.vue`. The refactor carried `validateMandatoryFields()` over unchanged, so the bug came with it — the fix is now applied there instead.

One line of the original change is already upstream: the refactor dropped the `console.error` that sat beside the toast, so this PR no longer touches it.

## Testing

- Profile with no avatar and no last name: changing Language now saves and applies.
- Clearing First Name still blocks the save with the toast.
- `yarn test`: 137 files, 1276 tests, all passing — including `profileEditRoute.test.ts`, which mounts this component.
