### PR TITLE
fix: preserve batch discussion hash in notifications

### DIFF
--- a/frontend/src/components/Notifications/NotificationPanel.vue
+++ b/frontend/src/components/Notifications/NotificationPanel.vue
@@ -156,7 +156,13 @@ const navigateToPage = (log) => {
 	if (link[2] == 'courses') {
 		router.push({ name: 'CourseDetail', params: { courseName: link[3] } })
 	} else if (link.includes('batches')) {
-		router.push({ name: 'BatchDetail', params: { batchName: link.pop() } })
+		const batchTarget = link.pop()
+		const [batchName, hashValue] = batchTarget.split('#')
+		router.push({
+			name: 'BatchDetail',
+			params: { batchName },
+			hash: hashValue ? `#${hashValue}` : '',
+		})
 	} else if (link.includes('assignment-submission')) {
 		router.push({
 			name: 'AssignmentSubmission',


### PR DESCRIPTION
## Description

Fixes batch discussion notifications opening an invalid batch URL.

When a user clicks a notification related to a batch discussion, the notification link contains a fragment such as:

```text
/lms/batches/my-batch#discussions
```

However, `NotificationPanel.vue` currently passes the last part of the URL directly as the `batchName` route parameter:

```js
router.push({
    name: 'BatchDetail',
    params: { batchName: link.pop() },
})
```

This causes Vue Router to treat:

```text
my-batch#discussions
```

as the batch name itself and URL-encode the `#` character.

The resulting URL becomes:

```text
/lms/batches/my-batch%23discussions
```

instead of:

```text
/lms/batches/my-batch#discussions
```

## Result

The invalid URL causes the Batch Detail page to load incorrectly.

Observed symptoms include:

- blank batch page
- dashboard statistics showing zero
- student details not opening correctly
- subsequent tab navigation producing URLs such as:

```text
/lms/batches/my-batch#discussions#dashboard
```

## Fix

Split the batch name and URL fragment before navigating and pass the fragment through Vue Router's `hash` property:

```js
const batchTarget = link.pop()
const [batchName, hashValue] = batchTarget.split('#')

router.push({
    name: 'BatchDetail',
    params: { batchName },
    hash: hashValue ? `#${hashValue}` : '',
})
```

This preserves the intended URL:

```text
/lms/batches/my-batch#discussions
```

## Testing

Tested with Frappe Learning 2.61.0.

Verified the issue and fix using:

- an instructor account
- a student account
- batch discussion notifications
- navigation between Discussions and other Batch Detail tabs

After the fix, clicking a discussion notification correctly opens the Discussions tab and subsequent tab navigation works normally.

## Screenshots

1. The broken URL:
<img width="1341" height="535" alt="Screenshot 2026-08-10 at 11 38 06 PM" src="https://github.com/user-attachments/assets/7f962736-2bf0-41fa-b43a-c9b2794dc554" />


2. The corrected URL:
<img width="1345" height="508" alt="Screenshot 2026-08-10 at 11 36 24 PM" src="https://github.com/user-attachments/assets/74a8ab1e-2175-4562-94a3-8c4690c82b5e" />
