### PR TITLE
fix(profile): stop a reverted language change from reloading the page

### DIFF
--- a/frontend/src/pages/Forms/ProfileEditForm.vue
+++ b/frontend/src/pages/Forms/ProfileEditForm.vue
@@ -110,7 +110,6 @@ const props = defineProps({
 const user = inject('$user')
 const router = useRouter()
 const readOnlyMode = window.read_only_mode
-const hasLanguageChanged = ref(false)
 const isDirty = ref(false)
 
 const parent = {
@@ -145,6 +144,12 @@ const profile = reactive({
 	twitter: '',
 })
 
+// Normalised to '' on both sides: `language` is nullable on User, so an unset
+// language would otherwise read as a change on every save.
+const hasLanguageChanged = computed(
+	() => (profile.language ?? '') !== (profileData.value?.language ?? '')
+)
+
 const updateProfile = createResource({
 	url: 'frappe.client.set_value',
 	makeParams() {
@@ -177,6 +182,11 @@ const validateMandatoryFields = () => {
 const saveProfile = () => {
 	if (refusal.value || !profileData.value) return
 	if (validateMandatoryFields()) return
+
+	// Read before submitting: the computed is live against the parent resource,
+	// which onSuccess reloads out from under it.
+	const languageChanged = hasLanguageChanged.value
+
 	profile.bio = sanitizeOnWrite(profile.bio)
 	submitResource(
 		updateProfile,
@@ -189,7 +199,7 @@ const saveProfile = () => {
 				// render a half-shaped profile for the tick before the reload lands.
 				props.profile?.reload()
 				toast.success(__('Profile updated successfully'))
-				if (hasLanguageChanged.value) {
+				if (languageChanged) {
 					// A language change only takes effect after the whole SPA reloads,
 					// which is what the modal did. Going through location rather than
 					// the router so the reload lands on the profile, not back here.
@@ -242,13 +252,5 @@ watch(
 		isDirty.value = false
 	},
 	{ immediate: true }
-)
-
-watch(
-	() => profile.language,
-	() => {
-		if (profileData.value && profile.language !== profileData.value.language)
-			hasLanguageChanged.value = true
-	}
 )
 </script>


### PR DESCRIPTION
## Problem

Changing **Language** in the Edit Profile form and then changing it *back* to its original value still triggers a full page reload on save. Any unsaved state elsewhere on the page is discarded for no reason.

`hasLanguageChanged` is a `ref(false)` maintained by a watcher that only ever sets it to `true`:

```js
const hasLanguageChanged = ref(false)

watch(
	() => profile.language,
	() => {
		if (profileData.value && profile.language !== profileData.value.language)
			hasLanguageChanged.value = true
	}
)
```

There is no branch that clears it. Once it flips, it stays `true` for the lifetime of the form regardless of what the field currently holds, and `saveProfile` reads that stale flag to decide whether to reload.

The underlying issue is that `hasLanguageChanged` is not an event to react to — it is a comparison between the draft and the server copy, i.e. derived state. Derived state belongs in a `computed`, which cannot drift out of sync with its inputs.

### Steps to reproduce

1. Open **Edit Profile** (`/user/<username>/edit`).
2. Change Language to any other value.
3. Change Language back to the original value.
4. Change some other field, e.g. Headline.
5. Save.

**Expected:** the form closes, profile refreshes in place, no page reload.
**Actual:** the whole page reloads.

## Demo

<!-- video -->

https://github.com/user-attachments/assets/4fe84933-3a3f-4d96-abf5-2ccb35e37ace

## Fix

Replace the ref and its watcher with a `computed`:

```js
const hasLanguageChanged = computed(
	() => (profile.language ?? '') !== (profileData.value?.language ?? '')
)
```

Two details worth calling out for review:

**Both sides are normalised to `''`.** `language` is nullable on `User`, so a user who has never set one holds `null` server-side. Normalising only one side would make `null !== ''` true and reload the page on *every* save for those users.

**The computed is read before submitting, not inside `onSuccess`.** It compares the draft against the parent's profile resource, and `onSuccess` reloads that resource. Capturing the value first keeps the reload decision pinned to what the user actually changed, rather than leaving it dependent on when that refetch lands:

```js
const languageChanged = hasLanguageChanged.value
```

The manual `hasLanguageChanged.value = false` reset in the success path is dropped along with the ref — a computed cannot be assigned to, and it now resolves correctly on its own.

## Rebased onto the form-shell refactor

This PR originally targeted `components/Modals/EditProfile.vue`. #2662 moved the remaining forms onto the shared shell, deleting that modal in favour of the `/user/<username>/edit` route in `pages/Forms/ProfileEditForm.vue`. The refactor carried the latching ref and its watcher over unchanged, so the bug came with it — the fix is now applied there instead.

One detail of the original rationale no longer holds. In the modal, the resource declared its own `onSuccess` that assigned the response straight to `props.profile.data`, and frappe-ui runs the resource-level handler before the call-level one — so reading the computed inside `onSuccess` would have compared the new language against itself and read `false`. The refactor dropped that assignment in favour of `props.profile?.reload()`, so the ordering argument is gone; capturing before submit is now about not depending on the refetch's timing.

## Testing

`yarn test`: 137 files, 1276 tests, all passing.

Manual verification, against a local build of the pre-refactor modal — the flag's logic is carried over unchanged, but the runs below predate the move to the route. Sentinel-based check (`window.__sentinel = Date.now()` before each save, then reading it back) to distinguish a real page reload from a form close:

| scenario | expected | result |
| --- | --- | --- |
| Language changed and changed back, another field edited | no reload | ✅ |
| Language changed to a different value | reload, UI comes back in the new locale | ✅ |
| Language untouched, another field edited | no reload | ✅ |
| Save fails (offline), then retried online | no reload on failure, reload on the successful retry | ✅ |
| User with `language = NULL`, unrelated field edited | no reload | ✅ |
| "Not Saved" badge behaviour | unchanged | ✅ |

## Notes

Independent of #2656 — re-verified after both were rebased: they now touch the same file but different regions, and still merge cleanly in either order. They are complementary: #2656's reported symptom is that a user with no avatar *"cannot change their Language"*, and this PR fixes what happens once they can.
