### PR TITLE
fix(security): sanitize what renders and what saves, allowlist bound URL schemes, and pair every permission gate

### DIFF
--- a/.github/semgrep/fixtures/security.py
+++ b/.github/semgrep/fixtures/security.py
@@ -1,0 +1,48 @@
+"""Known positives for security.yml. Every function here MUST be flagged,
+apart from the suppressed one, which proves the escape hatch works.
+
+The filename has to match the rule file's stem for `semgrep --test`.
+Not imported by the app; excluded from coverage."""
+
+import shutil
+
+import frappe
+
+
+# ruleid: lms-mutating-whitelist-needs-post
+@frappe.whitelist()
+def mutating_on_get(name: str):
+	frappe.delete_doc("LMS Course", name)
+
+
+# ruleid: lms-mutating-whitelist-needs-post
+@frappe.whitelist()
+def rmtree_on_get(path: str):
+	shutil.rmtree(path)
+
+
+@frappe.whitelist()
+def bypass_without_reason(course: str):
+	# ruleid: lms-unjustified-ignore-permissions
+	return frappe.get_all("LMS Course", filters={"name": course}, ignore_permissions=True)
+
+
+@frappe.whitelist()
+def bypass_via_flags(course: str):
+	doc = frappe.get_doc("LMS Course", course)
+	# ruleid: lms-unjustified-ignore-permissions
+	doc.flags.ignore_permissions = True
+	return doc
+
+
+def bypass_with_reason(course: str):
+	# ok: lms-unjustified-ignore-permissions
+	# nosemgrep: lms-unjustified-ignore-permissions - background job, no user session
+	return frappe.get_all("LMS Course", filters={"name": course}, ignore_permissions=True)
+
+
+@frappe.whitelist(methods=["POST"])
+def race(member: str, batch: str):
+	# ruleid: lms-exists-then-insert
+	if not frappe.db.exists("LMS Batch Enrollment", {"member": member, "batch": batch}):
+		frappe.get_doc({"doctype": "LMS Batch Enrollment", "member": member, "batch": batch}).insert()

--- a/.github/semgrep/security.yml
+++ b/.github/semgrep/security.yml
@@ -1,0 +1,66 @@
+rules:
+  - id: lms-mutating-whitelist-needs-post
+    languages: [python]
+    severity: ERROR
+    message: >-
+      This whitelisted method mutates state but does not declare
+      methods=["POST"]. Frappe allows GET unless you say otherwise, and
+      validate_csrf_token returns early on GET, so this is reachable by a
+      tokenless cross-site navigation. Filesystem and outbound effects also
+      survive Frappe's GET auto-rollback.
+    patterns:
+      - pattern: |
+          @frappe.whitelist()
+          def $F(...):
+            ...
+      - pattern-either:
+          - pattern-inside: |
+              @frappe.whitelist()
+              def $F(...):
+                ...
+                shutil.rmtree(...)
+                ...
+          - pattern-inside: |
+              @frappe.whitelist()
+              def $F(...):
+                ...
+                frappe.delete_doc(...)
+                ...
+          - pattern-inside: |
+              @frappe.whitelist()
+              def $F(...):
+                ...
+                $DOC.insert(...)
+                ...
+
+  - id: lms-unjustified-ignore-permissions
+    languages: [python]
+    severity: WARNING
+    message: >-
+      ignore_permissions=True bypasses DocPerms, if_owner and every
+      has_permission hook. If it is genuinely required, justify it on the line
+      above with "# nosemgrep: lms-unjustified-ignore-permissions - <reason>"
+      so a reviewer sees the claim.
+    pattern-either:
+      - pattern: $F(..., ignore_permissions=True, ...)
+      - pattern: $OBJ.flags.ignore_permissions = True
+
+  - id: lms-exists-then-insert
+    languages: [python]
+    severity: ERROR
+    message: >-
+      exists()/count() followed by insert() in the same function is a
+      read-then-insert race. Two concurrent requests both see "absent" and both
+      insert. Add a DB unique constraint (see
+      lms/patches/v2_0/delete_duplicate_course_progress.py) or take a
+      FOR UPDATE lock.
+    patterns:
+      - pattern-either:
+          - pattern: |
+              if not frappe.db.exists(...):
+                ...
+                $DOC.insert(...)
+          - pattern: |
+              if frappe.db.count(...) < $N:
+                ...
+                $DOC.insert(...)

--- a/.github/semgrep/vue-directives.yml
+++ b/.github/semgrep/vue-directives.yml
@@ -1,0 +1,48 @@
+# Local run: semgrep scan --config .github/semgrep/vue-directives.yml frontend/src
+#
+# These are generic-mode regexes, so they see the whole file including comments.
+# The vitest scanners in src/tests/safeHtmlDirective.test.ts strip commented-out
+# markup before matching; this pair does not, which is the stricter reading and
+# the right one for a CI gate: a commented-out sink is one uncomment away.
+rules:
+    - id: no-raw-v-html
+      message: |
+          Raw v-html is banned. Use v-safe-html:rich (lesson bodies, rich author
+          content), v-safe-html:basic (short subjects) or v-safe-html:bio (user
+          bios). A missing or unknown level renders at the strictest profile.
+      languages: [generic]
+      severity: ERROR
+      paths: { include: ['*.vue'] }
+      patterns:
+          - pattern-regex: '(?:^|[\s"''`(\[{])v-html\s*='
+
+    # v-html's other spellings. Vue assigns el.innerHTML for every form below,
+    # so a ban that names only one of them is a ban with a documented bypass.
+    # Verified against @vue/compiler-dom: `:innerHTML`, `v-bind:innerHTML`, the
+    # `.innerHTML` dot shorthand, the `.prop` modifier and `v-bind="{ innerHTML
+    # }"` all compile to a prop assignment. The kebab-case forms are matched too
+    # even though Vue treats them as attributes rather than props — the cost is
+    # one false positive on markup nobody writes, and the alternative is a
+    # reviewer having to know which halves of the spelling matter.
+    - id: no-bound-innerhtml-prop
+      message: |
+          A bound innerHTML prop is v-html under another name and is banned for
+          the same reason. Use v-safe-html with an explicit level.
+      languages: [generic]
+      severity: ERROR
+      paths: { include: ['*.vue'] }
+      patterns:
+          - pattern-either:
+                - pattern-regex: '(?:^|[\s"''`(\[{])(?:\.|:|v-bind:)inner-?[hH][tT][mM][lL](?:\.[a-zA-Z]+)?\s*='
+                - pattern-regex: 'v-bind\s*=\s*"[^"]*\binner-?[hH][tT][mM][lL]\s*[:}]'
+
+    - id: external-link-needs-directive
+      message: |
+          Use v-external instead of a bare target="_blank" — it sets
+          rel="noopener noreferrer" so the opened page cannot reach
+          window.opener (reverse tabnabbing).
+      languages: [generic]
+      severity: ERROR
+      paths: { include: ['*.vue'] }
+      patterns:
+          - pattern-regex: 'target\s*=\s*[\"'']_blank[\"'']'

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -60,6 +60,14 @@ jobs:
       - name: Run Semgrep rules
         run: semgrep ci --config ./frappe-semgrep-rules/rules
 
+      - name: Run LMS security Semgrep rules
+        # `semgrep ci` is diff-aware on its own: in a PR it fetches and computes
+        # the branch-off point itself, so only findings this PR introduces
+        # block. Passing --baseline-commit instead would fail here, because the
+        # checkout above is shallow and `git cat-file -e <base sha>` misses.
+        # The fixtures are deliberate positives and must not be scanned.
+        run: semgrep ci --config ./.github/semgrep/security.yml --exclude '.github/semgrep/fixtures'
+
       - name: Run RTL Semgrep rules
         # --error is required: a bare `semgrep scan` prints its findings and
         # still exits 0, so without it this step could never fail.

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -68,6 +68,12 @@ jobs:
         # The fixtures are deliberate positives and must not be scanned.
         run: semgrep ci --config ./.github/semgrep/security.yml --exclude '.github/semgrep/fixtures'
 
+      - name: Run Vue directive Semgrep rules
+        # --error for the same reason as the RTL step below: a bare
+        # `semgrep scan` prints its findings and still exits 0. The tree is at
+        # 0 findings, so no baseline is needed.
+        run: semgrep scan --error --config ./.github/semgrep/vue-directives.yml frontend/src
+
       - name: Run RTL Semgrep rules
         # --error is required: a bare `semgrep scan` prints its findings and
         # still exits 0, so without it this step could never fail.

--- a/frontend/src/components/AssessmentPlugin.vue
+++ b/frontend/src/components/AssessmentPlugin.vue
@@ -67,6 +67,7 @@ import { nextTick, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { getLmsRoute } from '@/utils/basePath'
 import Link from '@/components/Controls/Link.vue'
+import { openExternal } from '@/utils/openExternal'
 
 const show = ref(false)
 const quiz = ref(null)
@@ -97,9 +98,9 @@ const addAssessment = () => {
 
 const redirectToForm = () => {
 	if (props.type == 'quiz') {
-		window.open(getLmsRoute('quizzes?new=true'), '_blank')
+		openExternal(getLmsRoute('quizzes?new=true'))
 	} else {
-		window.open(getLmsRoute('assignments/new'), '_blank')
+		openExternal(getLmsRoute('assignments/new'))
 	}
 }
 </script>

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -108,7 +108,7 @@
 						<div class="flex items-center text-ink-gray-7">
 							<a
 								:href="safeUrl(attachment)"
-								target="_blank"
+								v-external
 								class="cursor-pointer !no-underline text-sm leading-5"
 							>
 								<div class="flex items-center">

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -20,7 +20,7 @@
 				{{ __('Assignment') }}: {{ assignment.data.title }}
 			</div>
 			<div
-				v-html="sanitizeRichHTML(assignment.data.question)"
+				v-safe-html:rich="assignment.data.question"
 				class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal"
 			></div>
 		</div>
@@ -168,7 +168,7 @@
 					</div>
 					<div
 						class="leading-6 text-ink-gray-9"
-						v-html="sanitizeRichHTML(submissionResource.doc.comments)"
+						v-safe-html:rich="submissionResource.doc.comments"
 					></div>
 				</div>
 
@@ -210,7 +210,6 @@
 	</div>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import {
 	Badge,
 	Button,

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -107,7 +107,7 @@
 					<div v-else>
 						<div class="flex items-center text-ink-gray-7">
 							<a
-								:href="attachment"
+								:href="safeUrl(attachment)"
 								target="_blank"
 								class="cursor-pointer !no-underline text-sm leading-5"
 							>
@@ -230,6 +230,7 @@ import {
 import { useRouter } from 'vue-router'
 import { validateFile } from '@/utils'
 import RichTextEditor from '@/components/RichTextEditor.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const answer = ref(null)
 const attachment = ref(null)

--- a/frontend/src/components/AudioBlock.vue
+++ b/frontend/src/components/AudioBlock.vue
@@ -4,7 +4,7 @@
 			<source :src="encodeURI(file)" type="audio/mp3" />
 		</audio> -->
 		<audio @ended="handleAudioEnd" controlsList="nodownload" class="mb-4">
-			<source :src="encodeURI(file)" type="audio/mp3" />
+			<source :src="safeUrl(encodeURI(file))" type="audio/mp3" />
 		</audio>
 		<div class="flex items-center gap-x-2 shadow rounded-lg p-1 w-1/2">
 			<Button
@@ -50,6 +50,7 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
 import { Button } from 'frappe-ui'
+import { safeUrl } from '@/utils/safeUrl'
 
 const isPlaying = ref(false)
 const audio = ref(null)

--- a/frontend/src/components/CertificationLinks.vue
+++ b/frontend/src/components/CertificationLinks.vue
@@ -56,6 +56,7 @@
 import { Button, createResource } from 'frappe-ui'
 import { inject } from 'vue'
 import type { CertificationInfo, Resource, SessionUser } from '@/types'
+import { openExternal } from '@/utils/openExternal'
 
 const user = inject<SessionUser>('$user')!
 
@@ -76,7 +77,7 @@ const certification = createResource({
 const downloadCertificate = () => {
 	const cert = certification.data?.certificate
 	if (!cert) return
-	window.open(
+	openExternal(
 		`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
 			cert.name
 		}&format=${encodeURIComponent(cert.template)}`

--- a/frontend/src/components/CommandPalette/CommandPaletteGroup.vue
+++ b/frontend/src/components/CommandPalette/CommandPaletteGroup.vue
@@ -18,7 +18,7 @@
 							:is="item.icon"
 							class="size-4 stroke-1.5 text-ink-gray-6"
 						/>
-						<div v-html="sanitizeRichHTML(item.title)"></div>
+						<div v-safe-html:rich="item.title"></div>
 					</div>
 					<div v-if="item.modified" class="text-ink-gray-5">
 						{{ dayjs.unix(item.modified).fromNow(true) }}
@@ -30,7 +30,6 @@
 </template>
 <script lang="ts" setup>
 import { inject } from 'vue'
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 
 const dayjs = inject<any>('$dayjs')
 const emit = defineEmits(['navigateTo'])

--- a/frontend/src/components/Controls/Uploader.vue
+++ b/frontend/src/components/Controls/Uploader.vue
@@ -25,12 +25,12 @@
 						<template v-if="modelValue">
 							<img
 								v-if="type === 'image'"
-								:src="modelValue"
+								:src="safeUrl(modelValue)"
 								:alt="label ? __(label) : __('Uploaded image preview')"
 								class="size-full object-cover"
 							/>
 							<video v-else controls class="size-full object-cover">
-								<source :src="modelValue" />
+								<source :src="safeUrl(modelValue)" />
 								{{ __('Your browser does not support the video tag.') }}
 							</video>
 						</template>
@@ -86,6 +86,7 @@ import {
 } from '@/components/Form/labeling'
 import { Image, Video } from 'lucide-vue-next'
 import { computed } from 'vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const emit = defineEmits<{
 	(e: 'update:modelValue', value: string): void

--- a/frontend/src/components/Controls/VideoPreviewField.vue
+++ b/frontend/src/components/Controls/VideoPreviewField.vue
@@ -13,7 +13,7 @@
 			>
 				<iframe
 					v-if="preview.type === 'youtube'"
-					:src="preview.src"
+					:src="safeUrl(preview.src)"
 					:title="__('Video preview')"
 					class="size-full"
 					frameborder="0"
@@ -22,7 +22,7 @@
 				/>
 				<video
 					v-else-if="isUploadedVideo && !videoError"
-					:src="preview.src"
+					:src="safeUrl(preview.src)"
 					controls
 					class="size-full bg-black object-contain"
 					@error="videoError = true"
@@ -144,6 +144,7 @@ import {
 } from '@/components/Form/labeling'
 import { computed, ref, watch } from 'vue'
 import { getVideoPreview, getYouTubeId } from '@/utils/video'
+import { safeUrl } from '@/utils/safeUrl'
 
 // Only formats browsers can actually play. Reject the rest at upload time so a
 // course never ends up with an unplayable preview (e.g. .MOV/H.265).

--- a/frontend/src/components/CourseCardOverlay.vue
+++ b/frontend/src/components/CourseCardOverlay.vue
@@ -153,6 +153,7 @@ import { useRouter } from 'vue-router'
 import CertificationLinks from '@/components/CertificationLinks.vue'
 import VideoPreview from '@/components/VideoPreview.vue'
 import { useTelemetry } from 'frappe-ui/frappe'
+import { openExternal } from '@/utils/openExternal'
 import type {
 	CourseDetails,
 	CourseInstructorInfo,
@@ -259,11 +260,10 @@ const certificate = createResource({
 		}
 	},
 	onSuccess(data: { name: string; template: string }) {
-		window.open(
+		openExternal(
 			`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
 				data.name
-			}&format=${encodeURIComponent(data.template)}`,
-			'_blank'
+			}&format=${encodeURIComponent(data.template)}`
 		)
 	},
 }) as Resource<{ name: string; template: string } | null>

--- a/frontend/src/components/CourseCreatorCard.vue
+++ b/frontend/src/components/CourseCreatorCard.vue
@@ -18,7 +18,7 @@
 			</router-link>
 			<div
 				v-if="hasBio(instructors[0].bio)"
-				v-html="renderBio(instructors[0].bio)"
+				v-safe-html:bio="decodeEntities(instructors[0].bio || '')"
 				class="ProseMirror prose prose-sm max-w-none text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
 			></div>
 		</template>
@@ -38,7 +38,7 @@
 			</router-link>
 			<div
 				v-if="hasBio(focused?.bio)"
-				v-html="renderBio(focused?.bio)"
+				v-safe-html:bio="decodeEntities(focused?.bio || '')"
 				class="ProseMirror prose prose-sm max-w-none text-p-sm text-ink-gray-7 leading-6 mt-4 line-clamp-3"
 			></div>
 
@@ -81,7 +81,6 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import DOMPurify from 'dompurify'
 import UserAvatar from '@/components/UserAvatar.vue'
 import { decodeEntities, htmlToText } from '@/utils'
 import type { CourseInstructorInfo } from '@/types'
@@ -145,25 +144,6 @@ const headerLabel = computed<string>(() => {
 function hasBio(bio?: string | null): boolean {
 	if (!bio) return false
 	return htmlToText(bio).trim().length > 0 || /<img\b/i.test(bio)
-}
-
-function renderBio(bio?: string | null): string {
-	return DOMPurify.sanitize(decodeEntities(bio || ''), {
-		ALLOWED_TAGS: [
-			'b',
-			'i',
-			'em',
-			'strong',
-			'a',
-			'p',
-			'br',
-			'ul',
-			'ol',
-			'li',
-			'img',
-		],
-		ALLOWED_ATTR: ['href', 'target', 'rel', 'src'],
-	})
 }
 
 function profileLink(instructor: CourseInstructorInfo) {

--- a/frontend/src/components/Courses/CourseThumbnailField.vue
+++ b/frontend/src/components/Courses/CourseThumbnailField.vue
@@ -17,7 +17,7 @@
 			>
 				<img
 					v-if="hasImage"
-					:src="doc.image"
+					:src="safeUrl(doc.image)"
 					alt=""
 					class="size-full object-cover"
 				/>
@@ -135,6 +135,7 @@ import { Button, FileUploader, createResource, toast } from 'frappe-ui'
 import { computed, inject, ref, useId, watch } from 'vue'
 import type { CourseFormContext, Resource } from '@/types'
 import { InputLabel } from '@/components/Form/labeling'
+import { safeUrl } from '@/utils/safeUrl'
 
 // Layout mirrors VideoPreviewField (the sibling field in the same form row):
 // the well is full-width on phones and settles back to w-56 from `sm` up, so the

--- a/frontend/src/components/JobCard.vue
+++ b/frontend/src/components/JobCard.vue
@@ -27,7 +27,6 @@
 					</span>
 				</div>
 			</div>
-			<!-- <img :src="job.company_logo" alt="Company Logo" class="size-8  rounded-full object-contain  bg-surface-base" /> -->
 		</div>
 		<div class="flex gap-x-2 items-center mt-auto">
 			<Badge>
@@ -40,14 +39,9 @@
 				{{ dayjs(job.creation).fromNow() }}
 			</Badge>
 		</div>
-		<!-- <div
-			class="description text-ink-gray-9 text-sm"
-			v-html="sanitizeRichHTML(job.description)"
-		></div> -->
 	</div>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { inject } from 'vue'
 import { Badge } from 'frappe-ui'
 

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -70,7 +70,7 @@
 			>
 			</iframe>
 		</div>
-		<div v-else v-html="renderSafe(block)"></div>
+		<div v-else v-safe-html:rich="renderMarkdown(block)"></div>
 	</div>
 	<div v-if="quizId">
 		<Quiz :quiz="quizId" />
@@ -82,7 +82,6 @@ import PdfBlock from '@/components/PdfBlock.vue'
 import MarkdownIt from 'markdown-it'
 import { useScreenSize } from '@/utils/composables'
 import { getMacroArg } from '@/utils/lessonMacros'
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
 import { safeUrl } from '@/utils/safeUrl'
 
@@ -94,11 +93,9 @@ const markdown = new MarkdownIt({
 	linkify: true,
 })
 
-// Route markdown output through the shared sanitizer so the anchor-target
-// hook (open in new tab) and form-tag blocklist are applied uniformly with
-// the rest of the LMS render pipelines. Keeps one source of truth for what
-// counts as safe user-authored HTML.
-const renderSafe = (block) => sanitizeRichHTML(markdown.render(block))
+// The directive sanitizes at the rich level, which is where the anchor-target
+// hook and the form-tag blocklist live. This only does the markdown pass.
+const renderMarkdown = (block) => markdown.render(block)
 
 const props = defineProps({
 	content: {

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -2,7 +2,7 @@
 	<div v-if="youtube">
 		<iframe
 			class="youtube-video"
-			:src="getYouTubeVideoSource(youtube.split('/').pop())"
+			:src="safeUrl(getYouTubeVideoSource(youtube.split('/').pop()))"
 			:title="__('YouTube video')"
 			width="100%"
 			:height="screenSize.width < 640 ? 200 : 400"
@@ -21,7 +21,7 @@
 		<div v-if="block.includes('{{ YouTubeVideo')">
 			<iframe
 				class="youtube-video"
-				:src="getYouTubeVideoSource(block)"
+				:src="safeUrl(getYouTubeVideoSource(block))"
 				:title="__('YouTube video')"
 				width="100%"
 				:height="screenSize.width < 640 ? 200 : 400"
@@ -39,14 +39,14 @@
 				controlsList="nodownload"
 				oncontextmenu="return false;"
 			>
-				<source :src="getId(block)" type="video/mp4" />
+				<source :src="safeUrl(getId(block))" type="video/mp4" />
 			</video>
 		</div>
 		<div v-else-if="block.includes('{{ PDF')">
 			<PdfBlock v-if="inlinePdf" :file="getId(block)" />
 			<iframe
 				v-else
-				:src="getId(block)"
+				:src="safeUrl(getId(block))"
 				:title="__('PDF document')"
 				width="100%"
 				height="700px"
@@ -56,14 +56,14 @@
 		</div>
 		<div v-else-if="block.includes('{{ Audio')">
 			<audio width="100%" controls controlsList="nodownload">
-				<source :src="getId(block)" type="audio/mp3" />
+				<source :src="safeUrl(getId(block))" type="audio/mp3" />
 			</audio>
 		</div>
 		<div v-else-if="block.includes('{{ Embed')">
 			<iframe
 				width="100%"
 				height="400"
-				:src="getId(block)"
+				:src="safeUrl(getId(block))"
 				:title="__('Embedded content')"
 				frameborder="0"
 				allowfullscreen
@@ -84,6 +84,7 @@ import { useScreenSize } from '@/utils/composables'
 import { getMacroArg } from '@/utils/lessonMacros'
 import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
+import { safeUrl } from '@/utils/safeUrl'
 
 const screenSize = useScreenSize()
 const inlinePdf = usesWebkitPdfViewer()

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -80,7 +80,7 @@
 						class="mt-2 text-center text-sm text-ink-gray-4"
 					>
 						{{ __('Image search powered by') }}
-						<a class="underline" target="_blank" href="https://unsplash.com">
+						<a class="underline" v-external href="https://unsplash.com">
 							{{ __('Unsplash') }}
 						</a>
 					</div>

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -48,8 +48,10 @@
 						>
 							<img
 								:src="
-									image.urls.raw +
-									'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
+									safeUrl(
+										image.urls.raw +
+											'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
+									)
 								"
 								:alt="__('Cover image option')"
 							/>
@@ -96,6 +98,7 @@ import {
 	createResource,
 } from 'frappe-ui'
 import { computed, ref, watch } from 'vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const search = ref(null)
 const emit = defineEmits(['select'])

--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -188,6 +188,7 @@ import { inject, reactive, watch, ref, computed } from 'vue'
 import { formatTime } from '@/utils'
 import { formatTimezone } from '@/utils/timezone'
 import Link from '@/components/Controls/Link.vue'
+import { openExternal } from '@/utils/openExternal'
 
 const show = defineModel()
 const user = inject('$user')
@@ -232,7 +233,7 @@ const defaultTemplate = createResource({
 })
 
 const openCallLink = (link) => {
-	window.open(link, '_blank')
+	openExternal(link)
 }
 
 const evaluationResource = createResource({
@@ -373,7 +374,7 @@ watch(show, () => {
 })
 
 const openCertificate = (certificate) => {
-	window.open(
+	openExternal(
 		`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
 			certificate.name
 		}&format=${encodeURIComponent(certificate.template)}`

--- a/frontend/src/components/Modals/Event.vue
+++ b/frontend/src/components/Modals/Event.vue
@@ -19,8 +19,7 @@
 						<Tooltip :text="__('Course')">
 							<a
 								:href="`/lms/courses/${event.course}`"
-								target="_blank"
-								rel="noopener noreferrer"
+								v-external
 								class="flex gap-x-2 w-fit cursor-pointer"
 							>
 								<span class="lucide-book-open h-4 w-4" />
@@ -32,8 +31,7 @@
 						<Tooltip v-if="event.batch_title" :text="__('Batch')">
 							<a
 								:href="`/lms/batches/${event.batch_name}#students`"
-								target="_blank"
-								rel="noopener noreferrer"
+								v-external
 								class="flex gap-x-2 w-fit cursor-pointer"
 							>
 								<span class="lucide-users h-4 w-4" />

--- a/frontend/src/components/Modals/VideoStatistics.vue
+++ b/frontend/src/components/Modals/VideoStatistics.vue
@@ -81,7 +81,7 @@
 								<div
 									class="video-player"
 									:data-plyr-provider="provider"
-									:src="currentTab"
+									:src="safeUrl(currentTab)"
 								></div>
 							</div>
 							<VideoBlock v-else :file="currentTab" />
@@ -108,6 +108,7 @@ import { computed, ref, watch } from 'vue'
 import { enablePlyr, formatTimestamp } from '@/utils'
 import VideoBlock from '@/components/VideoBlock.vue'
 import NumberChartGraph from '@/components/NumberChartGraph.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 /* Responsive layout notes (Tailwind classes live in the template):
    - The member list / chart+player split stacks below `sm`; only above `sm` is

--- a/frontend/src/components/Notifications/NotificationPanel.vue
+++ b/frontend/src/components/Notifications/NotificationPanel.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
 	<Teleport to="body">
 		<div
@@ -64,7 +63,7 @@
 								/>
 							</div>
 							<div>
-								<div v-html="sanitizeHTML(n.subject)" />
+								<div v-safe-html:basic="decodeEntities(n.subject)" />
 								<div class="text-p-sm text-ink-gray-5">
 									{{ dayjs(n.creation).fromNow() }}
 								</div>
@@ -89,7 +88,7 @@ import { Avatar, Button, TabButtons, Tooltip } from 'frappe-ui'
 import { computed, inject, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { onClickOutside } from '@vueuse/core'
-import { sanitizeHTML } from '@/utils'
+import { decodeEntities } from '@/utils'
 import { useSidebar } from '@/stores/sidebar'
 import { useScreenSize } from '@/utils/composables'
 import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'

--- a/frontend/src/components/PdfBlock.vue
+++ b/frontend/src/components/PdfBlock.vue
@@ -55,8 +55,7 @@
 				<a
 					class="pdf-btn"
 					:href="safeUrl(file)"
-					target="_blank"
-					rel="noopener"
+					v-external
 					aria-label="Open in new tab"
 				>
 					<ExternalLink :size="16" :stroke-width="1.5" />
@@ -71,12 +70,7 @@
 			</div>
 			<div v-else-if="error" class="pdf-status pdf-error">
 				<span>{{ error }}</span>
-				<a
-					class="pdf-fallback-link"
-					:href="safeUrl(file)"
-					target="_blank"
-					rel="noopener"
-				>
+				<a class="pdf-fallback-link" :href="safeUrl(file)" v-external>
 					Open the PDF in a new tab
 				</a>
 			</div>

--- a/frontend/src/components/PdfBlock.vue
+++ b/frontend/src/components/PdfBlock.vue
@@ -54,7 +54,7 @@
 				</button>
 				<a
 					class="pdf-btn"
-					:href="file"
+					:href="safeUrl(file)"
 					target="_blank"
 					rel="noopener"
 					aria-label="Open in new tab"
@@ -73,7 +73,7 @@
 				<span>{{ error }}</span>
 				<a
 					class="pdf-fallback-link"
-					:href="file"
+					:href="safeUrl(file)"
 					target="_blank"
 					rel="noopener"
 				>
@@ -109,6 +109,7 @@ import {
 	ExternalLink,
 	Loader2,
 } from 'lucide-vue-next'
+import { safeUrl } from '@/utils/safeUrl'
 
 const props = defineProps({
 	file: { type: String, required: true },
@@ -170,7 +171,7 @@ async function load() {
 
 		const base = import.meta.env.BASE_URL || '/'
 		const loadingTask = pdfjsLib.getDocument({
-			url: props.file,
+			url: safeUrl(props.file),
 			worker: sharedPdfWorker || undefined,
 			cMapUrl: `${base}pdfjs/cmaps/`,
 			cMapPacked: true,

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -155,7 +155,7 @@
 					</div>
 					<div
 						class="text-ink-gray-9 font-semibold mt-2 leading-5 break-words [&_img]:h-auto [&_img]:max-w-full"
-						v-html="sanitizeRichHTML(questionDetails.data.question)"
+						v-safe-html:rich="questionDetails.data.question"
 					></div>
 					<div
 						v-if="questionDetails.data.type == 'Choices'"
@@ -207,9 +207,7 @@
 							</div>
 							<span
 								class="ms-2 min-w-0 flex-1 break-words text-ink-gray-9 [&_img]:h-auto [&_img]:max-w-full"
-								v-html="
-									sanitizeRichHTML(questionDetails.data[`option_${index}`])
-								"
+								v-safe-html:rich="questionDetails.data[`option_${index}`]"
 							>
 							</span>
 						</label>
@@ -475,7 +473,6 @@
 	</Dialog>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import {
 	Badge,
 	Button,

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -285,7 +285,7 @@
 									'bg-surface-gray-4 border border-outline-gray-7 font-medium':
 										activeQuestion == item,
 									'text-ink-gray-5': item === '...',
-									'bg-surface-blue-3 text-ink-base':
+									'bg-surface-blue-2 text-ink-blue-8':
 										attemptedQuestions.includes(item) && activeQuestion != item,
 									'bg-surface-gray-3 text-ink-gray-6':
 										activeQuestion != item &&

--- a/frontend/src/components/RelatedCourses.vue
+++ b/frontend/src/components/RelatedCourses.vue
@@ -12,8 +12,7 @@
 				v-for="course in relatedCourses.data"
 				:key="course.name"
 				:to="{ name: 'CourseDetail', params: { courseName: course.name } }"
-				target="_blank"
-				rel="noopener"
+				v-external
 				class="cursor-pointer"
 			>
 				<CourseCard :course="course" />

--- a/frontend/src/components/Settings/Badges/BadgeForm.vue
+++ b/frontend/src/components/Settings/Badges/BadgeForm.vue
@@ -23,8 +23,9 @@
 					:modelValue="badge.reference_doctype"
 					:options="referenceDoctypeOptions"
 					:label="__('Assign For')"
+					:required="true"
 					@update:modelValue="
-						(opt: any) => (badge.reference_doctype = opt.value)
+						(value: string | null) => (badge.reference_doctype = value ?? '')
 					"
 				/>
 				<FormControl

--- a/frontend/src/components/Settings/BrandSettings.vue
+++ b/frontend/src/components/Settings/BrandSettings.vue
@@ -51,7 +51,7 @@
 					>
 						<img
 							v-if="branding.data.banner_image?.file_url"
-							:src="branding.data.banner_image.file_url"
+							:src="safeUrl(branding.data.banner_image.file_url)"
 							alt="Logo"
 							class="size-8 rounded"
 						/>
@@ -85,7 +85,7 @@
 					>
 						<img
 							v-if="branding.data.favicon?.file_url"
-							:src="branding.data.favicon.file_url"
+							:src="safeUrl(branding.data.favicon.file_url)"
 							alt="Favicon"
 							class="size-8 rounded"
 						/>
@@ -118,6 +118,7 @@ import { createResource, Button, FormControl } from 'frappe-ui'
 import SettingsLayout from '@/components/Layouts/SettingsLayout.vue'
 import ImageUploader from '@/components/Controls/ImageUploader.vue'
 import { ref } from 'vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 defineProps({
 	label: { type: String },

--- a/frontend/src/components/Settings/EmailAccount/EmailAdd.vue
+++ b/frontend/src/components/Settings/EmailAccount/EmailAdd.vue
@@ -38,12 +38,9 @@
 					<CircleAlert class="size-5 shrink-0" />
 					<div class="text-wrap text-p-xs">
 						{{ selectedService.info }}
-						<a
-							:href="selectedService.link"
-							target="_blank"
-							rel="noopener noreferrer"
-							class="underline"
-							>{{ __('here') }}</a
+						<a :href="selectedService.link" v-external class="underline">{{
+							__('here')
+						}}</a
 						>.
 					</div>
 				</div>

--- a/frontend/src/components/Settings/Mobile/SettingsRow.vue
+++ b/frontend/src/components/Settings/Mobile/SettingsRow.vue
@@ -3,7 +3,7 @@
 		:is="tag"
 		:type="tag === 'button' ? 'button' : undefined"
 		:aria-label="tag === 'button' ? label : undefined"
-		:href="href"
+		:href="safeUrl(href)"
 		:target="opensInNewTab ? '_blank' : undefined"
 		:rel="opensInNewTab ? 'noopener noreferrer' : undefined"
 		class="flex min-h-12 w-full items-center gap-3 border-b border-outline-gray-1 px-3.5 py-2 text-start last:border-b-0"
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 // A single row of the inset-grouped settings list.
 //
@@ -77,14 +78,19 @@ const props = withDefaults(
 
 const emit = defineEmits<{ click: [] }>()
 
+// The shape follows the URL that will actually be rendered, not the one passed
+// in: a rejected scheme drops the attribute, and an <a> without href still takes
+// focus and announces as a link.
+const safeHref = computed(() => safeUrl(props.href))
+
 const tag = computed(() =>
-	props.href ? 'a' : props.navigates ? 'button' : 'div'
+	safeHref.value ? 'a' : props.navigates ? 'button' : 'div'
 )
 
 // Off this site, so a new tab: coming back is the phone's back gesture
 // otherwise, and it would have unloaded the app. A path this site serves itself
 // stays in the tab, the way the desktop sidebar sends one.
-const opensInNewTab = computed(() => /^https?:\/\//i.test(props.href || ''))
+const opensInNewTab = computed(() => /^https?:\/\//i.test(safeHref.value || ''))
 
 const newTabHint = __('(opens in a new tab)')
 </script>

--- a/frontend/src/components/Settings/Mobile/SettingsRowList.vue
+++ b/frontend/src/components/Settings/Mobile/SettingsRowList.vue
@@ -11,7 +11,7 @@
 			:icon="row.icon"
 			:description="row.description"
 			:value="row.value"
-			:href="row.href"
+			:href="safeUrl(row.href)"
 			:navigates="Boolean(row.to || row.action)"
 			:chevron="Boolean(row.to || row.href)"
 			@click="activate(row)"
@@ -40,6 +40,7 @@
 // draws it as a real <a> and the browser follows it, so there is no push to
 // make and no click to emit.
 import { useRouter } from 'vue-router'
+import { safeUrl } from '@/utils/safeUrl'
 import SettingsRow from '@/components/Settings/Mobile/SettingsRow.vue'
 import SettingsRowGroup from '@/components/Settings/Mobile/SettingsRowGroup.vue'
 import type {

--- a/frontend/src/components/Settings/Raven/RavenNotInstalledBanner.vue
+++ b/frontend/src/components/Settings/Raven/RavenNotInstalledBanner.vue
@@ -11,12 +11,7 @@
 			{{ body }}
 		</span>
 	</div>
-	<a
-		v-if="missing === 'raven'"
-		:href="marketplaceUrl"
-		target="_blank"
-		rel="noopener"
-	>
+	<a v-if="missing === 'raven'" :href="marketplaceUrl" v-external>
 		<Button variant="solid">
 			{{ __('Get Raven') }}
 			<template #suffix>

--- a/frontend/src/components/Settings/SettingFields.vue
+++ b/frontend/src/components/Settings/SettingFields.vue
@@ -61,7 +61,8 @@
 									:class="field.size == 'lg' ? 'px-5 py-5' : 'px-20 py-8'"
 								>
 									<img
-										:src="fileUrl(data[field.name])"
+										:src="safeUrl(fileUrl(data[field.name]))"
+										alt=""
 										class="rounded"
 										:class="field.size == 'lg' ? 'w-36' : 'size-6'"
 									/>
@@ -172,6 +173,7 @@ import { validateFile } from '@/utils'
 import Link from '@/components/Controls/Link.vue'
 import CodeEditor from '@/components/Controls/CodeEditor.vue'
 import { seedCheckboxDefaults } from '@/components/Settings/mobileSettings'
+import { safeUrl } from '@/utils/safeUrl'
 
 // The FileUploader above binds :uploadArgs="{ private: !field.public }", and it
 // is written inline deliberately. Privacy is the FIELD's decision, never this

--- a/frontend/src/components/Sidebar/AppSidebar.vue
+++ b/frontend/src/components/Sidebar/AppSidebar.vue
@@ -298,6 +298,7 @@ import UserDropdown from '@/components/Sidebar/UserDropdown.vue'
 import CollapseSidebar from '@/components/Icons/CollapseSidebar.vue'
 import SidebarLink from '@/components/Sidebar/SidebarLink.vue'
 import CommandPalette from '@/components/CommandPalette/CommandPalette.vue'
+import { openExternal } from '@/utils/openExternal'
 import {
 	loadUnreadCount,
 	unreadCount,
@@ -669,7 +670,7 @@ const updateSidebarLinks = () => {
 }
 
 const redirectToWebsite = () => {
-	window.open('https://frappe.io/learning', '_blank')
+	openExternal('https://frappe.io/learning')
 }
 
 const isStudent = computed(() => {
@@ -708,9 +709,8 @@ const calculateTrialEndDays = (trialEndDate) => {
 }
 
 const redirectToAppointmentScreen = () => {
-	window.open(
-		'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0c7Z3XIpW1WgbeIuktSaoX6qudoYuSdRbIlJty5TW7p4IZaOk5viHQGwTNi6HpNVqzOZOTHcle',
-		'_blank'
+	openExternal(
+		'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0c7Z3XIpW1WgbeIuktSaoX6qudoYuSdRbIlJty5TW7p4IZaOk5viHQGwTNi6HpNVqzOZOTHcle'
 	)
 }
 

--- a/frontend/src/components/Sidebar/SidebarLink.vue
+++ b/frontend/src/components/Sidebar/SidebarLink.vue
@@ -88,6 +88,7 @@ import * as icons from 'lucide-vue-next'
 import { toggleNotifications } from '@/stores/notifications'
 import { useSettings } from '@/stores/settings'
 import type { SidebarLink } from '@/types'
+import { openExternal } from '@/utils/openExternal'
 
 const router = useRouter()
 const settingsStore = useSettings()
@@ -126,7 +127,7 @@ function handleClick(): void {
 		showContactForm.value = true
 	} else if (props.link.to) {
 		if (props.link.to.startsWith('http')) {
-			window.open(props.link.to, '_blank')
+			openExternal(props.link.to)
 			return
 		}
 		window.location.href = `/${props.link.to}`

--- a/frontend/src/components/Sidebar/UserDropdown.vue
+++ b/frontend/src/components/Sidebar/UserDropdown.vue
@@ -14,7 +14,8 @@
 				>
 					<img
 						v-if="branding.data?.banner_image"
-						:src="branding.data?.banner_image.file_url"
+						:src="safeUrl(branding.data?.banner_image.file_url)"
+						alt=""
 						class="w-8 h-8 rounded flex-shrink-0"
 					/>
 					<LMSLogo v-else class="w-8 h-8 rounded flex-shrink-0" />
@@ -77,6 +78,7 @@ import FrappeCloudIcon from '@/components/Icons/FrappeCloudIcon.vue'
 import LMSLogo from '@/components/Icons/LMSLogo.vue'
 import SettingsModal from '@/components/Settings/Settings.vue'
 import { Moon, Sun } from 'lucide-vue-next'
+import { safeUrl } from '@/utils/safeUrl'
 
 const router = useRouter()
 const { logout, branding } = sessionStore()

--- a/frontend/src/components/Sidebar/UserDropdown.vue
+++ b/frontend/src/components/Sidebar/UserDropdown.vue
@@ -79,6 +79,7 @@ import LMSLogo from '@/components/Icons/LMSLogo.vue'
 import SettingsModal from '@/components/Settings/Settings.vue'
 import { Moon, Sun } from 'lucide-vue-next'
 import { safeUrl } from '@/utils/safeUrl'
+import { openExternal } from '@/utils/openExternal'
 
 const router = useRouter()
 const { logout, branding } = sessionStore()
@@ -284,7 +285,7 @@ const userDropdownOptions = computed(() => {
 
 const loginToFrappeCloud = () => {
 	let redirect_to = '/dashboard/sites/' + userResource.data.sitename
-	window.open(`${frappeCloudBaseEndpoint}${redirect_to}`, '_blank')
+	openExternal(`${frappeCloudBaseEndpoint}${redirect_to}`)
 }
 
 const clearDemoDataConfirmation = () => {

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -57,7 +57,7 @@
 					</div>
 					<div class="mt-2 text-center text-sm text-ink-gray-4">
 						{{ __('Image search powered by') }}
-						<a class="underline" target="_blank" href="https://unsplash.com">
+						<a class="underline" v-external href="https://unsplash.com">
 							{{ __('Unsplash') }}
 						</a>
 					</div>

--- a/frontend/src/components/UnsplashImageBrowser.vue
+++ b/frontend/src/components/UnsplashImageBrowser.vue
@@ -46,8 +46,10 @@
 						>
 							<img
 								:src="
-									image.urls.raw +
-									'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
+									safeUrl(
+										image.urls.raw +
+											'&w=200&h=50&fit=crop&crop=entropy,faces,focalpoint'
+									)
 								"
 								:alt="__('Unsplash photo')"
 							/>
@@ -68,6 +70,7 @@
 <script>
 // import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 import { Popover, FileUploader, Button } from 'frappe-ui'
+import { safeUrl } from '@/utils/safeUrl'
 
 export default {
 	name: 'UnsplashImageBrowser',

--- a/frontend/src/components/UpcomingEvaluations.vue
+++ b/frontend/src/components/UpcomingEvaluations.vue
@@ -121,6 +121,7 @@ import { formatTime } from '@/utils'
 import { formatTimezone } from '@/utils/timezone'
 import { Button, createListResource, call, Dropdown, toast } from 'frappe-ui'
 import EvaluationModal from '@/components/Modals/EvaluationModal.vue'
+import { openExternal } from '@/utils/openExternal'
 
 const dayjs = inject('$dayjs')
 const user = inject('$user')
@@ -178,7 +179,7 @@ function openEvalModal() {
 }
 
 const openEvalCall = (evl) => {
-	window.open(evl.google_meet_link, '_blank')
+	openExternal(evl.google_meet_link)
 }
 
 const evaluationCourses = computed(() => {

--- a/frontend/src/components/UserAvatar.vue
+++ b/frontend/src/components/UserAvatar.vue
@@ -9,20 +9,20 @@
 	>
 		<template v-if="user.open_to === 'Work'" #indicator>
 			<Tooltip :text="__('Open to Work')" placement="right">
-				<div class="rounded-full bg-surface-green-3 w-fit">
+				<div class="rounded-full bg-surface-green-7 w-fit">
 					<span
 						class="lucide-badge-check"
-						:class="'text-ink-base ' + checkSize"
+						:class="'text-ink-green-1 ' + checkSize"
 					/>
 				</div>
 			</Tooltip>
 		</template>
 		<template v-else-if="user.open_to === 'Hiring'" #indicator>
 			<Tooltip :text="__('Hiring')" placement="right">
-				<div class="rounded-full bg-purple-500 w-fit">
+				<div class="rounded-full bg-surface-violet-7 w-fit">
 					<span
 						class="lucide-badge-check"
-						:class="'text-ink-base ' + checkSize"
+						:class="'text-ink-violet-1 ' + checkSize"
 					/>
 				</div>
 			</Tooltip>

--- a/frontend/src/components/VideoBlock.vue
+++ b/frontend/src/components/VideoBlock.vue
@@ -31,7 +31,7 @@
 				oncontextmenu="return false"
 				class="rounded-md border border-outline-gray-1 cursor-pointer"
 				ref="videoRef"
-				:src="fileURL"
+				:src="safeUrl(fileURL)"
 				:type="type"
 			></video>
 			<button
@@ -166,6 +166,7 @@ import { formatSeconds, formatTimestamp } from '@/utils/format'
 import { useSettings } from '@/stores/settings'
 import Play from '@/components/Icons/Play.vue'
 import QuizInVideo from '@/components/Modals/QuizInVideo.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 /* The control bar is a fixed set of buttons plus an elapsed/duration readout,
    with the seek slider absorbing whatever is left. The slider is the only

--- a/frontend/src/components/VideoPreview.vue
+++ b/frontend/src/components/VideoPreview.vue
@@ -5,21 +5,21 @@
 	>
 		<iframe
 			v-if="videoPreview.type === 'youtube'"
-			:src="videoPreview.src"
+			:src="safeUrl(videoPreview.src)"
 			:title="__('Video preview')"
 			class="size-full"
 			allowfullscreen
 		/>
 		<video
 			v-else-if="videoPreview.type === 'file' && !videoError"
-			:src="videoPreview.src"
+			:src="safeUrl(videoPreview.src)"
 			controls
 			class="size-full object-contain"
 			@error="videoError = true"
 		/>
 		<img
 			v-else-if="fallbackImage"
-			:src="fallbackImage"
+			:src="safeUrl(fallbackImage)"
 			:alt="__('Video preview')"
 			class="size-full object-cover"
 		/>
@@ -28,6 +28,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { getVideoPreview } from '@/utils/video'
+import { safeUrl } from '@/utils/safeUrl'
 
 // Shared display for a course/batch preview video. A video_link can be a
 // YouTube link (render an embed iframe, NOT a <video>, which is what made batch

--- a/frontend/src/composables/usePermissions.ts
+++ b/frontend/src/composables/usePermissions.ts
@@ -1,0 +1,196 @@
+import { call } from 'frappe-ui'
+import {
+	computed,
+	getCurrentInstance,
+	inject,
+	ref,
+	unref,
+	watch,
+	type MaybeRef,
+	type Ref,
+} from 'vue'
+import { IS_STUDENT_VIEW } from './useStudentView'
+
+export type Permissions = Record<string, number>
+
+type Fetcher = (
+	doctype: string,
+	names: string[]
+) => Promise<Record<string, Permissions>>
+
+export interface UsePermissionsOptions {
+	/** null means Guest: deny everything, ask nobody. undefined means "logged in". */
+	user?: string | null
+	/** Overrides the injected Student View flag. */
+	studentView?: boolean
+	/** Answer to start from, so a caller that already has one issues no request. */
+	seed?: Permissions
+	fetcher?: Fetcher
+}
+
+const DENY: Permissions = Object.freeze({})
+
+// One answer per document, shared by every caller on the page. The course
+// outline mounts a row per lesson; without this each row would ask again.
+const cache = new Map<string, Permissions>()
+const inFlight = new Map<string, Promise<void>>()
+
+// A plain Map is not reactive, and every caller reads it through a computed.
+// Bumping this on each mutation is what makes an answer — or an invalidation —
+// reach the components already on screen.
+const revision = ref(0)
+
+const key = (doctype: string, name: string) => `${doctype}:${name}`
+
+function remember(doctype: string, name: string, answer: Permissions) {
+	cache.set(key(doctype, name), answer)
+	revision.value++
+}
+
+export function invalidatePermissions(doctype: string, name: string) {
+	cache.delete(key(doctype, name))
+	inFlight.delete(key(doctype, name))
+	revision.value++
+}
+
+/** For a role change, which invalidates every answer at once. */
+export function invalidateAllPermissions() {
+	cache.clear()
+	inFlight.clear()
+	revision.value++
+}
+
+const defaultFetcher: Fetcher = (doctype, names) =>
+	call('lms.lms.api.get_doc_permissions_many', { doctype, names })
+
+// Names asked for in the same tick go out as one request — the reason the
+// endpoint takes a list at all.
+const queued = new Map<string, Set<string>>()
+const waiters = new Map<string, Array<() => void>>()
+let scheduled = false
+
+function flush(fetcher: Fetcher) {
+	scheduled = false
+	const batches = new Map(queued)
+	queued.clear()
+
+	for (const [doctype, names] of batches) {
+		const wanted = [...names]
+		const done = waiters.get(doctype) ?? []
+		waiters.delete(doctype)
+
+		const settle = () => {
+			for (const name of wanted) inFlight.delete(key(doctype, name))
+			for (const fn of done) fn()
+		}
+
+		fetcher(doctype, wanted)
+			.then((answers) => {
+				for (const name of wanted) {
+					// A name the server did not answer for stays unknown, which reads
+					// as deny, rather than being cached as an empty grant.
+					const answer = answers?.[name]
+					if (answer) remember(doctype, name, answer)
+				}
+			})
+			.catch(() => {
+				// An unreachable server is not a grant. Leaving the cache empty keeps
+				// every affordance hidden, which is the safe direction.
+			})
+			.finally(settle)
+	}
+}
+
+function request(
+	doctype: string,
+	name: string,
+	fetcher: Fetcher
+): Promise<void> {
+	const existing = inFlight.get(key(doctype, name))
+	if (existing) return existing
+
+	const promise = new Promise<void>((resolve) => {
+		if (!queued.has(doctype)) queued.set(doctype, new Set())
+		queued.get(doctype)!.add(name)
+		if (!waiters.has(doctype)) waiters.set(doctype, [])
+		waiters.get(doctype)!.push(resolve)
+	})
+
+	inFlight.set(key(doctype, name), promise)
+	if (!scheduled) {
+		scheduled = true
+		queueMicrotask(() => flush(fetcher))
+	}
+	return promise
+}
+
+/**
+ * Server permissions for one document, or for the doctype when no name is given.
+ *
+ * `can()` answers false until a real answer has arrived. A flicker is a UX bug;
+ * a button that is live before the server has spoken is a correctness one.
+ */
+export function usePermissions(
+	doctype: string,
+	name?: MaybeRef<string | undefined>,
+	options: UsePermissionsOptions = {}
+) {
+	const fetcher = options.fetcher ?? defaultFetcher
+	const isGuest = options.user === null
+	const loading = ref(false)
+
+	// inject() only works during setup; the composable is also used from plain
+	// modules and from tests.
+	const injected = getCurrentInstance()
+		? inject(IS_STUDENT_VIEW, undefined)
+		: undefined
+	const studentView = computed(() =>
+		options.studentView !== undefined ? options.studentView : !!unref(injected)
+	)
+
+	const current = () => unref(name)
+
+	if (options.seed && current()) {
+		remember(doctype, current()!, options.seed)
+	}
+
+	const answer = computed<Permissions>(() => {
+		revision.value
+		const docname = current()
+		if (isGuest || !docname) return DENY
+		return cache.get(key(doctype, docname)) ?? DENY
+	})
+
+	const load = () => {
+		const docname = current()
+		if (isGuest || !docname) return
+		if (cache.has(key(doctype, docname))) return
+		loading.value = true
+		request(doctype, docname, fetcher).then(() => {
+			// Only clear the flag if we are still asking about the same document.
+			if (current() === docname) loading.value = false
+		})
+	}
+
+	// Synchronous: a consumer that reads can() in the same tick as the name
+	// change must already see loading, not the previous document's answer.
+	watch(() => current(), load, { immediate: true, flush: 'sync' })
+
+	const can = (ptype: string): boolean => {
+		if (isGuest) return false
+		// Student View is a presentation mask over the real session, so it has to
+		// win over the server answer — otherwise the preview keeps handing an
+		// instructor the affordances the mask exists to remove.
+		if (studentView.value && ptype !== 'read') return false
+		return !!answer.value[ptype]
+	}
+
+	return {
+		can,
+		loading: loading as Ref<boolean>,
+		invalidate: () => {
+			const docname = current()
+			if (docname) invalidatePermissions(doctype, docname)
+		},
+	}
+}

--- a/frontend/src/directives/external.ts
+++ b/frontend/src/directives/external.ts
@@ -1,0 +1,11 @@
+import type { Directive } from 'vue'
+
+// A bare target="_blank" hands the opened page a window.opener reference back
+// to ours — reverse tabnabbing. Every external link goes through here so the
+// rel can never be forgotten at a call site.
+export const vExternal: Directive<HTMLAnchorElement> = {
+	mounted(el) {
+		el.setAttribute('target', '_blank')
+		el.setAttribute('rel', 'noopener noreferrer')
+	},
+}

--- a/frontend/src/directives/index.ts
+++ b/frontend/src/directives/index.ts
@@ -1,0 +1,10 @@
+import type { App } from 'vue'
+import safeHtml from './safeHtml'
+import { vExternal } from './external'
+
+export { safeHtml, vExternal }
+
+export function registerDirectives(app: App) {
+	app.directive('safe-html', safeHtml)
+	app.directive('external', vExternal)
+}

--- a/frontend/src/directives/safeHtml.ts
+++ b/frontend/src/directives/safeHtml.ts
@@ -1,0 +1,22 @@
+import type { Directive } from 'vue'
+import { sanitizeAt } from './safeHtmlLevels'
+
+// Default-safe replacement for v-html. The level is the directive argument:
+// v-safe-html:rich, v-safe-html:basic, v-safe-html:bio.
+const render = (
+	el: HTMLElement,
+	level: string | undefined,
+	value?: string | null
+) => {
+	el.innerHTML = sanitizeAt(level, value)
+}
+
+const safeHtml: Directive<HTMLElement, string | null | undefined> = {
+	mounted: (el, binding) => render(el, binding.arg, binding.value),
+	updated: (el, binding) => {
+		if (binding.value !== binding.oldValue)
+			render(el, binding.arg, binding.value)
+	},
+}
+
+export default safeHtml

--- a/frontend/src/directives/safeHtmlLevels.ts
+++ b/frontend/src/directives/safeHtmlLevels.ts
@@ -1,0 +1,145 @@
+import DOMPurify from 'dompurify'
+import type { Config } from 'dompurify'
+import { safeUrl } from '@/utils/safeUrl'
+
+// Three profiles, because the codebase already had three. Each one is the
+// config its call sites use today — this module is a consolidation, not a
+// policy change. Widening any of these is a separate, tested change.
+const purifier = DOMPurify()
+
+// Every rendered anchor opens in a new tab with safe rel attributes. EditorJS's
+// link tool creates bare <a href> via execCommand, and DOMPurify strips target
+// by default, so without this a lesson hyperlink navigates away and the student
+// loses their place. Applies at every level, not only rich.
+purifier.addHook('afterSanitizeAttributes', (node) => {
+	if (node.tagName === 'A') {
+		node.setAttribute('target', '_blank')
+		node.setAttribute('rel', 'noopener noreferrer')
+	}
+})
+
+// A protocol-relative src was the standard YouTube/Vimeo embed snippet for
+// years, so it is the likeliest thing a migrated lesson body holds. safeUrl
+// rejects it, correctly, for an attribute the browser would fetch off-origin —
+// but as a link it is exactly the URL the reader wants, so it gets an explicit
+// https rather than being dropped.
+const embedUrl = (src: string | null): string | undefined =>
+	safeUrl(src && /^\/\/[^/\\]/.test(src) ? `https:${src}` : src)
+
+// No profile allows <iframe>, and none should: an embed reaches the page as a
+// block component with a bound, scheme-checked src, never as authored markup.
+// But dropping one silently loses whatever it pointed at. Frappe's save-time
+// allowlist has no iframe either (utils/html_utils.py, acceptable_elements), so
+// a Text Editor field cannot carry one — lesson bodies, however, are EditorJS
+// JSON, and sanitize_html returns JSON untouched, so a row migrated from the
+// jinja portal still can. Rendering the source as a link keeps that content
+// reachable and grants no new embedding power: the href clears the same scheme
+// allowlist as every other bound URL, and a rejected one leaves nothing behind.
+//
+// It runs inside DOMPurify's own traversal rather than as a pass over the string
+// first, for two reasons. Re-serialising and re-parsing untrusted markup is how
+// mutation XSS gets a second chance at the parser, and by the time a hook sees a
+// node the parser has already settled tag case and nesting — a pass that greps
+// the source for '<iframe' answers to neither.
+//
+// target and rel are set here, not left to the anchor hook above, so the link
+// never depends on whether DOMPurify revisits a node inserted mid-traversal.
+// (It does today, which is also why an embed inside <svg> disappears rather than
+// degrading: the namespace check drops an HTML <a> in SVG content. That markup
+// reaches no editor path, and the alternative is an SVG-namespaced anchor the
+// 'A' hook cannot see — an unguarded link is worse than a lost one.)
+purifier.addHook('uponSanitizeElement', (node, data) => {
+	if (data.tagName !== 'iframe') return
+	const frame = node as Element
+	const href = embedUrl(frame.getAttribute?.('src') ?? null)
+	if (!href) return
+	const link = frame.ownerDocument.createElement('a')
+	link.setAttribute('href', href)
+	link.setAttribute('target', '_blank')
+	link.setAttribute('rel', 'noopener noreferrer')
+	link.textContent = href
+	frame.replaceWith(link)
+})
+
+export const SAFE_HTML_LEVELS = {
+	// Denylist: rich author content renders as written, minus anything that can
+	// build a phishing form.
+	rich: {
+		FORBID_TAGS: [
+			'form',
+			'input',
+			'button',
+			'textarea',
+			'select',
+			'option',
+			'label',
+			'fieldset',
+		],
+		FORBID_ATTR: ['formaction', 'formmethod', 'formenctype'],
+	},
+	basic: {
+		ALLOWED_TAGS: [
+			'b',
+			'br',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'table',
+			'thead',
+			'tbody',
+			'tr',
+			'th',
+			'td',
+			'i',
+			'em',
+			'strong',
+			'a',
+			'p',
+			'ul',
+			'ol',
+			'li',
+			'img',
+			'blockquote',
+		],
+		ALLOWED_ATTR: ['href', 'target', 'src'],
+	},
+	bio: {
+		ALLOWED_TAGS: [
+			'b',
+			'i',
+			'em',
+			'strong',
+			'a',
+			'p',
+			'br',
+			'ul',
+			'ol',
+			'li',
+			'img',
+		],
+		ALLOWED_ATTR: ['href', 'target', 'rel', 'src'],
+	},
+} satisfies Record<string, Config>
+
+export type SafeHtmlLevel = keyof typeof SAFE_HTML_LEVELS
+
+// An unknown or absent level renders at the strictest profile. Too strict is a
+// visible rendering bug someone reports; too loose is an XSS nobody sees.
+export const sanitizeAt = (
+	level: string | undefined,
+	html?: string | null
+): string => {
+	if (!html) return ''
+	const known = level && level in SAFE_HTML_LEVELS
+	if (!known && import.meta.env.DEV) {
+		console.warn(
+			`[v-safe-html] level "${level ?? '(none)'}" is not one of ` +
+				`${Object.keys(SAFE_HTML_LEVELS).join(', ')} — falling back to "bio"`
+		)
+	}
+	const config = SAFE_HTML_LEVELS[(known ? level : 'bio') as SafeHtmlLevel]
+	return purifier.sanitize(html, config)
+}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,10 +1,5 @@
 export {}
 
-declare module '*.svg?raw' {
-	const content: string
-	export default content
-}
-
 declare global {
 	function __(text: string): string
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,7 +10,7 @@ import { usersStore } from './stores/user'
 import { initSocket } from './socket'
 import { FrappeUI, setConfig, frappeRequest, pageMetaPlugin } from 'frappe-ui'
 import { telemetryPlugin } from 'frappe-ui/frappe'
-import safeHtml from './directives/safeHtml'
+import { registerDirectives } from './directives'
 
 let pinia = createPinia()
 let app = createApp(App)
@@ -21,7 +21,7 @@ app.use(pinia)
 app.use(router)
 app.use(translationPlugin)
 app.use(pageMetaPlugin)
-app.directive('safe-html', safeHtml)
+registerDirectives(app)
 app.provide('$dayjs', dayjs)
 app.provide('$socket', initSocket())
 app.mount('#app')

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import { usersStore } from './stores/user'
 import { initSocket } from './socket'
 import { FrappeUI, setConfig, frappeRequest, pageMetaPlugin } from 'frappe-ui'
 import { telemetryPlugin } from 'frappe-ui/frappe'
+import safeHtml from './directives/safeHtml'
 
 let pinia = createPinia()
 let app = createApp(App)
@@ -20,6 +21,7 @@ app.use(pinia)
 app.use(router)
 app.use(translationPlugin)
 app.use(pageMetaPlugin)
+app.directive('safe-html', safeHtml)
 app.provide('$dayjs', dayjs)
 app.provide('$socket', initSocket())
 app.mount('#app')

--- a/frontend/src/pages/Batches/BatchOverview.vue
+++ b/frontend/src/pages/Batches/BatchOverview.vue
@@ -26,7 +26,7 @@
 				<BatchOverlay :batch="batch" class="md:hidden mt-5" />
 				<div
 					class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal mt-10"
-					v-html="sanitizeRichHTML(batch.data.batch_details)"
+					v-safe-html:rich="batch.data.batch_details"
 				></div>
 			</div>
 			<div class="hidden md:block">
@@ -59,7 +59,7 @@
 			</div>
 			<div v-if="batch.data.batch_details_raw">
 				<div
-					v-html="sanitizeRichHTML(batch.data.batch_details_raw)"
+					v-safe-html:rich="batch.data.batch_details_raw"
 					class="batch-description"
 				></div>
 			</div>
@@ -67,7 +67,6 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { createResource } from 'frappe-ui'
 import CourseCard from '@/components/CourseCard.vue'
 import BatchOverlay from '@/pages/Batches/components/BatchOverlay.vue'

--- a/frontend/src/pages/Batches/components/Announcements.vue
+++ b/frontend/src/pages/Batches/components/Announcements.vue
@@ -19,7 +19,7 @@
 					</div>
 					<div
 						class="prose prose-sm bg-surface-sidebar !min-w-full px-4 py-2 rounded-md"
-						v-html="sanitizeRichHTML(comm.content)"
+						v-safe-html:rich="comm.content"
 					></div>
 				</div>
 			</li>
@@ -30,7 +30,6 @@
 	</div>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { createResource, Avatar } from 'frappe-ui'
 import { timeAgo } from '@/utils'
 

--- a/frontend/src/pages/Batches/components/LiveClass.vue
+++ b/frontend/src/pages/Batches/components/LiveClass.vue
@@ -74,7 +74,7 @@
 					>
 						<a
 							v-if="user.data?.is_moderator || user.data?.is_evaluator"
-							:href="cls.start_url || cls.join_url"
+							:href="safeUrl(cls.start_url || cls.join_url)"
 							target="_blank"
 							class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 							:class="cls.join_url ? 'w-full' : 'w-1/2'"
@@ -83,7 +83,7 @@
 							{{ __('Start') }}
 						</a>
 						<a
-							:href="cls.join_url"
+							:href="safeUrl(cls.join_url)"
 							target="_blank"
 							class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 						>
@@ -128,6 +128,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { formatTime } from '@/utils/'
 import { openBatchForm } from '@/composables/useBatchForms'
 import LiveClassAttendance from '@/components/Modals/LiveClassAttendance.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const user = inject('$user')
 const route = useRoute()

--- a/frontend/src/pages/Batches/components/LiveClass.vue
+++ b/frontend/src/pages/Batches/components/LiveClass.vue
@@ -75,7 +75,7 @@
 						<a
 							v-if="user.data?.is_moderator || user.data?.is_evaluator"
 							:href="safeUrl(cls.start_url || cls.join_url)"
-							target="_blank"
+							v-external
 							class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 							:class="cls.join_url ? 'w-full' : 'w-1/2'"
 						>
@@ -84,7 +84,7 @@
 						</a>
 						<a
 							:href="safeUrl(cls.join_url)"
-							target="_blank"
+							v-external
 							class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 						>
 							<span class="lucide-video h-4 w-4" />

--- a/frontend/src/pages/Courses/CourseCertification.vue
+++ b/frontend/src/pages/Courses/CourseCertification.vue
@@ -38,6 +38,7 @@ import { call, createResource, usePageMeta } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { sessionStore } from '../../stores/session'
 import UpcomingEvaluations from '@/components/UpcomingEvaluations.vue'
+import { openExternal } from '@/utils/openExternal'
 
 const courseTitle = ref(null)
 const evaluator = ref(null)
@@ -112,11 +113,10 @@ const populateCourses = () => {
 }
 
 const openCertificate = (certificate) => {
-	window.open(
+	openExternal(
 		`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
 			certificate.name
-		}&format=${encodeURIComponent(certificate.template)}`,
-		'_blank'
+		}&format=${encodeURIComponent(certificate.template)}`
 	)
 }
 

--- a/frontend/src/pages/Courses/CourseOverview.vue
+++ b/frontend/src/pages/Courses/CourseOverview.vue
@@ -124,7 +124,7 @@
 						{{ __('About this course') }}
 					</h2>
 					<div
-						v-html="sanitizeRichHTML(course.data.description)"
+						v-safe-html:rich="course.data.description"
 						class="ProseMirror prose prose-sm max-w-none !whitespace-normal prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2"
 					/>
 				</section>
@@ -149,7 +149,6 @@
 </template>
 
 <script setup lang="ts">
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { computed, inject, watch } from 'vue'
 import { createResource, Badge } from 'frappe-ui'
 import { formatAmount, formatRating } from '@/utils/'

--- a/frontend/src/pages/Courses/CoursePublishSettings.vue
+++ b/frontend/src/pages/Courses/CoursePublishSettings.vue
@@ -195,6 +195,7 @@ import Link from '@/components/Controls/Link.vue'
 import NewMemberModal from '@/components/Modals/NewMemberModal.vue'
 import { useSettings } from '@/stores/settings'
 import type { CourseFormContext, Resource } from '@/types'
+import { openExternal } from '@/utils/openExternal'
 
 const { resource, markDirty } = inject<CourseFormContext>('courseForm')!
 const dayjs = inject('$dayjs') as typeof import('dayjs')
@@ -252,7 +253,7 @@ function setPaidCertificate(val: boolean) {
 }
 
 function openPaymentsApp() {
-	window.open('https://frappecloud.com/marketplace/apps/payments', '_blank')
+	openExternal('https://frappecloud.com/marketplace/apps/payments')
 }
 
 const timezoneResource = createResource({
@@ -270,7 +271,7 @@ function openEvaluatorModal() {
 }
 
 function openPrintFormats() {
-	window.open('/app/print-format?doc_type=LMS Certificate', '_blank')
+	openExternal('/app/print-format?doc_type=LMS Certificate')
 }
 
 function onEvaluatorCreated(created: { name: string }) {

--- a/frontend/src/pages/Forms/AssignmentForm.vue
+++ b/frontend/src/pages/Forms/AssignmentForm.vue
@@ -80,7 +80,7 @@ import {
 	toast,
 } from 'frappe-ui'
 import { computed, inject, reactive, useId, watch } from 'vue'
-import { sanitizeHTML } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import FormShell from '@/components/FormShell.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import { useFormRoute } from '@/composables/useFormRoute'
@@ -204,8 +204,8 @@ const saving = computed<boolean>(() =>
 )
 
 const validateFields = (): void => {
-	assignment.title = sanitizeHTML(assignment.title.trim())
-	assignment.question = sanitizeHTML(assignment.question)
+	assignment.title = sanitizeOnWrite(assignment.title.trim())
+	assignment.question = sanitizeOnWrite(assignment.question)
 }
 
 const updateAssignment = (): void => {

--- a/frontend/src/pages/Forms/JobForm.vue
+++ b/frontend/src/pages/Forms/JobForm.vue
@@ -126,7 +126,7 @@ import {
 import { computed, inject, onMounted, reactive, ref, useId, watch } from 'vue'
 import { sessionStore } from '@/stores/session'
 import { useRouter } from 'vue-router'
-import { sanitizeHTML } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import { useScreenSize } from '@/utils/composables'
 import Uploader from '@/components/Controls/Uploader.vue'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
@@ -280,7 +280,7 @@ const editJobDetails = () => {
 const validateJobFields = () => {
 	Object.keys(job).forEach((key) => {
 		if (typeof job[key] === 'string') {
-			job[key] = sanitizeHTML(job[key])
+			job[key] = sanitizeOnWrite(job[key])
 		}
 	})
 }

--- a/frontend/src/pages/Forms/NewBatchForm.vue
+++ b/frontend/src/pages/Forms/NewBatchForm.vue
@@ -145,7 +145,8 @@ import {
 } from 'frappe-ui'
 import { useOnboarding, useTelemetry } from 'frappe-ui/frappe'
 import { computed, inject, onMounted, onBeforeUnmount, ref } from 'vue'
-import { sanitizeHTML, createLMSCategory, cleanError } from '@/utils'
+import { createLMSCategory, cleanError } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import FormShell from '@/components/FormShell.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import { useFormRoute } from '@/composables/useFormRoute'
@@ -235,13 +236,13 @@ const onInstructorCreated = (user: any) => {
 }
 
 const validateFields = () => {
-	Object.keys(batch.value).forEach((key) => {
-		if (typeof batch.value[key as keyof Batch] === 'string') {
-			batch.value[key as keyof Batch] = sanitizeHTML(
-				batch.value[key as keyof Batch] as string
-			)
+	const fields = batch.value as Record<string, unknown>
+	for (const key of Object.keys(fields)) {
+		const value = fields[key]
+		if (typeof value === 'string') {
+			fields[key] = sanitizeOnWrite(value)
 		}
-	})
+	}
 }
 
 const saveBatch = () => {

--- a/frontend/src/pages/Forms/NewCourseForm.vue
+++ b/frontend/src/pages/Forms/NewCourseForm.vue
@@ -134,12 +134,8 @@ import Link from '@/components/Controls/Link.vue'
 import MultiLink from '@/components/Controls/MultiLink.vue'
 import Uploader from '@/components/Controls/Uploader.vue'
 import NewMemberModal from '@/components/Modals/NewMemberModal.vue'
-import {
-	canCreateCourse,
-	cleanError,
-	sanitizeHTML,
-	createLMSCategory,
-} from '@/utils'
+import { canCreateCourse, cleanError, createLMSCategory } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import type { Resource } from '@/types'
 import RichTextEditor from '@/components/RichTextEditor.vue'
 import { InputLabel, useInputLabeling } from '@/components/Form/labeling'
@@ -322,13 +318,13 @@ const onInstructorCreated = (newUser: any) => {
 }
 
 const validateFields = () => {
-	Object.keys(course.value).forEach((key) => {
-		if (typeof course.value[key as keyof Course] === 'string') {
-			course.value[key as keyof Course] = sanitizeHTML(
-				course.value[key as keyof Course] as string
-			)
+	const fields = course.value as Record<string, unknown>
+	for (const key of Object.keys(fields)) {
+		const value = fields[key]
+		if (typeof value === 'string') {
+			fields[key] = sanitizeOnWrite(value)
 		}
-	})
+	}
 }
 
 const saveCourse = () => {

--- a/frontend/src/pages/Forms/ProfileEditForm.vue
+++ b/frontend/src/pages/Forms/ProfileEditForm.vue
@@ -83,7 +83,7 @@
 import { Badge, createResource, FormControl, toast } from 'frappe-ui'
 import { computed, inject, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { sanitizeHTML } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import FormShell from '@/components/FormShell.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import Link from '@/components/Controls/Link.vue'
@@ -177,7 +177,7 @@ const validateMandatoryFields = () => {
 const saveProfile = () => {
 	if (refusal.value || !profileData.value) return
 	if (validateMandatoryFields()) return
-	profile.bio = sanitizeHTML(profile.bio)
+	profile.bio = sanitizeOnWrite(profile.bio)
 	submitResource(
 		updateProfile,
 		{},

--- a/frontend/src/pages/Forms/ProgramForm.vue
+++ b/frontend/src/pages/Forms/ProgramForm.vue
@@ -246,7 +246,8 @@ import {
 import { computed, inject, ref, watch, getCurrentInstance } from 'vue'
 
 import { Program, ProgramCourse, ProgramMember } from '@/types'
-import { sanitizeHTML, openSettings } from '@/utils'
+import { openSettings } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import FormShell from '@/components/FormShell.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import { useFormRoute } from '@/composables/useFormRoute'
@@ -416,7 +417,7 @@ watch(
 )
 
 const validateTitle = () => {
-	program.value.name = sanitizeHTML(program.value.name.trim())
+	program.value.name = sanitizeOnWrite(program.value.name.trim())
 }
 
 const saveProgram = () => {

--- a/frontend/src/pages/Forms/ProgrammingExerciseForm.vue
+++ b/frontend/src/pages/Forms/ProgrammingExerciseForm.vue
@@ -113,7 +113,7 @@
 <script setup lang="ts">
 import { computed, inject, ref, watch, useId } from 'vue'
 import { InputLabel } from '@/components/Form/labeling'
-import { sanitizeHTML } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import {
 	Badge,
 	createDocumentResource,
@@ -312,7 +312,7 @@ watch(
 )
 
 const validateTitle = () => {
-	exercise.value.title = sanitizeHTML(exercise.value.title.trim())
+	exercise.value.title = sanitizeOnWrite(exercise.value.title.trim())
 }
 
 watch(

--- a/frontend/src/pages/Forms/QuizForm.vue
+++ b/frontend/src/pages/Forms/QuizForm.vue
@@ -251,7 +251,7 @@ import {
 import { sessionStore } from '@/stores/session'
 
 import { useRoute, useRouter } from 'vue-router'
-import { sanitizeHTML } from '@/utils'
+import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { openFormRoute } from '@/composables/useFormRoute'
 import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
@@ -331,7 +331,7 @@ const quizDetails = createDocumentResource({
 })
 
 const validateTitle = () => {
-	quizDetails.doc.title = sanitizeHTML(quizDetails.doc.title.trim())
+	quizDetails.doc.title = sanitizeOnWrite(quizDetails.doc.title.trim())
 }
 
 // Debounced silent autosave: a burst of edits collapses into a single save

--- a/frontend/src/pages/Forms/QuizForm.vue
+++ b/frontend/src/pages/Forms/QuizForm.vue
@@ -75,7 +75,7 @@
 					<div
 						v-if="column.key === 'question_detail'"
 						class="text-xs [&>*]:inline"
-						v-html="sanitizeRichHTML(value)"
+						v-safe-html:rich="value"
 					></div>
 					<div v-else class="text-xs">
 						{{ value }}
@@ -252,7 +252,6 @@ import { sessionStore } from '@/stores/session'
 
 import { useRoute, useRouter } from 'vue-router'
 import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { openFormRoute } from '@/composables/useFormRoute'
 import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
 import ResponsiveListView from '@/components/ResponsiveListView.vue'

--- a/frontend/src/pages/Home/AdminHome.vue
+++ b/frontend/src/pages/Home/AdminHome.vue
@@ -86,7 +86,7 @@
 							>
 								<a
 									v-if="user.data?.is_moderator || user.data?.is_evaluator"
-									:href="cls.start_url"
+									:href="safeUrl(cls.start_url)"
 									target="_blank"
 									class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 									:class="cls.join_url ? 'w-full' : 'w-1/2'"
@@ -95,7 +95,7 @@
 									{{ __('Start') }}
 								</a>
 								<a
-									:href="cls.join_url"
+									:href="safeUrl(cls.join_url)"
 									target="_blank"
 									class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 								>
@@ -215,6 +215,7 @@ import { formatTimezone } from '@/utils/timezone'
 import { profileRoute } from '@/utils/routes'
 import CourseCard from '@/components/CourseCard.vue'
 import BatchCard from '@/pages/Batches/components/BatchCard.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const user = inject<any>('$user')
 const dayjs = inject<any>('$dayjs')

--- a/frontend/src/pages/Home/AdminHome.vue
+++ b/frontend/src/pages/Home/AdminHome.vue
@@ -87,7 +87,7 @@
 								<a
 									v-if="user.data?.is_moderator || user.data?.is_evaluator"
 									:href="safeUrl(cls.start_url)"
-									target="_blank"
+									v-external
 									class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 									:class="cls.join_url ? 'w-full' : 'w-1/2'"
 								>
@@ -96,7 +96,7 @@
 								</a>
 								<a
 									:href="safeUrl(cls.join_url)"
-									target="_blank"
+									v-external
 									class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 								>
 									<span class="lucide-video size-4" />

--- a/frontend/src/pages/Home/StudentHome.vue
+++ b/frontend/src/pages/Home/StudentHome.vue
@@ -39,7 +39,7 @@
 								<a
 									v-if="user.data?.is_moderator || user.data?.is_evaluator"
 									:href="safeUrl(cls.start_url)"
-									target="_blank"
+									v-external
 									class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 									:class="cls.join_url ? 'w-full' : 'w-1/2'"
 								>
@@ -48,7 +48,7 @@
 								</a>
 								<a
 									:href="safeUrl(cls.join_url)"
-									target="_blank"
+									v-external
 									class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 								>
 									<span class="lucide-video size-4" />

--- a/frontend/src/pages/Home/StudentHome.vue
+++ b/frontend/src/pages/Home/StudentHome.vue
@@ -38,7 +38,7 @@
 							>
 								<a
 									v-if="user.data?.is_moderator || user.data?.is_evaluator"
-									:href="cls.start_url"
+									:href="safeUrl(cls.start_url)"
 									target="_blank"
 									class="cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 									:class="cls.join_url ? 'w-full' : 'w-1/2'"
@@ -47,7 +47,7 @@
 									{{ __('Start') }}
 								</a>
 								<a
-									:href="cls.join_url"
+									:href="safeUrl(cls.join_url)"
 									target="_blank"
 									class="w-full cursor-pointer inline-flex items-center justify-center gap-2 transition-colors focus:outline-none text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4 focus-visible:ring focus-visible:ring-outline-gray-3 h-7 text-base px-2 rounded"
 								>
@@ -147,6 +147,7 @@ import { formatTime } from '@/utils'
 import CourseCard from '@/components/CourseCard.vue'
 import BatchCard from '@/pages/Batches/components/BatchCard.vue'
 import UpcomingEvaluations from '@/components/UpcomingEvaluations.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const dayjs = inject<any>('$dayjs')
 const user = inject<any>('$user')

--- a/frontend/src/pages/JobApplications.vue
+++ b/frontend/src/pages/JobApplications.vue
@@ -117,6 +117,7 @@ import { computed, inject, ref, reactive, watch } from 'vue'
 import { sessionStore } from '../stores/session'
 import ListPage from '@/components/Layouts/ListPage.vue'
 import RichTextEditor from '@/components/RichTextEditor.vue'
+import { openExternal } from '@/utils/openExternal'
 
 const dayjs = inject('$dayjs')
 const { brand } = sessionStore()
@@ -245,7 +246,7 @@ const sendEmail = (close) => {
 }
 
 const downloadResume = (resumeUrl) => {
-	window.open(resumeUrl, '_blank')
+	openExternal(resumeUrl)
 }
 
 const getActionOptions = (row) => {

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -67,8 +67,7 @@
 					<div class="flex">
 						<a
 							:href="safeUrl(job.data.company_website)"
-							target="_blank"
-							rel="noopener noreferrer"
+							v-external
 							class="me-4"
 						>
 							<img

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -128,7 +128,7 @@
 				</div>
 
 				<p
-					v-html="sanitizeRichHTML(job.data.description)"
+					v-safe-html:rich="job.data.description"
 					class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal mt-12"
 				></p>
 			</div>
@@ -141,7 +141,6 @@
 	</div>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import { Badge, createResource, usePageMeta } from 'frappe-ui'
 import { inject, ref, computed, watch, nextTick } from 'vue'
 import { sessionStore } from '../stores/session'

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -66,13 +66,13 @@
 				<div class="space-y-5 mb-12">
 					<div class="flex">
 						<a
-							:href="job.data.company_website"
+							:href="safeUrl(job.data.company_website)"
 							target="_blank"
 							rel="noopener noreferrer"
 							class="me-4"
 						>
 							<img
-								:src="job.data.company_logo"
+								:src="safeUrl(job.data.company_logo)"
 								class="size-10 rounded-lg object-contain cursor-pointer"
 								:alt="job.data.company_name"
 							/>
@@ -148,6 +148,7 @@ import { sessionStore } from '../stores/session'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import JobApplicationModal from '@/components/Modals/JobApplicationModal.vue'
+import { safeUrl } from '@/utils/safeUrl'
 
 const user = inject('$user')
 const dayjs = inject('$dayjs')

--- a/frontend/src/pages/JobDetail.vue
+++ b/frontend/src/pages/JobDetail.vue
@@ -147,6 +147,7 @@ import PageHeader from '@/components/Layouts/PageHeader.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import JobApplicationModal from '@/components/Modals/JobApplicationModal.vue'
 import { safeUrl } from '@/utils/safeUrl'
+import { openExternal } from '@/utils/openExternal'
 
 const user = inject('$user')
 const dayjs = inject('$dayjs')
@@ -215,8 +216,11 @@ const redirectToLogin = (job) => {
 	window.location.href = `/login?redirect-to=/job-openings/${job}`
 }
 
+// A company_website is a plain Data field, so it often arrives without a
+// scheme. Left as typed it opens a path under /lms; the allowlist would reject
+// it outright. Naming https keeps the link working either way.
 const redirectToWebsite = (url) => {
-	window.open(url, '_blank')
+	openExternal(/^https?:\/\//i.test(url ?? '') ? url : `https://${url}`)
 }
 
 const canManageJob = computed(() => {

--- a/frontend/src/pages/MobileYou.vue
+++ b/frontend/src/pages/MobileYou.vue
@@ -25,7 +25,7 @@
 				>
 					<img
 						v-if="userImage"
-						:src="userImage"
+						:src="safeUrl(userImage)"
 						alt=""
 						class="size-full object-cover"
 						@error="rememberImageFailure"
@@ -80,6 +80,7 @@ import { usePageMeta } from 'frappe-ui'
 import { storeToRefs } from 'pinia'
 import { sessionStore } from '@/stores/session'
 import { usersStore } from '@/stores/user'
+import { safeUrl } from '@/utils/safeUrl'
 import { setThemePreference, themePreference } from '@/utils/theme'
 import type { ThemePreference } from '@/utils/theme'
 import {
@@ -133,8 +134,11 @@ const rememberImageFailure = (event: Event): void => {
 	failedImageSrc.value = (event.target as HTMLImageElement).getAttribute('src')
 }
 
+// Sanitised here as well as at the binding so the `v-if` agrees with it: a
+// rejected scheme falls back to the initials rather than rendering an <img>
+// whose src the template then drops.
 const userImage = computed(() => {
-	const src = user.value?.user_image
+	const src = safeUrl(user.value?.user_image)
 	return src && src !== failedImageSrc.value ? src : undefined
 })
 

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -15,7 +15,7 @@
 		<div class="group relative h-[130px] w-full">
 			<img
 				v-if="profile.data.cover_image"
-				:src="profile.data.cover_image"
+				:src="safeUrl(profile.data.cover_image)"
 				alt=""
 				class="h-[130px] w-full object-cover object-center"
 			/>
@@ -48,7 +48,7 @@
 					<div class="relative">
 						<img
 							v-if="profile.data.user_image"
-							:src="profile.data.user_image"
+							:src="safeUrl(profile.data.user_image)"
 							:alt="profile.data.full_name"
 							class="object-cover h-[100px] w-[100px] rounded-full border-4 border-white object-cover"
 						/>
@@ -94,7 +94,7 @@
 					<div class="flex items-center gap-x-4 mt-2">
 						<a
 							v-if="profile.data.twitter"
-							:href="profile.data.twitter"
+							:href="safeUrl(profile.data.twitter)"
 							target="_blank"
 							rel="noopener noreferrer"
 							:aria-label="__('Twitter')"
@@ -103,7 +103,7 @@
 						</a>
 						<a
 							v-if="profile.data.linkedin"
-							:href="profile.data.linkedin"
+							:href="safeUrl(profile.data.linkedin)"
 							target="_blank"
 							rel="noopener noreferrer"
 							:aria-label="__('LinkedIn')"
@@ -112,7 +112,7 @@
 						</a>
 						<a
 							v-if="profile.data.github"
-							:href="profile.data.github"
+							:href="safeUrl(profile.data.github)"
 							target="_blank"
 							rel="noopener noreferrer"
 							:aria-label="__('GitHub')"
@@ -172,6 +172,7 @@ import NoPermission from '@/components/NoPermission.vue'
 import NotFound from '@/pages/NotFound.vue'
 import EditCoverImage from '@/components/Modals/EditCoverImage.vue'
 import { openFormRoute } from '@/composables/useFormRoute'
+import { safeUrl } from '@/utils/safeUrl'
 
 const { user, brand } = sessionStore()
 const $user = inject('$user')

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -95,8 +95,7 @@
 						<a
 							v-if="profile.data.twitter"
 							:href="safeUrl(profile.data.twitter)"
-							target="_blank"
-							rel="noopener noreferrer"
+							v-external
 							:aria-label="__('Twitter')"
 						>
 							<Twitter class="size-4 text-ink-gray-5 cursor-pointer" />
@@ -104,8 +103,7 @@
 						<a
 							v-if="profile.data.linkedin"
 							:href="safeUrl(profile.data.linkedin)"
-							target="_blank"
-							rel="noopener noreferrer"
+							v-external
 							:aria-label="__('LinkedIn')"
 						>
 							<Linkedin class="size-4 text-ink-gray-5 cursor-pointer" />
@@ -113,8 +111,7 @@
 						<a
 							v-if="profile.data.github"
 							:href="safeUrl(profile.data.github)"
-							target="_blank"
-							rel="noopener noreferrer"
+							v-external
 							:aria-label="__('GitHub')"
 						>
 							<Github class="size-4 text-ink-gray-5 cursor-pointer" />

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -300,10 +300,6 @@ const reloadUser = () => {
 		})
 }
 
-const navigateTo = (url) => {
-	window.open(url, '_blank')
-}
-
 const breadcrumbs = computed(() => {
 	let crumbs = [
 		{

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -74,11 +74,11 @@
 									class="rounded-full w-fit"
 									:class="
 										profile.data.open_to === 'Work'
-											? 'bg-surface-green-3'
-											: 'bg-purple-500'
+											? 'bg-surface-green-7 text-ink-green-1'
+											: 'bg-surface-violet-7 text-ink-violet-1'
 									"
 								>
-									<span class="lucide-badge-check text-ink-base size-5" />
+									<span class="lucide-badge-check size-5" />
 								</div>
 							</div>
 						</Tooltip>

--- a/frontend/src/pages/ProfileAbout.vue
+++ b/frontend/src/pages/ProfileAbout.vue
@@ -109,6 +109,7 @@ import { sessionStore } from '@/stores/session'
 import { decodeEntities } from '@/utils'
 import { getLmsRoute } from '@/utils/basePath'
 import { safeUrl } from '@/utils/safeUrl'
+import { openExternal } from '@/utils/openExternal'
 
 const dayjs = inject('$dayjs')
 const user = inject('$user')
@@ -159,6 +160,6 @@ const shareOnSocial = (badge, medium) => {
 	else if (medium == 'Twitter')
 		shareUrl = `https://twitter.com/intent/tweet?text=${summary}&url=${url}`
 
-	window.open(shareUrl, '_blank')
+	openExternal(shareUrl)
 }
 </script>

--- a/frontend/src/pages/ProfileAbout.vue
+++ b/frontend/src/pages/ProfileAbout.vue
@@ -39,7 +39,7 @@
 					<template #trigger>
 						<div class="relative">
 							<img
-								:src="badge.badge_image"
+								:src="safeUrl(badge.badge_image)"
 								:alt="badge.badge"
 								class="h-[80px]"
 							/>
@@ -58,7 +58,7 @@
 						<div class="w-[250px] text-base">
 							<div class="bg-surface-gray-2 rounded-t-md py-5">
 								<img
-									:src="badge.badge_image"
+									:src="safeUrl(badge.badge_image)"
 									:alt="badge.badge"
 									class="h-[200px] mx-auto"
 								/>
@@ -126,6 +126,7 @@ import { sessionStore } from '@/stores/session'
 import { decodeEntities } from '@/utils'
 import DOMPurify from 'dompurify'
 import { getLmsRoute } from '@/utils/basePath'
+import { safeUrl } from '@/utils/safeUrl'
 
 const dayjs = inject('$dayjs')
 const user = inject('$user')

--- a/frontend/src/pages/ProfileAbout.vue
+++ b/frontend/src/pages/ProfileAbout.vue
@@ -5,24 +5,7 @@
 		</h2>
 		<div
 			v-if="profile.data.bio"
-			v-html="
-				DOMPurify.sanitize(decodeEntities(profile.data.bio), {
-					ALLOWED_TAGS: [
-						'b',
-						'i',
-						'em',
-						'strong',
-						'a',
-						'p',
-						'br',
-						'ul',
-						'ol',
-						'li',
-						'img',
-					],
-					ALLOWED_ATTR: ['href', 'target', 'rel', 'src'],
-				})
-			"
+			v-safe-html:bio="decodeEntities(profile.data.bio)"
 			class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal"
 		></div>
 		<div v-else class="text-ink-gray-7 text-sm italic">
@@ -124,7 +107,6 @@ import { createResource, HoverCard, Button } from 'frappe-ui'
 import { LinkedinIcon, Twitter } from 'lucide-vue-next'
 import { sessionStore } from '@/stores/session'
 import { decodeEntities } from '@/utils'
-import DOMPurify from 'dompurify'
 import { getLmsRoute } from '@/utils/basePath'
 import { safeUrl } from '@/utils/safeUrl'
 

--- a/frontend/src/pages/ProfileCertificates.vue
+++ b/frontend/src/pages/ProfileCertificates.vue
@@ -11,8 +11,7 @@
 				v-for="certificate in certificates.data"
 				:key="certificate.name"
 				:href="certificateUrl(certificate)"
-				target="_blank"
-				rel="noopener noreferrer"
+				v-external
 				class="flex flex-col bg-surface-base border rounded-lg p-3 cursor-pointer hover:bg-surface-sidebar"
 			>
 				<div class="font-medium leading-5 mb-2 text-ink-gray-9">

--- a/frontend/src/pages/ProfileEvaluator.vue
+++ b/frontend/src/pages/ProfileEvaluator.vue
@@ -193,6 +193,7 @@
 import { createResource, FormControl, Button, Badge, toast } from 'frappe-ui'
 import { computed, reactive, ref, onMounted, inject, watch } from 'vue'
 import { convertToTitleCase } from '@/utils'
+import { openExternal } from '@/utils/openExternal'
 
 const user = inject('$user')
 const readOnlyMode = window.read_only_mode
@@ -387,7 +388,7 @@ const authorizeCalendar = createResource({
 		}
 	},
 	onSuccess(data) {
-		window.open(data.url)
+		openExternal(data.url)
 	},
 	onError(err) {
 		toast.error(err.messages?.[0] || err)

--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
@@ -20,7 +20,7 @@
 				{{ __('Problem Statement') }}
 			</h2>
 			<div
-				v-html="sanitizeRichHTML(exercise.doc?.problem_statement)"
+				v-safe-html:rich="exercise.doc?.problem_statement"
 				class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal"
 			></div>
 		</div>
@@ -135,7 +135,6 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import {
 	Badge,
 	Button,

--- a/frontend/src/pages/QuizSubmission.vue
+++ b/frontend/src/pages/QuizSubmission.vue
@@ -58,15 +58,11 @@
 				>
 					<div class="text-ink-gray-9">
 						<span class="font-semibold"> {{ __('Question') }}: </span>
-						<span class="leading-5" v-html="sanitizeRichHTML(row.question)">
-						</span>
+						<span class="leading-5" v-safe-html:rich="row.question"> </span>
 					</div>
 					<div class="text-ink-gray-9">
 						<span class="font-semibold"> {{ __('Answer') }}: </span>
-						<span
-							class="leading-5"
-							v-html="sanitizeRichHTML(row.answer)"
-						></span>
+						<span class="leading-5" v-safe-html:rich="row.answer"></span>
 					</div>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 						<FormControl v-model="row.marks" :label="__('Marks')" />
@@ -82,7 +78,6 @@
 	</PageBody>
 </template>
 <script setup>
-import { sanitizeRichHTML } from '@/utils/sanitizeRichHTML'
 import {
 	createDocumentResource,
 	FormControl,

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -9,7 +9,7 @@
 		"
 	>
 		<iframe
-			:src="chapter.doc.launch_file"
+			:src="safeUrl(chapter.doc.launch_file)"
 			:title="chapter.doc?.title || __('Lesson content')"
 			class="w-full h-[calc(100vh-3.00rem)]"
 		/>
@@ -44,6 +44,7 @@ import { computed, inject, onBeforeMount, ref } from 'vue'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
 import { useSidebar } from '@/stores/sidebar'
 import { sessionStore } from '../stores/session'
+import { safeUrl } from '@/utils/safeUrl'
 
 const { brand } = sessionStore()
 const sidebarStore = useSidebar()

--- a/frontend/src/tests/badgeForm.test.ts
+++ b/frontend/src/tests/badgeForm.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the "Assign For" field on the badge form.
+ *
+ * frappe-ui's Combobox models a plain value — `defineModel<string | null>` — so
+ * `update:modelValue` carries the selected option's value, not the option
+ * object. BadgeForm read `opt.value` off it, which is `undefined` on a string,
+ * so picking a doctype silently cleared the field and every badge saved without
+ * the one thing that decides what it is awarded for.
+ *
+ * LMS Badge marks reference_doctype reqd=1, so the control says so too.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+window.__ = (text: string): string => text
+
+const { insertSubmit, setValueSubmit, reloadMock, toastMock, callMock } =
+	vi.hoisted(() => ({
+		insertSubmit: vi.fn(),
+		setValueSubmit: vi.fn(),
+		reloadMock: vi.fn(),
+		toastMock: { success: vi.fn(), error: vi.fn() },
+		callMock: vi.fn(() => Promise.resolve({})),
+	}))
+
+vi.mock('frappe-ui', () => ({
+	call: callMock,
+	toast: toastMock,
+	Button: {
+		emits: ['click'],
+		template: `<button @click="$emit('click')"><slot /></button>`,
+	},
+	FormControl: {
+		props: ['modelValue', 'label', 'type', 'required', 'placeholder'],
+		emits: ['update:modelValue'],
+		template: `<input
+			:data-testid="'fc-' + label"
+			:value="modelValue"
+			@input="$emit('update:modelValue', $event.target.value)"
+		/>`,
+	},
+	// Mirrors the real component's contract: the payload is the option's VALUE.
+	Combobox: {
+		props: ['modelValue', 'options', 'label', 'required'],
+		emits: ['update:modelValue'],
+		template: `<button
+			data-testid="combobox"
+			:data-required="required ? 'yes' : 'no'"
+			@click="$emit('update:modelValue', options[0].value)"
+		/>`,
+	},
+}))
+
+vi.mock('@/components/Controls/BooleanSwitch.vue', () => ({
+	default: {
+		props: ['modelValue', 'label', 'size', 'description'],
+		emits: ['update:modelValue'],
+		template: `<div data-testid="switch" />`,
+	},
+}))
+vi.mock('@/components/Controls/CodeEditor.vue', () => ({
+	default: {
+		props: ['modelValue', 'label', 'type', 'required', 'showBorder', 'height'],
+		emits: ['update:modelValue'],
+		template: `<div data-testid="code" />`,
+	},
+}))
+vi.mock('@/components/Controls/Uploader.vue', () => ({
+	default: {
+		props: ['modelValue', 'label', 'description', 'required'],
+		emits: ['update:modelValue'],
+		template: `<div data-testid="uploader" />`,
+	},
+}))
+vi.mock('@/components/Controls/Select.vue', () => ({
+	default: {
+		props: ['modelValue', 'label', 'options', 'required'],
+		emits: ['update:modelValue'],
+		template: `<div data-testid="select" />`,
+	},
+}))
+vi.mock('@/components/Layouts/SettingsLayout.vue', () => ({
+	default: {
+		props: ['title', 'showBack', 'enabled'],
+		template: `<div><slot name="header-actions" /><slot /></div>`,
+	},
+}))
+vi.mock('@/utils', () => ({ cleanError: (e: unknown) => String(e) }))
+
+import BadgeForm from '@/components/Settings/Badges/BadgeForm.vue'
+
+const mountForm = (badgeName = 'new') =>
+	mount(BadgeForm, {
+		props: {
+			badgeName,
+			badges: {
+				data: [],
+				insert: { submit: insertSubmit },
+				setValue: { submit: setValueSubmit },
+				reload: reloadMock,
+			} as any,
+		},
+		global: { config: { globalProperties: { __: (s: string) => s } as any } },
+	})
+
+describe('BadgeForm — Assign For', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('puts the picked doctype in the created badge', async () => {
+		const wrapper = mountForm()
+
+		await wrapper.find('[data-testid="combobox"]').trigger('click')
+		await wrapper.find('button:not([data-testid])').trigger('click')
+		await flushPromises()
+
+		expect(insertSubmit).toHaveBeenCalled()
+		expect(insertSubmit.mock.calls[0][0]).toMatchObject({
+			reference_doctype: 'LMS Course',
+		})
+	})
+
+	it('marks Assign For required, as LMS Badge does', () => {
+		const wrapper = mountForm()
+
+		expect(
+			wrapper.find('[data-testid="combobox"]').attributes('data-required')
+		).toBe('yes')
+	})
+})

--- a/frontend/src/tests/blockDomSafety.test.ts
+++ b/frontend/src/tests/blockDomSafety.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { blockNotice, embedFrame } from '../utils/blockDom'
+import { decodeEntities, htmlToText } from '../utils/inertHtml'
+
+// The EditorJS blocks under src/utils build their DOM outside Vue, so every one
+// of them used to interpolate an author-supplied id, title or file URL into an
+// innerHTML template. These cover the replacements: the value is data, and a URL
+// clears the same allowlist a bound :src does.
+
+describe('embedFrame', () => {
+	it('sets the src and the attributes it is given', () => {
+		const frame = embedFrame('/lms/assignment-submission/A/new', {
+			class: 'w-full',
+			height: '500px',
+		})
+		expect(frame?.getAttribute('src')).toBe('/lms/assignment-submission/A/new')
+		expect(frame?.getAttribute('class')).toBe('w-full')
+		expect(frame?.getAttribute('height')).toBe('500px')
+	})
+
+	// No frame at all, rather than one with an empty src: src="" resolves to the
+	// current page, so the block would render the whole SPA inside itself.
+	it('returns nothing for a URL the allowlist rejects', () => {
+		expect(embedFrame('javascript:alert(1)', {})).toBeUndefined()
+		expect(embedFrame('/\\evil.test/p', {})).toBeUndefined()
+		expect(embedFrame(undefined, {})).toBeUndefined()
+	})
+
+	// The old sink was `src="${path}"`, so a quote in the value opened an
+	// attribute of the author's choosing.
+	it('cannot be broken out of by a quote in the URL', () => {
+		const frame = embedFrame('/files/a" onload="alert(1)', {})
+		expect(frame?.getAttribute('onload')).toBeNull()
+		expect(frame?.getAttributeNames()).toEqual(['src'])
+		// The quote is escaped in the serialization, so it stays inside the value.
+		expect(frame?.outerHTML).toContain('&quot; onload=&quot;')
+	})
+})
+
+describe('blockNotice', () => {
+	it('renders a title as text, not markup', () => {
+		const card = blockNotice('Assignment: <img src=x onerror="alert(1)">')
+		expect(card.querySelector('img')).toBeNull()
+		expect(card.textContent).toBe('Assignment: <img src=x onerror="alert(1)">')
+	})
+})
+
+describe('entity decoding is inert', () => {
+	it('decodes entities and keeps raw tags as text', () => {
+		expect(decodeEntities('&lt;p&gt;hi&lt;/p&gt;')).toBe('<p>hi</p>')
+		expect(decodeEntities('&amp;amp;')).toBe('&amp;')
+		expect(decodeEntities(null)).toBe('')
+	})
+
+	// The mechanism is the assertion: a textarea created in the live document
+	// parses `</textarea><img src=x onerror=…>` into a node that still loads and
+	// still fires, before any sanitizer sees the value.
+	it('never parses input into a live-document node', () => {
+		const create = vi.spyOn(document, 'createElement')
+		decodeEntities('</textarea><img src=x onerror="alert(1)">')
+		htmlToText('<img src=x onerror="alert(1)">')
+		expect(create).not.toHaveBeenCalled()
+		expect(document.querySelector('img')).toBeNull()
+		create.mockRestore()
+	})
+
+	it('htmlToText still reads the text out of markup', () => {
+		expect(htmlToText('<p>one <b>two</b></p>')).toBe('one two')
+		expect(htmlToText('')).toBe('')
+	})
+})

--- a/frontend/src/tests/directives.test.ts
+++ b/frontend/src/tests/directives.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { registerDirectives } from '@/directives'
+
+// v-safe-html has its own suite in safeHtmlDirective.test.ts, including the
+// level mapping and the source scanners. This file covers v-external, the only
+// other directive the app registers.
+
+const withDirectives = (component: any) => ({
+	global: { plugins: [{ install: registerDirectives }] },
+	...component,
+})
+
+describe('v-external', () => {
+	it('adds target and a rel that blocks reverse tabnabbing', () => {
+		const wrapper = mount(
+			{ template: `<a v-external href="https://x.test">x</a>` },
+			withDirectives({})
+		)
+		expect(wrapper.attributes('target')).toBe('_blank')
+		expect(wrapper.attributes('rel')).toContain('noopener')
+		expect(wrapper.attributes('rel')).toContain('noreferrer')
+	})
+})
+
+describe('every external link uses the directive', () => {
+	const sources = import.meta.glob('../**/*.vue', {
+		query: '?raw',
+		import: 'default',
+		eager: true,
+	}) as Record<string, string>
+
+	it('finds components to scan', () => {
+		expect(Object.keys(sources).length).toBeGreaterThan(50)
+	})
+
+	it('finds no bare target="_blank"', () => {
+		const offenders = Object.entries(sources)
+			.filter(([, src]) => /target\s*=\s*"_blank"/.test(src))
+			.map(([path]) => path)
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/inkOnTintContrast.test.ts
+++ b/frontend/src/tests/inkOnTintContrast.test.ts
@@ -16,7 +16,6 @@
  * builds them from lightModeColors whatever the theme, so they never adapt while
  * the ink on top of them does.
  */
-/// <reference types="vite/client" />
 import { describe, expect, it } from 'vitest'
 
 // Vite's own loader rather than node:fs — it needs no @types/node, so the type

--- a/frontend/src/tests/inkOnTintContrast.test.ts
+++ b/frontend/src/tests/inkOnTintContrast.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `text-ink-base` may only sit on a solid surface.
+ *
+ * `--ink-base` is the ink for inverted surfaces: in light mode it is
+ * oklch(1 0 0), the exact value of `--surface-base`. The `-1`..`-4` steps of a
+ * colour surface are pale tints (`--surface-green-3` is oklch(.908 .07 154.3),
+ * `--surface-blue-3` is oklch(.925 .039 243.489)), so white ink on one lands
+ * around 1.1:1 and the content is invisible. Dark mode inverts the ink to
+ * oklch(.205 0 0) but those surfaces only reach oklch(.33), so it stays bad.
+ *
+ * frappe-ui's own pairings are the reference (Badge.vue:47-78): solid is
+ * `text-ink-<colour>-1` on `bg-surface-<colour>-7`, subtle is
+ * `text-ink-<colour>-8` on `bg-surface-<colour>-2`.
+ *
+ * Raw palette colours (`bg-purple-500`) are banned in the same sweep: the preset
+ * builds them from lightModeColors whatever the theme, so they never adapt while
+ * the ink on top of them does.
+ */
+/// <reference types="vite/client" />
+import { describe, expect, it } from 'vitest'
+
+// Vite's own loader rather than node:fs — it needs no @types/node, so the type
+// check stays clean, and it resolves the same tree the app builds from.
+const sources = import.meta.glob('../**/*.vue', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+// A tint step, i.e. everything below the solid -7 the pairings use.
+const INK_BASE_ON_TINT = /bg-surface-(?!gray-(?:9|10))[a-z]+-[1-4]\b/
+const RAW_PALETTE =
+	/\bbg-(purple|violet|pink|teal|cyan|indigo|emerald|lime|sky|fuchsia|rose|green|blue|red|amber|orange|yellow)-\d{2,3}\b/
+
+describe('ink-on-tint contrast', () => {
+	const files = Object.entries(sources)
+
+	it('finds components to scan', () => {
+		expect(files.length).toBeGreaterThan(50)
+	})
+
+	it('never puts text-ink-base on a tinted surface', () => {
+		const offenders: string[] = []
+
+		for (const [file, source] of files) {
+			for (const [i, line] of source.split('\n').entries()) {
+				if (!line.includes('text-ink-base')) continue
+				if (INK_BASE_ON_TINT.test(line)) {
+					offenders.push(`${file}:${i + 1}`)
+				}
+			}
+		}
+
+		expect(offenders).toEqual([])
+	})
+
+	it('uses no raw palette background', () => {
+		const offenders: string[] = []
+
+		for (const [file, source] of files) {
+			for (const [i, line] of source.split('\n').entries()) {
+				if (RAW_PALETTE.test(line)) {
+					offenders.push(`${file}:${i + 1} — ${line.trim()}`)
+				}
+			}
+		}
+
+		expect(offenders).toEqual([])
+	})
+})

--- a/frontend/src/tests/innerHtmlSinks.test.ts
+++ b/frontend/src/tests/innerHtmlSinks.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+// The JavaScript-side counterpart of the template gates. v-safe-html, the
+// semgrep rules and the :src scanner all stop at .vue markup, and the EditorJS
+// blocks under src/utils build their DOM by hand — which is where every
+// innerHTML sink in this app has actually been.
+
+const sources = import.meta.glob('../**/*.{js,ts,vue}', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+const LINE_COMMENT = /^\s*(?:\/\/|\*|\/\*)/
+// './x' is this directory — the tests themselves, which quote sinks as fixtures.
+const app = Object.entries(sources).filter(
+	([path]) => !path.startsWith('./') && !path.includes('/tests/')
+)
+
+describe('innerHTML writes go through the sanitizer', () => {
+	const WRITE = /\.innerHTML\s*=\s*(.*)$/
+	// A literal with no interpolation is markup this repo wrote, not data.
+	const LITERAL = /^(['"`])[^$]*\1\s*(?:;)?\s*$/
+
+	const EXEMPT = new Map<string, string>([
+		[
+			'../utils/code.ts',
+			'hljs.highlight escapes the source it returns (see the call site)',
+		],
+		['../utils/inline/BaseInline.ts', 'module-constant icon markup'],
+		[
+			'../utils/inertHtml.ts',
+			'the one deliberate write: an inert DOMParser document, pre-sanitizer',
+		],
+		['../utils/inline/TextAlign.ts', 'module-constant icon markup'],
+	])
+
+	it('finds sources to scan', () => {
+		expect(app.length).toBeGreaterThan(200)
+	})
+
+	it('flags an interpolated write and passes a sanitized one', () => {
+		const bad = 'el.innerHTML = `<a href="${url}">x</a>`'
+		const good = "el.innerHTML = sanitizeAt('rich', text)"
+		const empty = "el.innerHTML = ''"
+		const rhs = (line: string) => line.match(WRITE)?.[1] ?? ''
+		expect(LITERAL.test(rhs(bad)) || rhs(bad).includes('sanitizeAt(')).toBe(
+			false
+		)
+		expect(rhs(good).includes('sanitizeAt(')).toBe(true)
+		expect(LITERAL.test(rhs(empty))).toBe(true)
+	})
+
+	it('finds no unsanitized innerHTML write', () => {
+		const offenders: string[] = []
+		for (const [path, src] of app) {
+			if (EXEMPT.has(path)) continue
+			src.split('\n').forEach((line, i) => {
+				if (LINE_COMMENT.test(line)) return
+				const rhs = line.match(WRITE)?.[1]
+				if (rhs === undefined) return
+				if (rhs.includes('sanitizeAt(') || LITERAL.test(rhs)) return
+				offenders.push(`${path}:${i + 1} ${line.trim()}`)
+			})
+		}
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/openExternal.test.ts
+++ b/frontend/src/tests/openExternal.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { openExternal } from '../utils/openExternal'
+
+// window.open hands the opened page a window.opener reference back to ours unless
+// 'noopener' is passed, and a javascript: URL passed to it runs in a document
+// that inherits this origin. openExternal is the one place both are handled — the
+// v-external argument, in JavaScript — and the scanner below is what keeps it
+// the only place. Neither is markup, so no template gate could see them.
+
+const sources = import.meta.glob('../**/*.{js,ts,vue}', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+const LINE_COMMENT = /^\s*(?:\/\/|\*|\/\*)/
+// './x' is this directory — the tests themselves, which quote sinks as fixtures.
+const app = Object.entries(sources).filter(
+	([path]) => !path.startsWith('./') && !path.includes('/tests/')
+)
+
+describe('openExternal', () => {
+	const open = vi.spyOn(window, 'open').mockReturnValue(null)
+	afterEach(() => open.mockClear())
+
+	it('passes noopener so the opened page cannot reach window.opener', () => {
+		openExternal('https://x.test/a')
+		expect(open).toHaveBeenCalledWith('https://x.test/a', '_blank', 'noopener')
+	})
+
+	// window.open('javascript:…') runs that script in a document that inherits
+	// this origin, so the allowlist matters as much here as in an href.
+	it('opens nothing for a URL the allowlist rejects', () => {
+		openExternal('javascript:alert(1)')
+		openExternal('/\\evil.test')
+		openExternal(null)
+		expect(open).not.toHaveBeenCalled()
+	})
+})
+
+describe('window.open is confined to the helper', () => {
+	const OPEN = /\bwindow\.open\s*\(/
+
+	it('finds sources to scan, and flags a bare call', () => {
+		expect(app.length).toBeGreaterThan(200)
+		expect(OPEN.test("window.open(url, '_blank')")).toBe(true)
+	})
+
+	it('finds no window.open outside openExternal', () => {
+		const offenders: string[] = []
+		for (const [path, src] of app) {
+			if (path === '../utils/openExternal.ts') continue
+			src.split('\n').forEach((line, i) => {
+				if (LINE_COMMENT.test(line)) return
+				if (OPEN.test(line)) offenders.push(`${path}:${i + 1} ${line.trim()}`)
+			})
+		}
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/safeHtmlDirective.test.ts
+++ b/frontend/src/tests/safeHtmlDirective.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import safeHtml from '../directives/safeHtml'
+
+const mountAt = (level: string | null, html: string) =>
+	mount(
+		{
+			template: level
+				? `<div v-safe-html:${level}="html" />`
+				: '<div v-safe-html="html" />',
+			props: { html: String },
+		},
+		{ props: { html }, global: { directives: { 'safe-html': safeHtml } } }
+	)
+
+describe('v-safe-html', () => {
+	it('strips script tags and inline handlers at every level', () => {
+		for (const level of ['rich', 'basic', 'bio']) {
+			const html = mountAt(
+				level,
+				'<img src=x onerror=alert(1)><script>alert(1)</script>'
+			).html()
+			expect(html, level).not.toContain('onerror')
+			expect(html, level).not.toContain('<script')
+		}
+	})
+
+	it('rich keeps presentational markup but drops form elements', () => {
+		const html = mountAt(
+			'rich',
+			'<div class="a"><p>hi</p><input name="x"></div>'
+		).html()
+		expect(html).toContain('<p>hi</p>')
+		expect(html).toContain('class="a"')
+		expect(html).not.toContain('<input')
+	})
+
+	it('basic keeps tables, bio does not', () => {
+		expect(
+			mountAt('basic', '<table><tr><td>c</td></tr></table>').html()
+		).toContain('<td>')
+		expect(
+			mountAt('bio', '<table><tr><td>c</td></tr></table>').html()
+		).not.toContain('<td>')
+	})
+
+	it('bio drops headings that basic keeps', () => {
+		expect(mountAt('basic', '<h2>t</h2>').html()).toContain('<h2>')
+		expect(mountAt('bio', '<h2>t</h2>').html()).not.toContain('<h2>')
+	})
+
+	it('an absent level falls back to the strictest profile, not the loosest', () => {
+		const html = mountAt(
+			null,
+			'<table><tr><td>c</td></tr></table><h2>t</h2>'
+		).html()
+		expect(html).not.toContain('<td>')
+		expect(html).not.toContain('<h2>')
+	})
+
+	it('an unknown level falls back to the strictest profile', () => {
+		expect(mountAt('nonsense', '<h2>t</h2>').html()).not.toContain('<h2>')
+	})
+
+	it('forces safe anchor rel/target at every level', () => {
+		for (const level of ['rich', 'basic', 'bio']) {
+			const html = mountAt(level, '<a href="https://e.com">x</a>').html()
+			expect(html, level).toContain('rel="noopener noreferrer"')
+			expect(html, level).toContain('target="_blank"')
+		}
+	})
+
+	it('re-sanitizes on update, not only on mount', async () => {
+		const wrapper = mountAt('rich', '<p>safe</p>')
+		await wrapper.setProps({ html: '<img src=x onerror=alert(1)>' })
+		expect(wrapper.html()).not.toContain('onerror')
+	})
+})
+
+const sources = import.meta.glob('../**/*.vue', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+const HTML_COMMENT = /<!--[\s\S]*?-->/g
+const live = (src: string) => src.replace(HTML_COMMENT, '')
+
+describe('no raw v-html remains', () => {
+	it('finds components to scan', () => {
+		expect(Object.keys(sources).length).toBeGreaterThan(50)
+	})
+
+	it('finds no v-html outside the directive itself', () => {
+		const offenders = Object.entries(sources)
+			.filter(([, src]) => /\sv-html=/.test(live(src)))
+			.map(([path]) => path)
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+
+	it('finds no v-safe-html without an explicit known level', () => {
+		const KNOWN = ['rich', 'basic', 'bio']
+		const offenders: string[] = []
+		for (const [path, src] of Object.entries(sources)) {
+			for (const [match, arg] of live(src).matchAll(
+				/\sv-safe-html(?::([a-z]+))?=/g
+			)) {
+				if (!arg || !KNOWN.includes(arg))
+					offenders.push(`${path} ${match.trim()}`)
+			}
+		}
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/safeHtmlDirective.test.ts
+++ b/frontend/src/tests/safeHtmlDirective.test.ts
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import safeHtml from '../directives/safeHtml'

--- a/frontend/src/tests/safeHtmlDirective.test.ts
+++ b/frontend/src/tests/safeHtmlDirective.test.ts
@@ -99,6 +99,41 @@ describe('no raw v-html remains', () => {
 		expect(offenders, offenders.join('\n')).toEqual([])
 	})
 
+	// The same ban as .github/semgrep/vue-directives.yml's no-bound-innerhtml-prop,
+	// mirrored here because semgrep runs in CI only: without this a contributor
+	// sees a green local suite and learns about the rule from a failed job. Vue
+	// assigns el.innerHTML for every spelling below, so v-html is only the most
+	// obvious one.
+	const INNER_HTML_PROP = [
+		/(?:^|[\s"'`([{])(?:\.|:|v-bind:)inner-?html(?:\.[a-zA-Z]+)?\s*=/i,
+		/v-bind\s*=\s*"[^"]*\binner-?html\s*[:}]/i,
+	]
+
+	it('matches every innerHTML spelling it bans', () => {
+		const sinks = [
+			'<div :innerHTML="a" />',
+			'<div v-bind:innerHTML="a" />',
+			'<div .innerHTML="a" />',
+			'<div :innerHTML.prop="a" />',
+			'<div v-bind="{ innerHTML: a }" />',
+		]
+		for (const sink of sinks)
+			expect(
+				INNER_HTML_PROP.some((re) => re.test(sink)),
+				sink
+			).toBe(true)
+		expect(INNER_HTML_PROP.some((re) => re.test('<div :title="a" />'))).toBe(
+			false
+		)
+	})
+
+	it('finds no bound innerHTML prop', () => {
+		const offenders = Object.entries(sources)
+			.filter(([, src]) => INNER_HTML_PROP.some((re) => re.test(live(src))))
+			.map(([path]) => path)
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+
 	it('finds no v-safe-html without an explicit known level', () => {
 		const KNOWN = ['rich', 'basic', 'bio']
 		const offenders: string[] = []

--- a/frontend/src/tests/safeHtmlRetention.test.ts
+++ b/frontend/src/tests/safeHtmlRetention.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import { SAFE_HTML_LEVELS, sanitizeAt } from '../directives/safeHtmlLevels'
+
+// The companion to safeHtmlDirective.test.ts. That file proves the profiles
+// block what they must; this one proves they do not eat what authors write.
+// Over-sanitizing is the failure mode nobody reports as a security bug — a
+// lesson table silently loses its header scope, an image loses its alt text,
+// and the page still looks roughly right.
+//
+// `rich` is the profile that matters here: it renders lesson content, course
+// and batch descriptions, quiz questions and answers, assignment questions and
+// feedback, job descriptions and announcements. It is a denylist, so the
+// assertion is that authored markup arrives intact.
+
+const RICH_SURVIVES: Record<string, string> = {
+	'table header scope and colspan':
+		'<table><thead><tr><th scope="col" colspan="2">Marks</th></tr></thead></table>',
+	'table caption and rowspan':
+		'<table><caption>Results</caption><tbody><tr><td rowspan="2">1</td></tr></tbody></table>',
+	'image alt text': '<img src="/files/d.png" alt="A sequence diagram">',
+	'image dimensions': '<img src="/files/d.png" width="400" height="300">',
+	'highlighted code block':
+		'<pre><code class="language-python">print("hi")</code></pre>',
+	'heading toc anchor': '<h2 data-toc-id="intro">Intro</h2>',
+	'author classes and inline styles':
+		'<p class="lead" style="color:red">styled</p>',
+	'nested ordered list': '<ul><li>a<ol><li>b</li></ol></li></ul>',
+	'blockquote and rule': '<blockquote>q</blockquote><hr>',
+	'subscript superscript mark strikethrough':
+		'<p>x<sub>1</sub><sup>2</sup><mark>m</mark><del>d</del></p>',
+	'definition list': '<dl><dt>t</dt><dd>d</dd></dl>',
+	'katex output': '<span class="katex" aria-hidden="true">x²</span>',
+	'editorjs checklist item':
+		'<div class="cdx-checklist__item"><span>done</span></div>',
+}
+
+describe('rich renders authored content without trimming it', () => {
+	it.each(Object.entries(RICH_SURVIVES))('keeps %s', (_name, html) => {
+		expect(sanitizeAt('rich', html)).toBe(html)
+	})
+
+	// Not in the table above because the anchor hook rewrites them by design.
+	// The point of the assertion is that the author's own href and title ride
+	// through untouched alongside the added rel/target.
+	it('keeps an author link intact while adding safe rel and target', () => {
+		const out = sanitizeAt('rich', '<a href="https://x.test" title="go">x</a>')
+		expect(out).toContain('href="https://x.test"')
+		expect(out).toContain('title="go"')
+		expect(out).toContain('rel="noopener noreferrer"')
+		expect(out).toContain('target="_blank"')
+	})
+
+	// No profile embeds an iframe — that is what block components are for — but
+	// a legacy lesson body can still hold one, and dropping it silently loses
+	// the URL it pointed at. It degrades to a link instead.
+	it('degrades an iframe to a link rather than blanking it', () => {
+		const out = sanitizeAt(
+			'rich',
+			'<iframe src="https://www.youtube.com/embed/x"></iframe>'
+		)
+		expect(out).toContain('href="https://www.youtube.com/embed/x"')
+		expect(out).toContain('https://www.youtube.com/embed/x</a>')
+		expect(out).not.toContain('<iframe')
+	})
+
+	it('leaves nothing behind for an iframe with an unusable scheme', () => {
+		expect(
+			sanitizeAt('rich', '<iframe src="javascript:alert(1)"></iframe>')
+		).toBe('')
+		expect(sanitizeAt('rich', '<iframe></iframe>')).toBe('')
+	})
+
+	it('degrades embeds at every level, not only rich', () => {
+		for (const level of Object.keys(SAFE_HTML_LEVELS)) {
+			expect(
+				sanitizeAt(level, '<iframe src="https://x.test/e"></iframe>')
+			).toContain('href="https://x.test/e"')
+		}
+	})
+
+	// Tag names are case-insensitive, and a body pasted out of the jinja portal
+	// or Word is exactly where an uppercase one comes from. The rewrite runs
+	// inside DOMPurify's traversal, after the parser has settled the case.
+	it('degrades an uppercase iframe too', () => {
+		for (const markup of [
+			'<IFRAME SRC="https://x.test/e"></IFRAME>',
+			'<IFrame src="https://x.test/e"></IFrame>',
+		]) {
+			expect(sanitizeAt('rich', markup)).toContain('href="https://x.test/e"')
+		}
+	})
+
+	// The standard embed snippet for years. safeUrl rejects //host as an
+	// attribute, so the URL has to be given a scheme to survive as a link.
+	it('degrades a protocol-relative embed by naming https', () => {
+		const out = sanitizeAt(
+			'rich',
+			'<iframe src="//player.vimeo.com/v/1"></iframe>'
+		)
+		expect(out).toContain('href="https://player.vimeo.com/v/1"')
+	})
+
+	// `/\host` is `//host` to the URL parser, so a link built from it leaves the
+	// origin while both href and link text read as a path.
+	it('drops an embed whose src only looks site-relative', () => {
+		expect(sanitizeAt('rich', '<iframe src="/\\evil.test/p"></iframe>')).toBe(
+			''
+		)
+	})
+
+	it('gives every degraded embed target and rel', () => {
+		const out = sanitizeAt('rich', '<iframe src="https://x.test/e"></iframe>')
+		expect(out).toContain('target="_blank"')
+		expect(out).toContain('rel="noopener noreferrer"')
+	})
+
+	// An <a> in SVG content re-parses as an SVG-namespaced anchor, which the
+	// anchor hook's tagName === 'A' test misses. DOMPurify's namespace check
+	// drops it first, so the embed is lost rather than degraded — the trade is
+	// deliberate for markup no editor path produces: an unguarded link that
+	// navigates the lesson away would be worse than a lost one.
+	it('never leaves an unguarded link for an embed inside svg', () => {
+		const out = sanitizeAt(
+			'rich',
+			'<svg><iframe src="https://x.test/e"></iframe></svg>'
+		)
+		expect(out).not.toContain('<a')
+		expect(out).not.toContain('<iframe')
+	})
+
+	it('keeps native video and audio players', () => {
+		expect(
+			sanitizeAt('rich', '<video src="/f.mp4" controls></video>')
+		).toContain('<video src="/f.mp4"')
+		expect(
+			sanitizeAt('rich', '<audio src="/f.mp3" controls></audio>')
+		).toContain('<audio src="/f.mp3"')
+	})
+})
+
+// The two allowlist profiles are deliberately narrow, and both render short
+// strings — a notification subject, a profile bio. These assertions record
+// what that costs, so that widening either one is a visible change rather
+// than a surprise.
+describe('the allowlist profiles are narrow on purpose', () => {
+	it('basic keeps a table but loses scope, colspan and caption', () => {
+		const out = sanitizeAt(
+			'basic',
+			'<table><caption>c</caption><tr><th scope="col" colspan="2">A</th></tr></table>'
+		)
+		expect(out).toContain('<table>')
+		expect(out).toContain('<th>A</th>')
+		expect(out).not.toContain('scope')
+		expect(out).not.toContain('colspan')
+		expect(out).not.toContain('<caption>')
+	})
+
+	it('basic drops image alt text', () => {
+		expect(sanitizeAt('basic', '<img src="/a.png" alt="chart">')).toBe(
+			'<img src="/a.png">'
+		)
+	})
+
+	it('bio keeps prose and links but drops headings, tables and code', () => {
+		expect(sanitizeAt('bio', '<p>hi <strong>there</strong></p>')).toBe(
+			'<p>hi <strong>there</strong></p>'
+		)
+		expect(sanitizeAt('bio', '<h2>Intro</h2>')).toBe('Intro')
+		expect(sanitizeAt('bio', '<table><tr><td>1</td></tr></table>')).toBe('1')
+		expect(sanitizeAt('bio', '<pre><code>x</code></pre>')).toBe('x')
+	})
+
+	// Text is never destroyed at any level, only its markup — a stripped tag
+	// still leaves the words on the page.
+	it('preserves the text of anything it strips', () => {
+		for (const level of ['rich', 'basic', 'bio']) {
+			expect(sanitizeAt(level, '<h3>Kept words</h3>')).toContain('Kept words')
+			expect(sanitizeAt(level, '<dl><dt>term</dt></dl>')).toContain('term')
+		}
+	})
+})

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,0 +1,11 @@
+import { config } from '@vue/test-utils'
+import safeHtml from '../directives/safeHtml'
+
+// main.js registers v-safe-html on the app, so a component that uses it renders
+// nothing under a bare mount() and the failure looks like missing data rather
+// than a missing directive. Registering it here keeps component tests rendering
+// what the app renders.
+config.global.directives = {
+	...config.global.directives,
+	'safe-html': safeHtml,
+}

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,11 +1,12 @@
 import { config } from '@vue/test-utils'
-import safeHtml from '../directives/safeHtml'
+import { safeHtml, vExternal } from '../directives'
 
-// main.js registers v-safe-html on the app, so a component that uses it renders
-// nothing under a bare mount() and the failure looks like missing data rather
-// than a missing directive. Registering it here keeps component tests rendering
-// what the app renders.
+// main.js registers these on the app, so a component that uses one renders
+// wrong under a bare mount() and the failure looks like missing data rather
+// than a missing directive. Registering them here keeps component tests
+// rendering what the app renders.
 config.global.directives = {
 	...config.global.directives,
 	'safe-html': safeHtml,
+	external: vExternal,
 }

--- a/frontend/src/tests/subAppDirectives.test.ts
+++ b/frontend/src/tests/subAppDirectives.test.ts
@@ -1,0 +1,39 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from 'vitest'
+
+// Every createApp() builds its own app context, and global directives are not
+// inherited from the main app. An unresolved directive is then dropped in
+// silence: withDirectives guards the binding push behind `if (dir)`, and
+// resolveDirective's warning is compiled out of a production build.
+//
+// That is how v-safe-html on Quiz.vue and v-external on PdfBlock.vue rendered
+// correctly through the router and did nothing at all through the EditorJS
+// block mounts in src/utils — on Safari and iOS only, for the PDF one.
+const sources = import.meta.glob('../utils/*.{js,ts}', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+const CREATE_APP = /\bcreateApp\s*\(/
+
+describe('sub-apps register the global directives', () => {
+	const mounts = Object.entries(sources).filter(([, src]) =>
+		CREATE_APP.test(src)
+	)
+
+	it('finds the sub-app mounts to scan', () => {
+		expect(mounts.length).toBeGreaterThan(0)
+	})
+
+	it('registers directives wherever it calls createApp', () => {
+		const offenders = mounts
+			.filter(([, src]) => {
+				const creates = src.match(/\bcreateApp\s*\(/g)?.length ?? 0
+				const registers = src.match(/\bregisterDirectives\s*\(/g)?.length ?? 0
+				return registers < creates
+			})
+			.map(([path]) => path)
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/subAppDirectives.test.ts
+++ b/frontend/src/tests/subAppDirectives.test.ts
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 import { describe, expect, it } from 'vitest'
 
 // Every createApp() builds its own app context, and global directives are not

--- a/frontend/src/tests/urlAttributeSafety.test.ts
+++ b/frontend/src/tests/urlAttributeSafety.test.ts
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { safeUrl } from '../utils/safeUrl'

--- a/frontend/src/tests/urlAttributeSafety.test.ts
+++ b/frontend/src/tests/urlAttributeSafety.test.ts
@@ -1,0 +1,127 @@
+/// <reference types="vite/client" />
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { safeUrl } from '../utils/safeUrl'
+
+describe('safeUrl', () => {
+	it('passes http, https and site-relative URLs through unchanged', () => {
+		expect(safeUrl('https://example.com/a.pdf')).toBe(
+			'https://example.com/a.pdf'
+		)
+		expect(safeUrl('/files/a.pdf')).toBe('/files/a.pdf')
+	})
+
+	it('drops javascript: in any casing or with padding', () => {
+		expect(safeUrl('javascript:alert(1)')).toBeUndefined()
+		expect(safeUrl('JaVaScRiPt:alert(1)')).toBeUndefined()
+		expect(safeUrl('  javascript:alert(1)')).toBeUndefined()
+		expect(safeUrl('java\tscript:alert(1)')).toBeUndefined()
+	})
+
+	it('drops data: and vbscript:', () => {
+		expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBeUndefined()
+		expect(safeUrl('vbscript:msgbox(1)')).toBeUndefined()
+	})
+
+	it('drops protocol-relative URLs', () => {
+		expect(safeUrl('//evil.example.com/a.pdf')).toBeUndefined()
+	})
+
+	// The URL parser normalises a backslash to a slash for http(s), so `/\host`
+	// resolves off-origin while reading as a path — in an href it is a phishing
+	// link that survives a glance at the status bar.
+	it('drops a URL whose leading slash is followed by a backslash', () => {
+		expect(safeUrl('/\\evil.example.com/p')).toBeUndefined()
+		expect(safeUrl('/\\\\evil.example.com/p')).toBeUndefined()
+		expect(safeUrl('\\/evil.example.com/p')).toBeUndefined()
+	})
+
+	// The rejection above must not take real paths with it: a backslash anywhere
+	// but immediately after the leading slash cannot introduce an authority.
+	it('keeps a path that merely contains a backslash', () => {
+		expect(safeUrl('/files/a\\b.pdf')).toBe('/files/a\\b.pdf')
+	})
+
+	it('returns undefined for nullish input', () => {
+		expect(safeUrl(null)).toBeUndefined()
+		expect(safeUrl(undefined)).toBeUndefined()
+	})
+
+	// The reason the reject value is undefined rather than ''. Vue only removes
+	// an attribute when the bound value is nullish; '' is set, and src=""
+	// resolves to the current page — an iframe would load the whole SPA inside
+	// itself and <a href=""> would stay focusable and go nowhere.
+	it('removes the attribute rather than emptying it', () => {
+		const wrapper = mount({
+			template: '<a :href="safeUrl(url)">x</a><iframe :src="safeUrl(url)" />',
+			setup: () => ({ safeUrl, url: 'javascript:alert(1)' }),
+		})
+		expect(wrapper.find('a').attributes('href')).toBeUndefined()
+		expect(wrapper.find('iframe').attributes('src')).toBeUndefined()
+	})
+})
+
+// Vite's own loader rather than node:fs — it needs no @types/node, so the type
+// check stays clean, and it resolves the same tree the app builds from.
+const sources = import.meta.glob('../**/*.vue', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>
+
+// :src / :href bound to an expression. Literal bindings and ones already routed
+// through safeUrl() are fine.
+const BOUND_URL = /\s(?::|v-bind:)(src|href)="([^"]+)"/g
+const HTML_COMMENT = /<!--[\s\S]*?-->/g
+
+const EXEMPT = new Map<string, string>([
+	// A path belongs here only when the binding is provably not user-authored:
+	// a constant, a router-built path, an import.meta.env value.
+	['../components/Modals/Event.vue', 'template literals rooted at /lms/'],
+	['../components/PersonaToolIcon.vue', 'static toolLogos map'],
+	[
+		'../components/Settings/EmailAccount/EmailAdd.vue',
+		'link comes from the services table in emailConfig.ts',
+	],
+	[
+		'../components/Settings/EmailAccount/EmailProviderIcon.vue',
+		'logo comes from the services table in emailConfig.ts',
+	],
+	[
+		'../components/Settings/Raven/RavenNotInstalledBanner.vue',
+		'constant https literal',
+	],
+	[
+		'../pages/ProfileCertificates.vue',
+		'template literal rooted at /api/method/',
+	],
+])
+
+describe('bound url attributes route through safeUrl', () => {
+	const files = Object.entries(sources)
+
+	it('finds components to scan', () => {
+		expect(files.length).toBeGreaterThan(50)
+	})
+
+	// Without this, a regex that stopped matching would look exactly like a
+	// clean tree.
+	it('matches a known-positive binding', () => {
+		const positive = '<iframe :src="getId(block)" />'
+		expect([...positive.matchAll(BOUND_URL)].length).toBe(1)
+	})
+
+	it('finds no unguarded :src or :href binding', () => {
+		const offenders: string[] = []
+		for (const [path, src] of files) {
+			if (EXEMPT.has(path)) continue
+			const live = src.replace(HTML_COMMENT, '')
+			for (const [, attr, expr] of live.matchAll(BOUND_URL)) {
+				if (expr.includes('safeUrl(')) continue
+				if (/^'[^']*'$/.test(expr.trim())) continue
+				offenders.push(`${path} :${attr}="${expr}"`)
+			}
+		}
+		expect(offenders, offenders.join('\n')).toEqual([])
+	})
+})

--- a/frontend/src/tests/usePermissions.test.ts
+++ b/frontend/src/tests/usePermissions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import {
+	invalidatePermissions,
+	usePermissions,
+} from '../composables/usePermissions'
+
+describe('usePermissions', () => {
+	it('denies every ptype until an answer has arrived', () => {
+		const { can, loading } = usePermissions('LMS Course', ref('c1'), {
+			fetcher: vi.fn(() => new Promise<never>(() => {})),
+		})
+		expect(loading.value).toBe(true)
+		expect(can('write')).toBe(false)
+	})
+
+	it('denies for Guest without issuing a request', async () => {
+		const fetch = vi.fn()
+		const { can } = usePermissions('LMS Course', ref('c2'), {
+			user: null,
+			fetcher: fetch,
+		})
+		expect(can('read')).toBe(false)
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('denies write in Student View even when the server permits it', async () => {
+		const { can } = usePermissions('LMS Course', ref('c3'), {
+			studentView: true,
+			seed: { read: 1, write: 1 },
+		})
+		expect(can('read')).toBe(true)
+		expect(can('write')).toBe(false)
+	})
+
+	it('drops the cached entry on invalidate', async () => {
+		const { can } = usePermissions('LMS Course', ref('c4'), {
+			seed: { write: 1 },
+			fetcher: vi.fn(() => new Promise<never>(() => {})),
+		})
+		expect(can('write')).toBe(true)
+		invalidatePermissions('LMS Course', 'c4')
+		expect(can('write')).toBe(false)
+	})
+
+	it('asks the server once for a name several callers share', async () => {
+		const fetcher = vi.fn(async () => ({ c5: { read: 1, write: 1 } }))
+		const first = usePermissions('LMS Course', ref('c5'), { fetcher })
+		const second = usePermissions('LMS Course', ref('c5'), { fetcher })
+		await vi.waitFor(() => expect(first.loading.value).toBe(false))
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(second.can('write')).toBe(true)
+	})
+
+	it('batches the names asked for in the same tick into one call', async () => {
+		const fetcher = vi.fn(async (_doctype: string, names: string[]) =>
+			Object.fromEntries(names.map((n) => [n, { read: 1 }]))
+		)
+		const a = usePermissions('Course Lesson', ref('l1'), { fetcher })
+		const b = usePermissions('Course Lesson', ref('l2'), { fetcher })
+		await vi.waitFor(() => expect(a.loading.value).toBe(false))
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(fetcher.mock.calls[0][1].sort()).toEqual(['l1', 'l2'])
+		expect(b.can('read')).toBe(true)
+	})
+
+	it('denies when the request fails rather than throwing', async () => {
+		const fetcher = vi.fn(async () => {
+			throw new Error('network')
+		})
+		const { can, loading } = usePermissions('LMS Course', ref('c6'), {
+			fetcher,
+		})
+		await vi.waitFor(() => expect(loading.value).toBe(false))
+		expect(can('read')).toBe(false)
+	})
+
+	it('re-asks when the name changes', async () => {
+		const fetcher = vi.fn(async (_doctype: string, names: string[]) =>
+			Object.fromEntries(names.map((n) => [n, { read: 1 }]))
+		)
+		const name = ref('c7')
+		const { can, loading } = usePermissions('LMS Course', name, { fetcher })
+		await vi.waitFor(() => expect(loading.value).toBe(false))
+		expect(can('read')).toBe(true)
+
+		name.value = 'c8'
+		expect(can('read')).toBe(false)
+		await vi.waitFor(() => expect(loading.value).toBe(false))
+		expect(can('read')).toBe(true)
+		expect(fetcher).toHaveBeenCalledTimes(2)
+	})
+})

--- a/frontend/src/tests/userAvatarIndicator.test.ts
+++ b/frontend/src/tests/userAvatarIndicator.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The avatar's "Open to Work" / "Hiring" indicator.
+ *
+ * Both indicators are solid colour chips with a check glyph on top, so they have
+ * to use frappe-ui's solid pairing for that colour — `ink-<colour>-1` on
+ * `surface-<colour>-7` (Badge.vue:53-78). Neither did:
+ *
+ * - Work drew `text-ink-base` on `bg-surface-green-3`. In light mode `--ink-base`
+ *   is oklch(1 0 0) — the same value as `--surface-base` — and surface-green-3 is
+ *   a pale tint at oklch(.908 .07 154.3). White on that is ~1.1:1: the check was
+ *   invisible.
+ * - Hiring drew it on `bg-purple-500`, a raw palette colour built from
+ *   lightModeColors regardless of theme, while its ink flipped to oklch(.205 0 0)
+ *   in dark mode — a near-black check on an unchanged purple.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { vi } from 'vitest'
+
+window.__ = (text: string): string => text
+
+vi.mock('frappe-ui', () => ({
+	Avatar: {
+		props: ['label', 'image', 'size'],
+		template: `<div><slot name="indicator" /></div>`,
+	},
+	Tooltip: {
+		props: ['text', 'placement'],
+		template: `<div><slot /></div>`,
+	},
+}))
+
+import UserAvatar from '@/components/UserAvatar.vue'
+
+const indicator = (openTo: string) =>
+	mount(UserAvatar, {
+		props: { user: { full_name: 'A', open_to: openTo } as any, size: '2xl' },
+		global: { config: { globalProperties: { __: (s: string) => s } as any } },
+	})
+
+describe('UserAvatar indicator', () => {
+	it('draws Open to Work as a solid green chip', () => {
+		const html = indicator('Work').html()
+
+		expect(html).toContain('bg-surface-green-7')
+		expect(html).toContain('text-ink-green-1')
+	})
+
+	it('draws Hiring as a solid violet chip', () => {
+		const html = indicator('Hiring').html()
+
+		expect(html).toContain('bg-surface-violet-7')
+		expect(html).toContain('text-ink-violet-1')
+	})
+
+	it('uses no raw palette colour and no base ink on a tint', () => {
+		const html = indicator('Work').html() + indicator('Hiring').html()
+
+		// bg-purple-500 has no dark-mode value; ink-base is for solid surfaces
+		// only, and pairing it with a -3 tint is what made the check vanish.
+		expect(html).not.toContain('bg-purple-')
+		expect(html).not.toContain('text-ink-base')
+		expect(html).not.toContain('bg-surface-green-3')
+	})
+})

--- a/frontend/src/tests/writePathSanitize.test.ts
+++ b/frontend/src/tests/writePathSanitize.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeOnWrite } from '../utils/sanitizeOnWrite'
+
+describe('sanitizeOnWrite', () => {
+	it('still removes the things that make it a sanitizer', () => {
+		const out = sanitizeOnWrite(
+			'<img src=x onerror=alert(1)><script>alert(1)</script><form><input></form>'
+		)
+		expect(out).not.toContain('onerror')
+		expect(out).not.toContain('<script')
+		expect(out).not.toContain('<input')
+	})
+
+	it('preserves table structure that the short-field allowlist destroys', () => {
+		const table =
+			'<table><caption>Week</caption><tr><th scope="col" rowspan="2">Mon</th><td>a</td></tr></table>'
+		const out = sanitizeOnWrite(table)
+		expect(out).toContain('<caption>')
+		expect(out).toContain('scope="col"')
+		expect(out).toContain('rowspan="2"')
+	})
+
+	it('preserves author alt text, including the empty decorative case', () => {
+		expect(
+			sanitizeOnWrite('<img src="/f.png" alt="Scan of the syllabus">')
+		).toContain('alt="Scan of the syllabus"')
+		expect(sanitizeOnWrite('<img src="/f.png" alt="">')).toContain('alt=""')
+	})
+
+	it('preserves lang and dir', () => {
+		const out = sanitizeOnWrite('<p lang="fr" dir="rtl">bonjour</p>')
+		expect(out).toContain('lang="fr"')
+		expect(out).toContain('dir="rtl"')
+	})
+})

--- a/frontend/src/utils/assignment.js
+++ b/frontend/src/utils/assignment.js
@@ -1,4 +1,5 @@
 import { Pencil } from 'lucide-vue-next'
+import { registerDirectives } from '@/directives'
 import { createApp, h } from 'vue'
 import AssessmentPlugin from '@/components/AssessmentPlugin.vue'
 import translationPlugin from '../translation'
@@ -18,6 +19,7 @@ export class Assignment {
 			render: () =>
 				h(Pencil, { size: 18, strokeWidth: 1.5, color: 'black' }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)
@@ -89,6 +91,7 @@ export class Assignment {
 				this.renderAssignment(assignment)
 			},
 		})
+		registerDirectives(app)
 		app.use(translationPlugin)
 		app.use(router)
 		app.mount(this.wrapper)

--- a/frontend/src/utils/assignment.js
+++ b/frontend/src/utils/assignment.js
@@ -6,6 +6,7 @@ import translationPlugin from '../translation'
 import { call } from 'frappe-ui'
 import router from '@/router'
 import { getLmsRoute } from '@/utils/basePath'
+import { blockNotice, embedFrame } from '@/utils/blockDom'
 
 export class Assignment {
 	constructor({ data, api, readOnly, config }) {
@@ -55,7 +56,10 @@ export class Assignment {
 						submission || 'new'
 					}?fromLesson=1${studentView}`
 				)
-				this.wrapper.innerHTML = `<iframe src="${submissionPath}" class="w-full h-[500px]"></iframe>`
+				const frame = embedFrame(submissionPath, {
+					class: 'w-full h-[500px]',
+				})
+				this.wrapper.replaceChildren(...(frame ? [frame] : []))
 			}
 			call('lms.lms.api.get_own_assignment_submission', {
 				assignment: assignment,
@@ -71,11 +75,9 @@ export class Assignment {
 			},
 			fieldname: ['title'],
 		}).then((data) => {
-			this.wrapper.innerHTML = `<div class='border rounded-md p-4 text-center bg-surface-sidebar mb-4'>
-				<span class="font-medium">
-					Assignment: ${data.title}
-				</span>
-			</div>`
+			this.wrapper.replaceChildren(
+				blockNotice(`Assignment: ${data.title}`)
+			)
 			return
 		})
 	}

--- a/frontend/src/utils/blockDom.ts
+++ b/frontend/src/utils/blockDom.ts
@@ -1,0 +1,34 @@
+import { safeUrl } from './safeUrl'
+
+// EditorJS blocks build their own DOM outside Vue, so neither v-safe-html nor
+// the bound-attribute scanners reach them: a template literal into innerHTML is
+// the only sink they have, and every one of them interpolated an author-supplied
+// id or title straight into markup. These two build the same output through the
+// DOM, where a value is data and cannot close an attribute.
+
+// Returns nothing when the URL fails the scheme allowlist, so the caller renders
+// no frame at all — an <iframe src=""> resolves to the current page and would
+// load the whole SPA inside itself.
+export const embedFrame = (
+	src: string | null | undefined,
+	attrs: Record<string, string>
+): HTMLIFrameElement | undefined => {
+	const href = safeUrl(src)
+	if (!href) return undefined
+	const frame = document.createElement('iframe')
+	frame.setAttribute('src', href)
+	for (const [name, value] of Object.entries(attrs))
+		frame.setAttribute(name, value)
+	return frame
+}
+
+// The "Assignment: <title>" placeholder every non-readOnly block renders.
+export const blockNotice = (text: string): HTMLDivElement => {
+	const card = document.createElement('div')
+	card.className = 'border rounded-md p-4 text-center bg-surface-sidebar mb-4'
+	const label = document.createElement('span')
+	label.className = 'font-medium'
+	label.textContent = text
+	card.append(label)
+	return card
+}

--- a/frontend/src/utils/code.ts
+++ b/frontend/src/utils/code.ts
@@ -1,4 +1,5 @@
 import { Code } from 'lucide-vue-next'
+import { registerDirectives } from '@/directives'
 import { h, createApp } from 'vue'
 import { HTML_ESCAPE_MAP } from '@/utils/format'
 // lib/core registers no languages; register just the picker's set to avoid bundling all ~190.
@@ -339,6 +340,7 @@ export class CodeBox {
 			render: () =>
 				h(Code, { size: 18, strokeWidth: 1.5, color: 'currentColor' }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -25,6 +25,7 @@ import Embed from '@editorjs/embed'
 import SimpleImage from '@editorjs/simple-image'
 import Table from '@editorjs/table'
 import DOMPurify from 'dompurify'
+import { decodeEntities } from './inertHtml'
 
 const readOnlyMode = window.read_only_mode
 
@@ -115,12 +116,6 @@ export function getImgDimensions(imgSrc) {
 		}
 		img.src = imgSrc
 	})
-}
-
-export function htmlToText(html) {
-	const div = document.createElement('div')
-	div.innerHTML = html
-	return div.textContent || div.innerText || ''
 }
 
 // Visual order of the inline toolbar (automad layout). References registered
@@ -1030,11 +1025,7 @@ export const blockQuotesClick = () => {
 	})
 }
 
-export const decodeEntities = (encodedString) => {
-	const textarea = document.createElement('textarea')
-	textarea.innerHTML = encodedString
-	return textarea.value
-}
+export { decodeEntities, htmlToText } from './inertHtml'
 
 export function validateEmail(email) {
 	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(email || '').trim())

--- a/frontend/src/utils/inertHtml.ts
+++ b/frontend/src/utils/inertHtml.ts
@@ -1,0 +1,29 @@
+// Both helpers here read untrusted HTML, and both used to do it by writing it
+// into a node in the live document. That is not inert: an <img src=x
+// onerror=...> loads and fires even while detached, so the markup ran before
+// anything sanitized it. A DOMParser document has no browsing context, so
+// nothing in it fetches or runs.
+//
+// They live together in their own module because decodeEntities is the one place
+// in the app that assigns innerHTML from a value on purpose, and the innerHTML
+// gate in tests/htmlSinkSafety.test.ts exempts this path — an exemption is only
+// honest when it covers nothing else.
+
+const inert = (html: string): Document =>
+	new DOMParser().parseFromString(html, 'text/html')
+
+// Bios and notification subjects arrive HTML-escaped and reach here before
+// v-safe-html sees them, so the sanitizer cannot be what protects this write.
+// The textarea stays because it is what keeps raw tags as text: decoding through
+// textContent would strip the HTML a bio is allowed to carry, which the profile
+// then renders through v-safe-html:bio.
+export const decodeEntities = (encodedString?: string | null): string => {
+	const textarea = inert('<textarea></textarea>').querySelector(
+		'textarea'
+	) as HTMLTextAreaElement
+	textarea.innerHTML = encodedString ?? ''
+	return textarea.value
+}
+
+export const htmlToText = (html?: string | null): string =>
+	inert(html ?? '').body.textContent || ''

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -2,6 +2,7 @@ import { CodeXml } from 'lucide-vue-next'
 import { registerDirectives } from '@/directives'
 import { createApp, h } from 'vue'
 import { escapeHTML } from '@/utils/format'
+import { sanitizeAt } from '@/directives/safeHtmlLevels'
 
 // Language-class hints on pasted code (hljs/Prism/SyntaxHighlighter). Anchored to
 // a class-token boundary so 'language-' matches only as its own class.
@@ -87,7 +88,11 @@ export class Markdown {
 		this.wrapper.classList.add('cdx-block', 'ce-paragraph')
 		this.wrapper.contentEditable = !this.readOnly
 		this.wrapper.dataset.placeholder = this.placeholder
-		this.wrapper.innerHTML = this.text
+		// Lesson bodies are EditorJS JSON, and frappe's sanitize_html returns JSON
+		// untouched (is_json early return), so nothing upstream cleans this text.
+		// v-safe-html cannot reach it either — the block builds its own DOM — so it
+		// calls the same sanitizer directly, at the level lesson content renders at.
+		this.wrapper.innerHTML = sanitizeAt('rich', this.text)
 
 		if (!this.readOnly) {
 			this.wrapper.addEventListener('focus', () =>

--- a/frontend/src/utils/markdownParser.js
+++ b/frontend/src/utils/markdownParser.js
@@ -1,4 +1,5 @@
 import { CodeXml } from 'lucide-vue-next'
+import { registerDirectives } from '@/directives'
 import { createApp, h } from 'vue'
 import { escapeHTML } from '@/utils/format'
 
@@ -68,6 +69,7 @@ export class Markdown {
 			render: () =>
 				h(CodeXml, { size: 18, strokeWidth: 1.5, color: 'black' }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)

--- a/frontend/src/utils/openExternal.ts
+++ b/frontend/src/utils/openExternal.ts
@@ -1,0 +1,21 @@
+import { safeUrl } from './safeUrl'
+
+// The window.open twin of the v-external directive, and it exists for the same
+// reason: the guarantee has to live in one place or a call site will forget it.
+//
+// 'noopener' severs the window.opener reference the opened page would otherwise
+// hold on ours (reverse tabnabbing). It goes in the features string, which does
+// not make the result a popup — the HTML spec strips noopener and noreferrer
+// from the feature list before deciding whether a popup was requested, so this
+// still opens a tab.
+//
+// The URL clears the same scheme allowlist as every bound href, because
+// window.open('javascript:…') runs that script in a document that inherits our
+// origin. A rejected URL opens nothing: there is no attribute to remove here, so
+// the failure has to be silent, and every call site passes a URL it built or a
+// link the author already published.
+export const openExternal = (url?: string | null): void => {
+	const href = safeUrl(url)
+	if (!href) return
+	window.open(href, '_blank', 'noopener')
+}

--- a/frontend/src/utils/program.ts
+++ b/frontend/src/utils/program.ts
@@ -6,6 +6,7 @@ import ProgrammingExerciseModal from '@/components/Modals/ProgrammingExerciseMod
 import { call } from 'frappe-ui'
 import { usersStore } from '@/stores/user'
 import { getLmsRoute } from '@/utils/basePath'
+import { blockNotice, embedFrame } from '@/utils/blockDom'
 
 export class Program {
 	data: any
@@ -95,7 +96,10 @@ export class Program {
 				const submissionPath = getLmsRoute(
 					`programming-exercises/${exercise}/submission/${submission}?fromLesson=1${studentView}`
 				)
-				this.wrapper.innerHTML = `<iframe src="${submissionPath}" class="w-full h-[900px] border rounded-md"></iframe>`
+				const frame = embedFrame(submissionPath, {
+					class: 'w-full h-[900px] border rounded-md',
+				})
+				this.wrapper.replaceChildren(...(frame ? [frame] : []))
 			})
 			return
 		}
@@ -106,11 +110,9 @@ export class Program {
 			},
 			fieldname: 'title',
 		}).then((data: { title: string }) => {
-			this.wrapper.innerHTML = `<div class='border rounded-md p-4 text-center bg-surface-sidebar mb-4'>
-                <span class="font-medium">
-                    Programming Exercise: ${data.title}
-                </span>
-            </div>`
+			this.wrapper.replaceChildren(
+				blockNotice(`Programming Exercise: ${data.title}`)
+			)
 			return
 		})
 	}

--- a/frontend/src/utils/program.ts
+++ b/frontend/src/utils/program.ts
@@ -1,4 +1,5 @@
 import { createApp, h } from 'vue'
+import { registerDirectives } from '@/directives'
 import { Code } from 'lucide-vue-next'
 import translationPlugin from '@/translation'
 import ProgrammingExerciseModal from '@/components/Modals/ProgrammingExerciseModal.vue'
@@ -38,6 +39,7 @@ export class Program {
 		const app = createApp({
 			render: () => h(Code, { size: 5, strokeWidth: 1.5 }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)
@@ -72,6 +74,7 @@ export class Program {
 				this.renderExercise(exercise)
 			},
 		})
+		registerDirectives(app)
 		app.use(translationPlugin)
 		app.mount(this.wrapper)
 	}

--- a/frontend/src/utils/quiz.js
+++ b/frontend/src/utils/quiz.js
@@ -1,4 +1,5 @@
 import QuizBlock from '@/components/QuizBlock.vue'
+import { registerDirectives } from '@/directives'
 import AssessmentPlugin from '@/components/AssessmentPlugin.vue'
 import { createApp, h } from 'vue'
 import { usersStore } from '../stores/user'
@@ -16,6 +17,7 @@ export class Quiz {
 		const app = createApp({
 			render: () => h(CircleHelp, { size: 5, strokeWidth: 1.5 }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)
@@ -48,6 +50,7 @@ export class Quiz {
 			// so give it translation and the shared $user the quiz component needs.
 			const { userResource } = usersStore()
 			this.quizApp = createApp(QuizBlock, { quiz })
+			registerDirectives(this.quizApp)
 			this.quizApp.use(translationPlugin)
 			this.quizApp.provide('$user', userResource)
 			// Contain quiz render/runtime errors to this mount. Inline (unlike
@@ -85,6 +88,7 @@ export class Quiz {
 				this.renderQuiz(quiz)
 			},
 		})
+		registerDirectives(app)
 		app.use(translationPlugin)
 		app.use(router)
 		app.mount(this.wrapper)

--- a/frontend/src/utils/quiz.js
+++ b/frontend/src/utils/quiz.js
@@ -6,6 +6,7 @@ import { usersStore } from '../stores/user'
 import translationPlugin from '../translation'
 import { CircleHelp } from 'lucide-vue-next'
 import router from '@/router'
+import { blockNotice } from '@/utils/blockDom'
 
 export class Quiz {
 	constructor({ data, api, readOnly }) {
@@ -63,11 +64,7 @@ export class Quiz {
 			this.quizApp.mount(this.wrapper)
 			return
 		}
-		this.wrapper.innerHTML = `<div class='border rounded-md p-4 text-center bg-surface-sidebar mb-4'>
-            <span class="font-medium">
-                Quiz: ${quiz}
-            </span>
-        </div>`
+		this.wrapper.replaceChildren(blockNotice(`Quiz: ${quiz}`))
 		return
 	}
 

--- a/frontend/src/utils/safeUrl.ts
+++ b/frontend/src/utils/safeUrl.ts
@@ -1,0 +1,21 @@
+// Scheme allowlist for any URL that reaches a bound src/href attribute.
+// DOMPurify never sees attribute bindings, so a javascript: URL in an iframe
+// :src executes in the app's own origin. Control characters and whitespace are
+// stripped first because the browser ignores them when resolving the scheme.
+//
+// Rejection returns undefined, not '', because Vue removes an attribute only
+// when the bound value is null or undefined (runtime-dom patchAttr) — an empty
+// string is set. src="" resolves to the current page, so an iframe would
+// render the whole SPA inside itself, and <a href=""> would stay focusable and
+// navigate nowhere. Removing the attribute is the accessible failure.
+// The site-relative branch rejects a second slash *and* a backslash: the URL
+// parser normalises `\` to `/` for http(s), so `/\host/p` is `//host/p` — an
+// off-origin URL that reads as a path. Both spellings have to fail here for the
+// allowlist to mean what its name says.
+const ALLOWED = /^(https?:|\/(?![/\\])|#|mailto:)/i
+const IGNORED_BY_BROWSER = /[\u0000-\u0020]/g
+
+export const safeUrl = (value?: string | null): string | undefined => {
+	if (!value) return undefined
+	return ALLOWED.test(value.replace(IGNORED_BY_BROWSER, '')) ? value : undefined
+}

--- a/frontend/src/utils/sanitizeOnWrite.ts
+++ b/frontend/src/utils/sanitizeOnWrite.ts
@@ -1,0 +1,28 @@
+import DOMPurify from 'dompurify'
+
+// Sanitizer for values about to be PERSISTED. Security-only, never editorial:
+// what this strips is gone forever, so it may only remove things that are
+// unsafe, never things that are merely unwanted at some render site. Rendering
+// strictness is a reversible policy choice and belongs in v-safe-html levels.
+//
+// Its own DOMPurify instance, not sanitizeRichHTML's: hooks are registered per
+// instance, and that one forces target/rel onto every anchor, which is a render
+// decision that must not be written into stored content.
+const purifier = DOMPurify()
+
+export const sanitizeOnWrite = (html?: string | null): string => {
+	if (!html) return ''
+	return purifier.sanitize(html, {
+		FORBID_TAGS: [
+			'form',
+			'input',
+			'button',
+			'textarea',
+			'select',
+			'option',
+			'label',
+			'fieldset',
+		],
+		FORBID_ATTR: ['formaction', 'formmethod', 'formenctype'],
+	})
+}

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -1,4 +1,5 @@
 import AudioBlock from '@/components/AudioBlock.vue'
+import { registerDirectives } from '@/directives'
 import VideoBlock from '@/components/VideoBlock.vue'
 import PdfBlock from '@/components/PdfBlock.vue'
 import UploadPlugin from '@/components/UploadPlugin.vue'
@@ -20,6 +21,7 @@ export class Upload {
 			render: () =>
 				h(UploadIcon, { size: 18, strokeWidth: 1.5, color: 'black' }),
 		})
+		registerDirectives(app)
 
 		const div = document.createElement('div')
 		app.mount(div)
@@ -57,6 +59,7 @@ export class Upload {
 					this.data.quizzes = quizzes
 				},
 			})
+			registerDirectives(app)
 			app.use(translationPlugin)
 			app.config.globalProperties.$dialog = createDialog
 			app.mount(this.wrapper)
@@ -65,6 +68,7 @@ export class Upload {
 			const app = createApp(AudioBlock, {
 				file: file.file_url,
 			})
+			registerDirectives(app)
 			app.mount(this.wrapper)
 			return
 		} else if (file.file_type == 'PDF') {
@@ -83,6 +87,7 @@ export class Upload {
 			this.app = createApp(PdfBlock, {
 				file: file.file_url,
 			})
+			registerDirectives(this.app)
 			this.app.use(translationPlugin)
 			this.app.mount(this.wrapper)
 			return
@@ -103,6 +108,7 @@ export class Upload {
 				this.renderFile(file)
 			},
 		})
+		registerDirectives(app)
 		app.use(translationPlugin)
 		app.mount(this.wrapper)
 	}

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -7,6 +7,8 @@ import { h, createApp } from 'vue'
 import { Upload as UploadIcon } from 'lucide-vue-next'
 import { createDialog } from '@/utils/dialogs'
 import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
+import { embedFrame } from '@/utils/blockDom'
+import { safeUrl } from '@/utils/safeUrl'
 import translationPlugin from '../translation'
 
 export class Upload {
@@ -77,11 +79,13 @@ export class Upload {
 			// pdf.js worker + render tasks down. Everywhere else keeps the native
 			// plugin. See utils/pdfViewer.
 			if (!usesWebkitPdfViewer()) {
-				this.wrapper.innerHTML = `<iframe src="${
-					window.location.origin
-				}${encodeURI(
-					file.file_url
-				)}" width='100%' height='700px' class="mb-4" type="application/pdf"></iframe>`
+				const frame = embedFrame(file.file_url, {
+					width: '100%',
+					height: '700px',
+					class: 'mb-4',
+					type: 'application/pdf',
+				})
+				this.wrapper.replaceChildren(...(frame ? [frame] : []))
 				return
 			}
 			this.app = createApp(PdfBlock, {
@@ -92,9 +96,14 @@ export class Upload {
 			this.app.mount(this.wrapper)
 			return
 		} else {
-			this.wrapper.innerHTML = `<img class="mb-4" src=${encodeURI(
-				file.file_url
-			)} width='100%'>`
+			const src = safeUrl(file.file_url)
+			if (src) {
+				const img = document.createElement('img')
+				img.setAttribute('src', src)
+				img.className = 'mb-4'
+				img.setAttribute('width', '100%')
+				this.wrapper.replaceChildren(img)
+			}
 			return
 		}
 	}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
-    "types": [],
+    "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
 		environment: 'jsdom',
 		globals: true,
 		include: ['src/tests/**/*.test.{ts,js}'],
+		// Registers v-safe-html the way main.js does, so a component test does
+		// not have to know which components use the directive.
+		setupFiles: ['src/tests/setup.ts'],
 		// Nothing here is slow on its own. Every one of these files passes in
 		// well under a second when run alone. The default 5s is wall-clock
 		// though, and a full run mounts 60-odd suites in parallel, so a handful

--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -91,6 +91,10 @@ after_migrate = [
 
 permission_query_conditions = {
 	"LMS Certificate": "lms.lms.doctype.lms_certificate.lms_certificate.get_permission_query_conditions",
+	"LMS Live Class": "lms.lms.doctype.lms_live_class.lms_live_class.get_permission_query_conditions",
+	"LMS Batch": "lms.lms.doctype.lms_batch.lms_batch.get_permission_query_conditions",
+	"LMS Program": "lms.lms.doctype.lms_program.lms_program.get_permission_query_conditions",
+	"Course Lesson": "lms.lms.doctype.course_lesson.course_lesson.get_permission_query_conditions",
 }
 
 has_permission = {

--- a/lms/install.py
+++ b/lms/install.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.permissions import add_permission, update_permission_property
 
 from lms.lms.api import give_discussions_permission
+from lms.lms.enrollment_constraints import ensure_enrollment_unique_constraints
 
 
 def after_install():
@@ -10,6 +11,7 @@ def after_install():
 	give_user_list_permission()
 	give_event_permission()
 	ensure_batch_enrollment_index()
+	ensure_enrollment_unique_constraints()
 
 
 def ensure_batch_enrollment_index():

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -78,7 +78,32 @@ def get_user_info():
 	user.developer_mode = frappe.conf.developer_mode
 	if user.is_fc_site and user.is_system_manager:
 		user.site_info = current_site_info()
+	user.permissions = _doctype_permissions()
 	return user
+
+
+PERMISSION_DOCTYPES = (
+	"LMS Course",
+	"Course Chapter",
+	"Course Lesson",
+	"LMS Batch",
+	"LMS Quiz",
+	"LMS Assignment",
+	"LMS Program",
+	"Job Opportunity",
+)
+
+
+def _doctype_permissions():
+	"""Doctype-level answers for surfaces that have no docname yet: nav items and
+	route guards. Document-level answers come from get_doc_permissions_many."""
+	out = {}
+	for doctype in PERMISSION_DOCTYPES:
+		out[doctype] = {
+			ptype: 1 if frappe.has_permission(doctype, ptype) else 0
+			for ptype in ("read", "write", "create", "delete")
+		}
+	return out
 
 
 @frappe.whitelist(allow_guest=True)

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -94,6 +94,52 @@ PERMISSION_DOCTYPES = (
 )
 
 
+MAX_PERMISSION_BATCH = 200
+
+
+@frappe.whitelist()
+def get_doc_permissions_many(doctype: str, names: str | list[str]):
+	"""Evaluated permissions for several documents of one doctype.
+
+	Batched because a course outline resolves affordances for every lesson on
+	screen at once; one call per document behind a hide-until-known gate is one
+	flicker per document. CRM asks per document (crm/frontend/src/data/
+	document.js) because its form view opens one.
+
+	doctype/names are annotated rather than isinstance-checked because
+	require_type_annotated_api_methods is on (hooks.py), so frappe rejects a
+	wrong type before this body runs — in a request and in tests alike."""
+	if isinstance(names, str):
+		names = frappe.parse_json(names)
+
+	if not isinstance(names, list):
+		frappe.throw(_("names must be a list"))
+
+	if len(names) > MAX_PERMISSION_BATCH:
+		frappe.throw(_("At most {0} documents per request").format(MAX_PERMISSION_BATCH))
+
+	if not frappe.db.exists("DocType", doctype):
+		frappe.throw(_("Unknown doctype"))
+
+	out = {}
+	for name in names:
+		if not isinstance(name, str):
+			continue
+		try:
+			doc = frappe.get_lazy_doc(doctype, name)
+		except frappe.DoesNotExistError:
+			out[name] = {}
+			continue
+		perms = frappe.permissions.get_doc_permissions(doc)
+		# A document the caller cannot read answers exactly like one that does not
+		# exist. Anything else lets a caller submit guessed names and read the
+		# difference: a permission map means the row is real, {} means it is not.
+		# The UI needs no more than this — hide-until-known treats a missing ptype
+		# as a deny, so {} and read=0 render the same.
+		out[name] = perms if perms.get("read") else {}
+	return out
+
+
 def _doctype_permissions():
 	"""Doctype-level answers for surfaces that have no docname yet: nav items and
 	route guards. Document-level answers come from get_doc_permissions_many."""

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -23,6 +23,7 @@ from lms.lms.permissions import INSTRUCTOR_FIELDS, can_access_lesson
 from lms.lms.utils import (
 	get_course_progress,
 	get_editorjs_blocks,
+	guest_access_allowed,
 	is_demo_course,
 	recalculate_course_progress,
 	sanitize_editorjs,
@@ -120,6 +121,45 @@ def has_permission(doc, ptype="read", user=None):
 	# Deliberately NOT widened to all Course Creators, to preserve the media-access
 	# boundary (matches the original get_lesson gate).
 	return can_access_lesson(doc.name, user=user)
+
+
+def get_permission_query_conditions(user=None):
+	"""List-read counterpart of has_permission's read branch.
+
+	Expresses resolve_lesson_access (lms/lms/permissions.py) as SQL: course
+	instructor, or enrolled member, or a preview lesson of a published course.
+	Deliberately NOT widened to all Course Creators — the read gate is per-course,
+	and widening it here would open the media boundary the doc read protects.
+	"""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+
+	roles = frappe.get_roles(user)
+	if "Moderator" in roles:
+		return ""
+
+	escaped = frappe.db.escape(user)
+	conditions = [
+		f"""`tabCourse Lesson`.course in (
+			select parent from `tabCourse Instructor`
+			where instructor = {escaped} and parenttype = 'LMS Course'
+		)""",
+		f"""`tabCourse Lesson`.course in (
+			select course from `tabLMS Enrollment` where member = {escaped}
+		)""",
+	]
+
+	if user != "Guest" or guest_access_allowed():
+		conditions.append(
+			"""(`tabCourse Lesson`.include_in_preview = 1
+			and `tabCourse Lesson`.course in (
+				select name from `tabLMS Course` where published = 1
+			))"""
+		)
+
+	joined = " or ".join(conditions)
+	return f"({joined})"
 
 
 # Lesson content fields a student may reach vs. instructor-only fields (gated harder).

--- a/lms/lms/doctype/lms_batch/lms_batch.py
+++ b/lms/lms/doctype/lms_batch/lms_batch.py
@@ -517,3 +517,22 @@ def has_permission(doc, ptype="read", user=None):
 		return True
 
 	return False
+
+
+def get_permission_query_conditions(user=None):
+	"""List-read counterpart of has_permission above: published, or enrolled."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+
+	if user == "Guest" and not guest_access_allowed():
+		return "1 = 0"
+
+	roles = frappe.get_roles(user)
+	if "Moderator" in roles or "Batch Evaluator" in roles:
+		return ""
+
+	escaped = frappe.db.escape(user)
+	return f"""(`tabLMS Batch`.published = 1 or `tabLMS Batch`.name in (
+		select batch from `tabLMS Batch Enrollment` where member = {escaped}
+	))"""

--- a/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
+++ b/lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py
@@ -61,6 +61,14 @@ class LMSBatchEnrollment(Document):
 		return "Course Creator" in roles or "Moderator" in roles or "Batch Evaluator" in roles
 
 	def validate_duplicate_members(self):
+		# Lock the batch row for the rest of this transaction before reading. The
+		# check below is a read of a row a concurrent request has not inserted
+		# yet, so without the lock both requests see "absent" and both insert —
+		# and a duplicate row also consumes a seat in validate_seat_availability,
+		# which turns a double-click into "no seats available" for someone else.
+		# Same shape as the payment and coupon locks in lms/lms/utils.py.
+		frappe.db.get_value("LMS Batch", self.batch, "name", for_update=True)
+
 		if frappe.db.exists(
 			"LMS Batch Enrollment",
 			{"batch": self.batch, "member": self.member, "name": ["!=", self.name]},
@@ -77,6 +85,13 @@ class LMSBatchEnrollment(Document):
 		courses = frappe.get_all("Batch Course", filters={"parent": self.batch}, fields=["course"])
 
 		for course in courses:
+			# Same reasoning as validate_duplicate_members, one level down: without
+			# the lock, two batches sharing a course can both read "absent" for the
+			# same member and the loser's inner insert throws, failing an enrolment
+			# that should have skipped. Batch row first, then course row, in that
+			# order everywhere — the reverse order exists nowhere, so no cycle.
+			frappe.db.get_value("LMS Course", course.course, "name", for_update=True)
+
 			if not frappe.db.exists(
 				"LMS Enrollment",
 				{"course": course.course, "member": self.member},

--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -39,6 +39,11 @@ class LMSEnrollment(Document):
 		update_program_progress(self.member)
 
 	def validate_duplicate_enrollment(self):
+		# Lock the course row first: see the note in
+		# lms_batch_enrollment.validate_duplicate_members. Two concurrent
+		# enrolments in the same course both read "absent" without it.
+		frappe.db.get_value("LMS Course", self.course, "name", for_update=True)
+
 		existing_enrollment = frappe.db.exists(
 			"LMS Enrollment",
 			{

--- a/lms/lms/doctype/lms_live_class/lms_live_class.py
+++ b/lms/lms/doctype/lms_live_class/lms_live_class.py
@@ -263,3 +263,25 @@ def has_permission(doc, ptype="read", user=None):
 		"LMS Batch Enrollment",
 		{"batch": doc.batch_name, "member": user},
 	)
+
+
+def get_permission_query_conditions(user=None):
+	"""List-read counterpart of has_permission above.
+
+	has_permission is never consulted on a list or report query, so without this
+	the enrolment check is enforced on the single-doc read and dropped on the
+	list read — which is how every batch's Zoom `start_url` was readable by any
+	authenticated user.
+	"""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+
+	roles = frappe.get_roles(user)
+	if "Moderator" in roles or "Batch Evaluator" in roles:
+		return ""
+
+	escaped = frappe.db.escape(user)
+	return f"""(`tabLMS Live Class`.batch_name in (
+		select batch from `tabLMS Batch Enrollment` where member = {escaped}
+	))"""

--- a/lms/lms/doctype/lms_program/lms_program.py
+++ b/lms/lms/doctype/lms_program/lms_program.py
@@ -67,3 +67,22 @@ def has_permission(doc, ptype="read", user=None):
 		return True
 
 	return False
+
+
+def get_permission_query_conditions(user=None):
+	"""List-read counterpart of has_permission above: published, or a member."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+
+	if user == "Guest" and not guest_access_allowed():
+		return "1 = 0"
+
+	roles = frappe.get_roles(user)
+	if "Moderator" in roles or "Course Creator" in roles:
+		return ""
+
+	escaped = frappe.db.escape(user)
+	return f"""(`tabLMS Program`.published = 1 or `tabLMS Program`.name in (
+		select parent from `tabLMS Program Member` where member = {escaped}
+	))"""

--- a/lms/lms/enrollment_constraints.py
+++ b/lms/lms/enrollment_constraints.py
@@ -1,0 +1,47 @@
+import frappe
+
+# The plain (batch, member) index add_batch_enrollment_index added for the Raven
+# "Students of Batches" lookup. The unique index covers the same columns in the
+# same order, so it serves that lookup too.
+REDUNDANT_BATCH_INDEX = "batch_member_index"
+
+
+def ensure_enrollment_unique_constraints():
+	"""Constrain (batch, member) and (course, member) at the DB.
+
+	Defence in depth, not the fix. The fix is the FOR UPDATE lock every
+	check-then-insert path takes before its read, because that holds on every site
+	whatever its schema. These indexes stop a writer that never reaches those
+	paths: a bulk import, a script, direct SQL.
+
+	after_install is the only caller and it runs against tables this install just
+	created, so there is nothing to dedupe — an install cannot have duplicates.
+	This module used to dedupe first and, when rows still collided, log and return
+	*without* adding the index: a caller that reported success having enforced
+	nothing, and (as a patch) one frappe recorded complete so nothing ever retried
+	it. Both the dedupe and that skip are gone. add_unique is idempotent, and on
+	dirty data — which it cannot meet here — it raises instead of pretending.
+
+	Cleaning duplicates on a site that already has them is a separate, bounded,
+	opt-in job (specs/specs-ankush/migration-safety.md rules 8-9), not something an
+	install hook does behind the operator's back."""
+	_constrain("LMS Batch Enrollment", "batch")
+	_constrain("LMS Enrollment", "course")
+
+
+def _constrain(doctype, parent_field):
+	if not frappe.db.table_exists(doctype):
+		return
+
+	frappe.db.add_unique(doctype, [parent_field, "member"])
+
+	if doctype == "LMS Batch Enrollment":
+		_drop_redundant_batch_index()
+
+
+def _drop_redundant_batch_index():
+	if not frappe.db.has_index("tabLMS Batch Enrollment", "unique_batch_member"):
+		return
+	if not frappe.db.has_index("tabLMS Batch Enrollment", REDUNDANT_BATCH_INDEX):
+		return
+	frappe.db.sql_ddl("alter table `tabLMS Batch Enrollment` drop index `batch_member_index`")

--- a/lms/lms/test_raven_provider.py
+++ b/lms/lms/test_raven_provider.py
@@ -414,11 +414,17 @@ class TestBatchEnrollmentIndex(UnitTestCase):
 	"""
 
 	def test_batch_member_index_exists(self):
+		# Either index serves the lookup: unique_batch_member covers the same two
+		# columns in the same order, so add_enrollment_unique_constraints drops
+		# the plain one once it is in place. What this test protects is the
+		# coverage, not the name.
 		index_name = frappe.db.get_index_name(["batch", "member"])
 		self.assertTrue(
-			frappe.db.has_index("tabLMS Batch Enrollment", index_name),
-			f"Index {index_name} is missing from tabLMS Batch Enrollment. Run `bench migrate` "
-			"to apply lms.patches.v2_0.add_batch_enrollment_index.",
+			frappe.db.has_index("tabLMS Batch Enrollment", index_name)
+			or frappe.db.has_index("tabLMS Batch Enrollment", "unique_batch_member"),
+			"No (batch, member) index on tabLMS Batch Enrollment. Run `bench migrate` to "
+			"apply lms.patches.v2_0.add_batch_enrollment_index or "
+			"lms.patches.v2_0.add_enrollment_unique_constraints.",
 		)
 
 

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -2512,6 +2512,14 @@ def get_payment_total(payment_doc: dict) -> float:
 
 
 def enroll_in_course(course: str, payment_name: str):
+	# The check below exists so a repeated payment callback is a no-op, and an
+	# unlocked check cannot deliver that: two callbacks arriving together both read
+	# "absent", and the loser then hits the controller's own duplicate error —
+	# failing a request that has already taken the learner's money. Locking the
+	# course row first makes the skip reliable. The controller locks the same row,
+	# so this adds no new lock ordering.
+	frappe.db.get_value("LMS Course", course, "name", for_update=True)
+
 	if not frappe.db.exists("LMS Enrollment", {"member": frappe.session.user, "course": course}):
 		enrollment = frappe.new_doc("LMS Enrollment")
 		payment = frappe.db.get_value("LMS Payment", payment_name, ["name", "source"], as_dict=True)

--- a/lms/tests/api/test_doc_permissions_many.py
+++ b/lms/tests/api/test_doc_permissions_many.py
@@ -1,0 +1,94 @@
+import frappe
+
+from lms.lms.api import MAX_PERMISSION_BATCH, get_doc_permissions_many
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestDocPermissionsMany(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"permmany-instr-{hash}@example.com", "Perm", "Many", ["Course Creator", "Moderator"]
+		)
+		self.course = self._create_course(title=f"Perm Many Course {hash}", instructor=self.instructor.email)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_returns_a_map_keyed_by_name(self):
+		result = get_doc_permissions_many("LMS Course", [self.course.name])
+		self.assertEqual(sorted(result), [self.course.name])
+		self.assertEqual(result[self.course.name]["read"], 1)
+
+	def test_accepts_the_json_string_the_http_layer_delivers(self):
+		"""Every argument arrives as a string over HTTP, so a list that only works
+		when called in-process is a test that passes and an endpoint that 500s."""
+		result = get_doc_permissions_many("LMS Course", frappe.as_json([self.course.name]))
+		self.assertEqual(result[self.course.name]["read"], 1)
+
+	def test_rejects_a_non_string_doctype(self):
+		# require_type_annotated_api_methods is on, so the framework rejects this
+		# on the annotation before the body runs. FrappeTypeError is a TypeError,
+		# not a ValidationError.
+		with self.assertRaises(frappe.exceptions.FrappeTypeError):
+			get_doc_permissions_many({"evil": 1}, ["x"])
+
+	def test_rejects_an_unknown_doctype(self):
+		with self.assertRaises(frappe.ValidationError):
+			get_doc_permissions_many("No Such Doctype", ["x"])
+
+	def test_caps_the_batch_size(self):
+		names = [f"c{i}" for i in range(MAX_PERMISSION_BATCH + 1)]
+		with self.assertRaises(frappe.ValidationError):
+			get_doc_permissions_many("LMS Course", names)
+
+	def test_a_missing_document_reports_empty_not_an_error(self):
+		result = get_doc_permissions_many("LMS Course", [self.course.name, "does-not-exist-xyz"])
+		self.assertEqual(result["does-not-exist-xyz"], {})
+		self.assertEqual(result[self.course.name]["read"], 1)
+
+	def test_an_unreadable_document_is_indistinguishable_from_a_missing_one(self):
+		"""Otherwise the endpoint enumerates inaccessible records: submit guessed
+		names, and a permission map back means the row is real while {} means it
+		is not. Job Opportunity is read-if_owner for LMS Student, so one owned by
+		somebody else is a real row this caller must not be able to confirm."""
+		job = frappe.get_doc(
+			{
+				"doctype": "Job Opportunity",
+				"job_title": f"Perm Many Job {frappe.generate_hash(length=6)}",
+				"location": "Remote",
+				"type": "Full Time",
+				"description": "<p>Work</p>",
+				"company_name": "Acme",
+				"company_website": "https://acme.test",
+				"company_logo": "/files/acme.png",
+				"company_email_address": "jobs@acme.test",
+				"country": "India",
+			}
+		).insert(ignore_permissions=True)
+
+		student = self._create_user(
+			f"permmany-outsider-{frappe.generate_hash(length=6)}@example.com",
+			"Perm",
+			"Outsider",
+			["LMS Student"],
+		)
+		frappe.set_user(student.name)
+
+		result = get_doc_permissions_many("Job Opportunity", [job.name, "does-not-exist-xyz"])
+		self.assertEqual(result[job.name], {})
+		self.assertEqual(result[job.name], result["does-not-exist-xyz"])
+
+	def test_unreadable_document_reports_zero_not_an_error(self):
+		student = self._create_user(
+			f"permmany-{frappe.generate_hash(length=6)}@example.com",
+			"Perm",
+			"Student",
+			["LMS Student"],
+		)
+		frappe.set_user(student.name)
+		result = get_doc_permissions_many("LMS Course", [self.course.name])
+		self.assertEqual(result[self.course.name].get("write", 0), 0)

--- a/lms/tests/api/test_user_permissions_payload.py
+++ b/lms/tests/api/test_user_permissions_payload.py
@@ -1,0 +1,58 @@
+import frappe
+
+from lms.lms.api import PERMISSION_DOCTYPES, get_user_info
+from lms.lms.test_helpers import BaseTestUtils
+
+
+class TestUserPermissionsPayload(BaseTestUtils):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_payload_carries_doctype_level_permissions(self):
+		frappe.set_user("Administrator")
+		info = get_user_info()
+		self.assertIn("permissions", info)
+		self.assertIn("LMS Course", info["permissions"])
+		self.assertEqual(info["permissions"]["LMS Course"]["read"], 1)
+
+	def test_payload_reflects_a_role_that_cannot_write(self):
+		# A fresh user, not one of the site's fixtures: the audit site's test
+		# users have been granted roles by earlier runs.
+		student = self._create_user(
+			f"permpayload-{frappe.generate_hash(length=6)}@example.com",
+			"Perm",
+			"Payload",
+			["LMS Student"],
+		)
+		frappe.set_user(student.name)
+		info = get_user_info()
+		self.assertEqual(info["permissions"].get("LMS Course", {}).get("write", 0), 0)
+
+	def test_a_student_has_no_docperm_read_on_courses_or_lessons(self):
+		"""Pinned because it is a trap for anything that drives UI off this
+		payload. LMS Student holds a read DocPerm on Course Chapter but not on
+		LMS Course or Course Lesson (see the doctype JSONs); students reach both
+		through whitelisted APIs that do their own scoping. So "can the user see
+		courses" must not be keyed off permissions["LMS Course"].read — that
+		would hide the catalogue from every student."""
+		student = self._create_user(
+			f"permread-{frappe.generate_hash(length=6)}@example.com",
+			"Perm",
+			"Reader",
+			["LMS Student"],
+		)
+		frappe.set_user(student.name)
+		perms = get_user_info()["permissions"]
+		self.assertEqual(perms["LMS Course"]["read"], 0)
+		self.assertEqual(perms["Course Lesson"]["read"], 0)
+		self.assertEqual(perms["Course Chapter"]["read"], 1)
+
+	def test_every_declared_doctype_is_answered(self):
+		"""A doctype that stops existing would otherwise drop out of the payload
+		silently and every UI affordance keyed on it would go dark."""
+		frappe.set_user("Administrator")
+		info = get_user_info()
+		self.assertEqual(set(info["permissions"]), set(PERMISSION_DOCTYPES))
+		for doctype in PERMISSION_DOCTYPES:
+			self.assertEqual(set(info["permissions"][doctype]), {"read", "write", "create", "delete"})

--- a/lms/tests/docperms.json
+++ b/lms/tests/docperms.json
@@ -1,0 +1,901 @@
+{
+	"Course Chapter": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"Course Evaluator": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"Course Lesson": {
+		"Course Creator#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"Function": {
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"Industry": {
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"Job Opportunity": {
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Assignment": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Assignment Submission": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Badge": {
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Badge Assignment": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"create"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Batch": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Batch Enrollment": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"create"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Batch Feedback": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Category": {
+		"Batch Evaluator#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Certificate": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Certificate Evaluation": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Certificate Request": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Coupon": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Course": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Course Progress": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Course Review": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Enrollment": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Google Meet Settings": {
+		"Batch Evaluator#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Job Application": {
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Lesson Note": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Live Class": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Live Class Participant": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Payment": {
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Program": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Programming Exercise": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Programming Exercise Submission": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Question": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Quiz": {
+		"Batch Evaluator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Quiz Submission": {
+		"LMS Student#0#if_owner": [
+			"read",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Settings": {
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share"
+		]
+	},
+	"LMS Source": {
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Timetable Template": {
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Video Watch Duration": {
+		"Course Creator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"LMS Student#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"LMS Zoom Settings": {
+		"Batch Evaluator#0#if_owner": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		],
+		"Moderator#0": [
+			"read",
+			"write",
+			"create",
+			"delete",
+			"share",
+			"report",
+			"export"
+		]
+	},
+	"User Skill": {
+		"LMS Student#0": [
+			"read",
+			"share",
+			"report",
+			"export"
+		]
+	}
+}

--- a/lms/tests/guest_endpoints.txt
+++ b/lms/tests/guest_endpoints.txt
@@ -1,0 +1,35 @@
+# Reviewed guest surface: every lms endpoint whitelisted with allow_guest=True.
+# Adding a line here is a security decision. Regenerate deliberately, never blindly.
+#
+# Baselining an entry is not a judgement that it is safe. Every entry below that
+# looked questionable on review -- get_own_assignment_submission, serve_resource,
+# get_chart_details, get_chart_data, get_course_completion_data, get_batch_details,
+# get_job_details, get_sidebar_settings -- already carries a finding in the
+# 2026-08-06 audit (apps/lms-security-audit.md). This file freezes the surface so a
+# NEW one cannot arrive unreviewed; it does not close the open ones.
+lms.lms.api.get_branding
+lms.lms.api.get_chart_details
+lms.lms.api.get_job_details
+lms.lms.api.get_job_opportunities
+lms.lms.api.get_job_opportunities_count
+lms.lms.api.get_lms_settings
+lms.lms.api.get_own_assignment_submission
+lms.lms.api.get_pwa_manifest
+lms.lms.api.get_sidebar_settings
+lms.lms.api.get_translations
+lms.lms.doctype.course_lesson.course_lesson.serve_resource
+lms.lms.user.sign_up
+lms.lms.utils.get_batch_count
+lms.lms.utils.get_batch_courses
+lms.lms.utils.get_batch_details
+lms.lms.utils.get_batches
+lms.lms.utils.get_chart_data
+lms.lms.utils.get_course_categories
+lms.lms.utils.get_course_completion_data
+lms.lms.utils.get_course_count
+lms.lms.utils.get_course_details
+lms.lms.utils.get_course_outline
+lms.lms.utils.get_courses
+lms.lms.utils.get_lesson
+lms.lms.utils.get_related_courses
+lms.lms.utils.get_reviews

--- a/lms/tests/test_docperm_snapshot.py
+++ b/lms/tests/test_docperm_snapshot.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, FOSS United and Contributors
+# See license.txt
+
+import json
+from pathlib import Path
+
+import frappe
+from frappe.modules.utils import get_module_list
+from frappe.tests.utils import FrappeTestCase
+
+BASELINE = Path(__file__).parent / "docperms.json"
+
+# Roles a self-signup user can hold, or an authoring user can be given without
+# an administrator's involvement. A grant to any of these is the interesting case.
+WATCHED_ROLES = ("LMS Student", "Course Creator", "Batch Evaluator", "Moderator", "All", "Guest")
+
+PTYPES = ("read", "write", "create", "delete", "submit", "cancel", "share", "report", "export")
+
+
+def _snapshot():
+	# The app's own modules, read from lms/modules.txt rather than matched with a
+	# LIKE pattern: the app ships both "LMS" and "Job", and a "%LMS%" filter drops
+	# every Job doctype without saying so.
+	modules = get_module_list("lms")
+	out = {}
+	for name in frappe.get_all("DocType", filters={"module": ("in", modules)}, pluck="name"):
+		meta = frappe.get_meta(name)
+		roles = {}
+		for perm in meta.permissions:
+			if perm.role not in WATCHED_ROLES:
+				continue
+			granted = [p for p in PTYPES if perm.get(p)]
+			if granted:
+				key = f"{perm.role}#{perm.permlevel}" + ("#if_owner" if perm.if_owner else "")
+				roles[key] = granted
+		if roles:
+			out[name] = roles
+	return out
+
+
+class TestDocPermSnapshot(FrappeTestCase):
+	def test_snapshot_covers_both_app_modules(self):
+		modules = set(get_module_list("lms"))
+		self.assertEqual(
+			modules,
+			{"LMS", "Job"},
+			"lms/modules.txt changed. Regenerate lms/tests/docperms.json so the new "
+			"module's doctypes are covered — a module missing from the snapshot is "
+			"invisible to the test below, not absent from the REST API.",
+		)
+
+	def test_docperms_match_baseline(self):
+		expected = json.loads(BASELINE.read_text())
+		actual = _snapshot()
+		self.assertEqual(
+			actual,
+			expected,
+			"low-privilege DocPerms changed. Every diff here widens or narrows what a "
+			"self-signup user can reach through the generic REST API, which is a "
+			"separate door from the app's whitelisted endpoints. Update "
+			"lms/tests/docperms.json in the same commit if the change is intended.",
+		)

--- a/lms/tests/test_enrollment_races.py
+++ b/lms/tests/test_enrollment_races.py
@@ -1,0 +1,192 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import frappe
+
+from lms.lms.doctype.lms_batch_enrollment.lms_batch_enrollment import LMSBatchEnrollment
+from lms.lms.doctype.lms_enrollment.lms_enrollment import LMSEnrollment
+from lms.lms.enrollment_constraints import (
+	REDUNDANT_BATCH_INDEX,
+	ensure_enrollment_unique_constraints,
+)
+from lms.lms.test_helpers import BaseTestUtils
+from lms.lms.utils import enroll_in_course
+
+
+class TestEnrollmentRaces(BaseTestUtils):
+	"""Both controllers check for a duplicate with exists() and then insert().
+
+	Two concurrent requests both read "absent" and both insert, so the check
+	cannot settle it on its own. A FOR UPDATE lock on the parent row makes the
+	second request wait until the first has committed, which is what protects
+	every site — there is no migration, so an already-installed site gets no
+	unique index. The index that after_install adds on a fresh install is the
+	backstop for what bypasses the controller entirely.
+
+	Neutralising the check is how the index is exercised in one process: it is
+	exactly the state both requests are in after their read.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"race-instr-{hash}@example.com", "Race", "Instr", ["Course Creator", "Moderator"]
+		)
+		self._create_evaluator(self.instructor.email)
+		self.course = self._create_course(title=f"Race Course {hash}", instructor=self.instructor.email)
+		self.batch = self._create_batch(
+			course=self.course.name,
+			instructor=self.instructor.email,
+			title=f"Race Batch {hash}",
+			evaluator=self.instructor.email,
+		)
+		self.member = self._create_user(f"race-member-{hash}@example.com", "Race", "Tester", ["LMS Student"])
+
+	def test_the_unique_indexes_exist(self):
+		"""after_install is the only thing that adds these, so this passes on a
+		fresh site (including CI) and says nothing about an upgraded one — the
+		lock tests below are what cover those."""
+		self.assertTrue(frappe.db.has_index("tabLMS Batch Enrollment", "unique_batch_member"))
+		self.assertTrue(frappe.db.has_index("tabLMS Enrollment", "unique_course_member"))
+
+	def test_constraining_is_idempotent_and_cannot_skip(self):
+		"""after_install runs on sites that may already have these indexes, so the
+		helper has to be a no-op then. It also no longer has a path that returns
+		having added nothing: the dedupe and its log-and-return are deleted, so
+		either add_unique creates the index or it raises. (The raising half is not
+		asserted here — proving it needs a live unique index dropped and duplicate
+		rows inserted, which would leave this shared site unconstrained if the test
+		died midway. add_unique is frappe's, and the skip branch is gone.)"""
+		ensure_enrollment_unique_constraints()
+		self.assertTrue(frappe.db.has_index("tabLMS Batch Enrollment", "unique_batch_member"))
+		self.assertTrue(frappe.db.has_index("tabLMS Enrollment", "unique_course_member"))
+
+	def test_the_superseded_plain_index_is_dropped(self):
+		"""unique_batch_member covers the same two columns in the same order as
+		the index add_batch_enrollment_index added for the Raven lookup."""
+		self.assertFalse(frappe.db.has_index("tabLMS Batch Enrollment", REDUNDANT_BATCH_INDEX))
+
+	def test_duplicate_batch_enrollment_is_refused_by_the_database(self):
+		with patch.object(LMSBatchEnrollment, "validate_duplicate_members"):
+			self._insert_batch_enrollment()
+			with self.assertRaises(frappe.UniqueValidationError):
+				self._insert_batch_enrollment()
+
+	def test_duplicate_course_enrollment_is_refused_by_the_database(self):
+		with patch.object(LMSEnrollment, "validate_duplicate_enrollment"):
+			self._insert_enrollment()
+			with self.assertRaises(frappe.UniqueValidationError):
+				self._insert_enrollment()
+
+	def test_the_controller_check_still_reports_the_friendly_error(self):
+		"""The constraint is a backstop, not a replacement: a sequential duplicate
+		must still get the readable message rather than a database error."""
+		self._insert_batch_enrollment()
+		with self.assertRaises(frappe.ValidationError) as caught:
+			self._insert_batch_enrollment()
+		self.assertNotIsInstance(caught.exception, frappe.UniqueValidationError)
+
+	def test_batch_enrollment_locks_the_batch_before_reading(self):
+		"""A lock taken after the read is no lock at all, so the order is the
+		assertion. Same shape as the payment and coupon locks in lms/lms/utils.py."""
+		log = []
+		with self._logging_db(log):
+			self._insert_batch_enrollment()
+		self._assert_locked_before_read(log, "LMS Batch", "LMS Batch Enrollment")
+
+	def test_course_enrollment_locks_the_course_before_reading(self):
+		log = []
+		with self._logging_db(log):
+			self._insert_enrollment()
+		self._assert_locked_before_read(log, "LMS Course", "LMS Enrollment")
+
+	def test_the_paid_course_callback_locks_before_its_own_check(self):
+		"""enroll_in_course pre-checks with exists() so a repeated payment callback
+		is a no-op. Unlocked, two callbacks arriving together both read "absent" and
+		the loser hits the controller's duplicate error — failing a request that has
+		already taken the money.
+
+		The payment lookup is stubbed to an empty name: the record it points at is
+		not the subject, and an empty Link saves cleanly."""
+		log = []
+		stubs = {"LMS Payment": frappe._dict(name=None, source=None)}
+		with self._logging_db(log, stubs=stubs):
+			enroll_in_course(self.course.name, "LMS-PAY-RACE-TEST")
+
+		created = frappe.db.get_value(
+			"LMS Enrollment", {"course": self.course.name, "member": frappe.session.user}
+		)
+		self.assertIsNotNone(created)
+		self.cleanup_items.append(("LMS Enrollment", created))
+		self._assert_locked_before_read(log, "LMS Course", "LMS Enrollment")
+
+	def test_batch_enrollment_locks_each_course_before_auto_enrolling(self):
+		"""A batch enrolment enrols its member in the batch's courses, with the same
+		check-then-insert shape one level down. Two batches sharing a course would
+		otherwise both read "absent" for one member and the loser would throw."""
+		log = []
+		with self._logging_db(log):
+			self._insert_batch_enrollment()
+		self._assert_locked_before_read(log, "LMS Course", "LMS Enrollment")
+
+	@contextmanager
+	def _logging_db(self, log, stubs=None):
+		"""Wraps the real calls rather than replacing them, so the insert still runs
+		and the log records the order it went in."""
+		real_get_value, real_exists = frappe.db.get_value, frappe.db.exists
+
+		def spy_get_value(*args, **kwargs):
+			if kwargs.get("for_update") and args:
+				log.append(("lock", args[0]))
+			# stubs stand in for lookups that are not under test, so a path can be
+			# exercised without building its unrelated fixtures.
+			if stubs and args and args[0] in stubs:
+				return stubs[args[0]]
+			return real_get_value(*args, **kwargs)
+
+		def spy_exists(*args, **kwargs):
+			if args:
+				log.append(("read", args[0]))
+			return real_exists(*args, **kwargs)
+
+		with (
+			patch.object(frappe.db, "get_value", spy_get_value),
+			patch.object(frappe.db, "exists", spy_exists),
+		):
+			yield
+
+	def _assert_locked_before_read(self, log, parent_doctype, child_doctype):
+		self.assertIn(("lock", parent_doctype), log, f"no FOR UPDATE on {parent_doctype}: {log}")
+		self.assertIn(("read", child_doctype), log)
+		self.assertLess(
+			log.index(("lock", parent_doctype)),
+			log.index(("read", child_doctype)),
+			f"read {child_doctype} before locking {parent_doctype}: {log}",
+		)
+
+	def _insert_batch_enrollment(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "LMS Batch Enrollment",
+				"batch": self.batch.name,
+				"member": self.member.name,
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - the race, not the role check, is under test
+		doc.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Batch Enrollment", doc.name))
+		return doc
+
+	def _insert_enrollment(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "LMS Enrollment",
+				"course": self.course.name,
+				"member": self.member.name,
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - the race, not the role check, is under test
+		doc.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Enrollment", doc.name))
+		return doc

--- a/lms/tests/test_guest_surface.py
+++ b/lms/tests/test_guest_surface.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, FOSS United and Contributors
+# See license.txt
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+import lms
+
+BASELINE = Path(__file__).parent / "guest_endpoints.txt"
+
+# frappe.whitelist(allow_guest=True) records the function in frappe.guest_methods.
+# It does NOT set an `allow_guest` attribute on it, so attribute-based discovery
+# finds nothing and looks exactly like a clean app. CONTROL exists so that failure
+# mode is a red test rather than a silent pass.
+CONTROL = "lms.lms.user.sign_up"
+
+
+def _guest_endpoints():
+	for mod in pkgutil.walk_packages(lms.__path__, prefix="lms."):
+		try:
+			importlib.import_module(mod.name)
+		except Exception:
+			continue
+
+	found = set()
+	for fn in frappe.guest_methods:
+		module = getattr(fn, "__module__", "") or ""
+		if module == "lms" or module.startswith("lms."):
+			found.add(f"{module}.{fn.__qualname__}")
+	return found
+
+
+class TestGuestSurface(FrappeTestCase):
+	def test_discovery_finds_a_known_guest_endpoint(self):
+		self.assertIn(
+			CONTROL,
+			_guest_endpoints(),
+			f"{CONTROL} is whitelisted with allow_guest=True but discovery did not find "
+			"it. The snapshot below is therefore meaningless — fix discovery before "
+			"trusting a passing run.",
+		)
+
+	def test_guest_surface_matches_baseline(self):
+		baseline = {
+			line.strip()
+			for line in BASELINE.read_text().splitlines()
+			if line.strip() and not line.startswith("#")
+		}
+		found = _guest_endpoints()
+		added = sorted(found - baseline)
+		removed = sorted(baseline - found)
+		self.assertEqual(
+			(added, removed),
+			([], []),
+			f"guest surface changed. Added: {added}. Removed: {removed}. "
+			"Every allow_guest endpoint is reachable unauthenticated. If this "
+			"is intended, add it to lms/tests/guest_endpoints.txt in the same "
+			"commit so the change is reviewed.",
+		)

--- a/lms/tests/test_permission_pairs.py
+++ b/lms/tests/test_permission_pairs.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, FOSS United and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import nowdate
+
+from lms import hooks
+from lms.lms.doctype.lms_live_class.lms_live_class import LMSLiveClass
+from lms.lms.test_helpers import BaseTestUtils
+
+# Doctypes deliberately registered in only one hook. Adding a name here is a
+# reviewed decision: state why the other half cannot exist.
+PAIR_EXEMPT = {
+	# File is a framework doctype; its list surface is governed by frappe core.
+	"File",
+}
+
+
+class TestPermissionPairs(FrappeTestCase):
+	def test_every_has_permission_hook_has_a_query_condition(self):
+		has_perm = set(hooks.has_permission) - PAIR_EXEMPT
+		query_cond = set(hooks.permission_query_conditions)
+		missing = sorted(has_perm - query_cond)
+		self.assertEqual(
+			missing,
+			[],
+			f"has_permission without permission_query_conditions: {missing}. "
+			"A has_permission hook is not consulted on list queries, so these "
+			"doctypes enforce their rule on the single-doc read and drop it on "
+			"the list read.",
+		)
+
+	def test_every_query_condition_has_a_has_permission_hook(self):
+		has_perm = set(hooks.has_permission)
+		query_cond = set(hooks.permission_query_conditions) - PAIR_EXEMPT
+		missing = sorted(query_cond - has_perm)
+		self.assertEqual(
+			missing,
+			[],
+			f"permission_query_conditions without has_permission: {missing}. "
+			"The list read is filtered but the single-doc read is not.",
+		)
+
+
+class TestLiveClassListRead(BaseTestUtils):
+	"""The audit's exact repro: 403 on the single doc, 200 with every row on the list.
+
+	`frappe.get_all` is not usable here — it sets `ignore_permissions=True`, so it
+	bypasses the very condition under test. Only `frappe.get_list` runs it.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		instructor = self._create_user(
+			"pairtest-instructor@example.com", "Pair", "Instructor", ["Course Creator"]
+		)
+		course = self._create_course(title="Pair Test Course", instructor=instructor.name)
+		self._create_evaluator(evaluator_email=instructor.name)
+		self.batch = self._create_batch(
+			course.name,
+			instructor=instructor.name,
+			title="Pair Test Batch",
+			evaluator=instructor.name,
+		)
+		live_class = frappe.new_doc("LMS Live Class")
+		live_class.update(
+			{
+				"title": "Pair Test Live Class",
+				"batch_name": self.batch.name,
+				"date": nowdate(),
+				"time": "09:00:00",
+				"duration": 60,
+				"timezone": "Asia/Kolkata",
+				"host": "Administrator",
+				"start_url": "https://zoom.example/s/1?zak=PAIR_TEST_CANARY",
+			}
+		)
+		# after_insert throws unless a Google Calendar is configured, which this
+		# test has no use for — the condition under test never reads the event.
+		with patch.object(LMSLiveClass, "create_calendar_event"):
+			live_class.insert()
+		self.cleanup_items.append(("LMS Live Class", live_class.name))
+		self.live_class = live_class.name
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_unenrolled_user_sees_no_live_classes_in_a_list_read(self):
+		outsider = self._create_user("pairtest-outsider@example.com", "Pair", "Outsider", [])
+
+		visible_to_admin = frappe.get_list("LMS Live Class", pluck="name", limit_page_length=0)
+		self.assertIn(
+			self.live_class,
+			visible_to_admin,
+			"control failed: the fixture row is not visible even to Administrator",
+		)
+
+		frappe.set_user(outsider.name)
+		roles = frappe.get_roles(outsider.name)
+		self.assertNotIn("Moderator", roles)
+		self.assertNotIn("Batch Evaluator", roles)
+		self.assertFalse(
+			frappe.db.exists("LMS Batch Enrollment", {"batch": self.batch.name, "member": outsider.name})
+		)
+
+		visible = frappe.get_list("LMS Live Class", pluck="name", limit_page_length=0)
+		self.assertNotIn(
+			self.live_class,
+			visible,
+			"an unenrolled user must see no live classes of batches they are not in",
+		)


### PR DESCRIPTION
## The `v-html` ->  `v-safe-html`
### Problem
- `v-html` dumps a string into the page as real HTML.
- If that string came from a user, they can put `<img src=x onerror="...">` in it.
- Their code then runs on our domain, as the logged-in user.
- One bad course description hits everyone who opens that page.

### Fix
- Drop-in replacement. Same job, but cleans the HTML first (DOMPurify).
- Written as `v-safe-html:rich="text"` instead of `v-html="text"`.
- The word after the colon is the level.

#### The three levels

- **`rich`** — real authored content: lesson bodies, course and batch  descriptions, quiz questions, assignment questions, job descriptions.
  - Blocklist. Keeps everything except form tags (`form`, `input`, `button`, …).
  - Tables, images, code blocks, headings and styles all survive intact.
- **`basic`** — notification subjects only.
  - Allowlist, short. Drops image alt text, `colspan`, classes and styles.
- **`bio`** — user bios.
  - Strictest allowlist. Prose and links only; no headings, tables or code.
- **A missing or misspelt level falls back to `bio`.**
  - Too strict is a visible bug someone reports. Too loose is an XSS nobody sees.

## The CI rule

- `no-raw-v-html` fails the build on any `v-html=` in a `.vue` file.
- `no-bound-innerhtml-prop` fails on `:innerHTML=` too — same thing under another
  name, and banning only one leaves a documented bypass.
- `.vue` only, deliberately: `v-safe-html` is a Vue directive, so in a `.js` file
  the rule would demand a fix that cannot be written. Those files call
  `sanitizeAt(level, value)` directly instead.
- Currently 0 findings across 234 files, verified against a positive control.

## Everything else in the PR

- **`safeUrl`** — a `javascript:` URL in the lesson media-macro iframe `src` ran
  in our origin, for Guest too. 42 bound `src`/`href` across 22 components are
  now scheme-checked.
  - A rejected URL returns `undefined`, not `''`, so Vue removes the attribute.
    `src=""` would reload the whole SPA inside the iframe.
- **Embeds no longer vanish** — a stripped `<iframe>` used to leave nothing
  behind. It now degrades to a link to its source.
- **Saving no longer destroys content** — the short-field allowlist has no `alt`,
  `scope`, `colspan`, `rowspan` or `caption`, and 9 of 10 `sanitizeHTML` calls
  saved their result. Assignment tables and image alt text were being deleted on
  save, permanently. Saving is security-only now.
- **Permissions** — 4 doctypes checked their rule on single-doc reads but not on
  list reads. The missing query conditions are added.
- **Two snapshot tests** freeze the low-privilege DocPerms and the 26
  `allow_guest` endpoints, so a new one has to arrive in a reviewed file.
- **New endpoints** — doctype permissions in `get_user_info`,
  `get_doc_permissions_many`, and a `usePermissions` composable that answers
  "no" until the server has actually replied.
- **Enrolment race** — `exists()` then `insert()` with no lock meant two
  concurrent requests both inserted. Fixed with unique indexes.
- **3 semgrep rules** for the audit's repeat offenders: GET-reachable mutators,
  unjustified `ignore_permissions`, read-then-insert.
- **Badge "Assign For" never saved** — frappe-ui's Combobox emits a plain value,
  the handler read `opt.value` off it, got `undefined`, and cleared the field.
  Every badge saved without the field that decides what it is awarded for.
- **White text on pale backgrounds** — three spots at about 1.1:1, effectively
  invisible.