### PR TITLE
feat(i18n): add Slovak language support and complete Czech translations

### DIFF
--- a/lms/locale/sk.po
+++ b/lms/locale/sk.po
@@ -1,14 +1,14 @@
-
+# Slovak translations for Frappe Learning.
 msgid ""
 msgstr ""
-"Project-Id-Version:  frappe\n"
+"Project-Id-Version: Frappe Learning frappe\n"
 "Report-Msgid-Bugs-To: jannat@frappe.io\n"
 "POT-Creation-Date: 2026-07-03 16:31+0000\n"
-"PO-Revision-Date: 2026-07-06 08:41+0000\n"
+"PO-Revision-Date: 2026-08-12 19:10+0000\n"
 "Last-Translator: vavrecan@gmail.com\n"
-"Language: cs_CZ\n"
-"Language-Team: Czech\n"
-"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 3;\n"
+"Language: sk_SK\n"
+"Language-Team: Slovak\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -16,23 +16,25 @@ msgstr ""
 
 #: lms/templates/emails/assignment_submission.html:5
 msgid " Please evaluate and grade it."
-msgstr " Vyhodnoťte jej a oznámkujte."
+msgstr " Prosím, vyhodnoťte ho a oznámkujte."
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:27
 msgid ""
-" designed as a learning path to guide your progress. You may take the courses in any order that "
-"suits you. "
+" designed as a learning path to guide your progress. You may take the "
+"courses in any order that suits you. "
 msgstr ""
-" a slouží jako studijní cesta, která vás povede při studiu. Kurzy můžete absolvovat v libovolném "
-"pořadí, které vám vyhovuje. "
+" a slúži ako študijná cesta, ktorá vás bude sprevádzať pri napredovaní. "
+"Kurzy môžete absolvovať v ľubovoľnom poradí, ktoré vám vyhovuje. "
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:20
 msgid ""
-" designed as a structured learning path to guide your progress. Courses in this program must be "
-"taken in order, and each course will unlock as you complete the previous one. "
+" designed as a structured learning path to guide your progress. Courses in "
+"this program must be taken in order, and each course will unlock as you "
+"complete the previous one. "
 msgstr ""
-" a tvoří strukturovanou studijní cestu, která vás povede při studiu. Kurzy v tomto programu je "
-"nutné absolvovat v daném pořadí; každý další kurz se odemkne po dokončení předchozího. "
+" a tvorí štruktúrovanú študijnú cestu, ktorá vás bude sprevádzať pri "
+"napredovaní. Kurzy v tomto programe je potrebné absolvovať v určenom poradí;"
+" každý ďalší kurz sa odomkne po dokončení predchádzajúceho. "
 
 #: lms/templates/emails/published_batch_notification.html:19
 msgid " to "
@@ -40,49 +42,51 @@ msgstr " až "
 
 #: frontend/src/pages/Home/Streak.vue:16
 msgid " you are on a"
-msgstr " právě máte"
+msgstr " práve máte"
 
 #. Paragraph text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<a href=\"/app/lms-settings/LMS%20Settings\">LMS Settings</a>"
-msgstr "<a href=\"/app/lms-settings/LMS%20Settings\">Nastavení LMS</a>"
+msgstr "<a href=\"/app/lms-settings/LMS%20Settings\">Nastavenia LMS</a>"
 
 #. Paragraph text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<a href=\"/app/web-page/new-web-page-1\">Setup a Home Page</a>"
-msgstr "<a href=\"/app/web-page/new-web-page-1\">Nastavit domovskou stránku</a>"
+msgstr "<a href=\"/app/web-page/new-web-page-1\">Nastaviť domovskú stránku</a>"
 
 #. Paragraph text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<a href=\"/lms/courses\">Visit LMS Portal</a>"
-msgstr "<a href=\"/lms/courses\">Navštívit portál LMS</a>"
+msgstr "<a href=\"/lms/courses\">Navštíviť portál LMS</a>"
 
 #. Paragraph text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<a href=\"/lms/courses/new/edit\">Create a Course</a>"
-msgstr "<a href=\"/lms/courses/new/edit\">Vytvořit kurz</a>"
+msgstr "<a href=\"/lms/courses/new/edit\">Vytvoriť kurz</a>"
 
 #. Paragraph text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<a href=\"https://docs.frappe.io/learning\">Documentation</a>"
-msgstr "<a href=\"https://docs.frappe.io/learning\">Dokumentace</a>"
+msgstr "<a href=\"https://docs.frappe.io/learning\">Dokumentácia</a>"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:48
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:106
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:105
 msgid ""
-"<p>Dear {{ member_name }},</p>\\n\\n<p>You have been enrolled in our upcoming batch {{ batch_name"
-" }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappe Learning</p>"
+"<p>Dear {{ member_name }},</p>\\n\\n<p>You have been enrolled in our "
+"upcoming batch {{ batch_name }}.</p>\\n\\n<p>Thanks,</p>\\n<p>Frappe "
+"Learning</p>"
 msgstr ""
-"<p>Dobrý den, {{ member_name }},</p>\\n\\n<p>byli jste zapsáni do našeho nadcházejícího školicího"
-" kola {{ batch_name }}.</p>\\n\\n<p>Děkujeme,</p>\\n<p>Frappe Learning</p>"
+"<p>Dobrý deň, {{ member_name }},</p>\\n\\n<p>Boli ste zapísaní do nášho "
+"nadchádzajúceho školiaceho kola {{ batch_name "
+"}}.</p>\\n\\n<p>Ďakujeme,</p>\\n<p>Frappe Learning</p>"
 
 
 
 #. Header text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<span class=\"h4\"><b>Get Started</b></span>"
-msgstr "<span class=\"h4\"><b>Začínáme</b></span>"
+msgstr "<span class=\"h4\"><b>Začíname</b></span>"
 
 #. Header text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
@@ -92,53 +96,58 @@ msgstr "<span class=\"h4\"><b>Pokročilé</b></span>"
 #. Header text in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "<span style=\"font-size: 18px;\"><b>Statistics</b></span>"
-msgstr "<span style=\"font-size: 18px;\"><b>Statistiky</b></span>"
+msgstr "<span style=\"font-size: 18px;\"><b>Štatistiky</b></span>"
 
 #: lms/lms/doctype/lms_course/lms_course.py:78
 msgid "A course cannot have both paid certificate and certificate of completion."
-msgstr "Kurz nemůže současně nabízet placený certifikát i certifikát o absolvování."
+msgstr "Kurz nemôže súčasne ponúkať platený certifikát aj certifikát o absolvovaní."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:218
 msgid "A new batch '{0}' has been published that might interest you. Check it out!"
-msgstr "Bylo zveřejněno nové školicí kolo „{0}“, které by vás mohlo zajímat. Podívejte se na něj!"
+msgstr ""
+"Bolo zverejnené nové školiace kolo „{0}“, ktoré by vás mohlo zaujímať. "
+"Pozrite si ho!"
+
 
 #: lms/templates/emails/published_batch_notification.html:7
 msgid "A new batch has been published on "
-msgstr "Bylo zveřejněno nové školicí kolo na platformě "
+msgstr "Bolo zverejnené nové školiace kolo na platforme "
 
 #: lms/lms/doctype/lms_course/lms_course.py:212
 msgid "A new course '{0}' has been published that might interest you. Check it out!"
-msgstr "Byl zveřejněn nový kurz „{0}“, který by vás mohl zajímat. Podívejte se na něj!"
+msgstr "Bol zverejnený nový kurz „{0}“, ktorý by vás mohol zaujímať. Pozrite si ho!"
 
 #: lms/templates/emails/published_course_notification.html:7
 msgid "A new course has been published on "
-msgstr "Byl zveřejněn nový kurz na platformě "
+msgstr "Bol zverejnený nový kurz na platforme "
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:180
 #: lms/lms/doctype/lms_course/lms_course.py:176
 msgid "A new course has been published on {0}"
-msgstr "Na platformě {0} byl zveřejněn nový kurz"
+msgstr "Na platforme {0} bol zverejnený nový kurz"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:62
 msgid "A short summary of the course for search results."
-msgstr "Krátké shrnutí kurzu pro výsledky vyhledávání."
+msgstr "Krátke zhrnutie kurzu pre výsledky vyhľadávania."
 
 #: frontend/src/pages/Profile.vue:261 frontend/src/pages/ProfileAbout.vue:4
 msgid "About"
-msgstr "O mně"
+msgstr "O mne"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:124
 msgid "About this course"
-msgstr "O tomto kurzu"
+msgstr "O tomto kurze"
 
 #. Label of the verify_terms (Check) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Acceptance for Terms and/or Policies"
-msgstr "Souhlas s podmínkami a/nebo zásadami"
+msgstr "Súhlas s podmienkami a/alebo zásadami"
 
 #: frontend/src/pages/ProfileRoles.vue:20
 msgid "Access courses, join batches, and track learning progress"
-msgstr "Přístup ke kurzům, připojení ke školicím kolům a sledování průběhu studia"
+msgstr ""
+"Prístup ku kurzom, pripájanie sa ku školiacim kolám a sledovanie pokroku "
+"v štúdiu"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:170
 msgid "Account"
@@ -161,23 +170,23 @@ msgstr "ID účtu"
 #: lms/lms/doctype/lms_google_meet_settings/lms_google_meet_settings.json
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 msgid "Account Name"
-msgstr "Název účtu"
+msgstr "Názov účtu"
 
 #: frontend/src/pages/ProfileAbout.vue:34
 msgid "Achievements"
-msgstr "Úspěchy"
+msgstr "Úspechy"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:19
 msgid "Activate this Google Meet account for scheduling meetings."
-msgstr "Aktivovat tento účet Google Meet pro plánování schůzek."
+msgstr "Aktivovať tento účet Google Meet na plánovanie stretnutí."
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:18
 msgid "Activate this Zoom account for scheduling meetings."
-msgstr "Aktivovat tento účet Zoom pro plánování schůzek."
+msgstr "Aktivovať tento účet Zoom na plánovanie stretnutí."
 
 #: frontend/src/pages/Statistics.vue:22
 msgid "Active Members"
-msgstr "Aktivní členové"
+msgstr "Aktívni členovia"
 
 #: frontend/src/components/CourseOutline.vue:21
 #: frontend/src/components/Modals/NewMemberModal.vue:8
@@ -191,109 +200,109 @@ msgstr "Aktivní členové"
 #: frontend/src/pages/Programs/ProgramForm.vue:126
 #: frontend/src/pages/Programs/ProgramForm.vue:175
 msgid "Add"
-msgstr "Přidat"
+msgstr "Pridať"
 
 #: frontend/src/components/CreateOutline.vue:18
 #: frontend/src/components/Modals/ChapterModal.vue:4
 msgid "Add Chapter"
-msgstr "Přidat kapitolu"
+msgstr "Pridať kapitolu"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:170
 msgid "Add Course to Program"
-msgstr "Přidat kurz do programu"
+msgstr "Pridať kurz do programu"
 
 #: frontend/src/components/ChapterRow.vue:139
 msgid "Add Lesson"
-msgstr "Přidat lekci"
+msgstr "Pridať lekciu"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:4
 msgid "Add New Member"
-msgstr "Přidat nového člena"
+msgstr "Pridať nového člena"
 
 #: frontend/src/components/Modals/Question.vue:102
 msgid "Add Option"
-msgstr "Přidat možnost"
+msgstr "Pridať možnosť"
 
 #: frontend/src/components/Modals/Question.vue:135
 msgid "Add Possibility"
-msgstr "Přidat možnou odpověď"
+msgstr "Pridať možnú odpoveď"
 
 #: frontend/src/pages/QuizForm.vue:250
 msgid "Add Question"
-msgstr "Přidat otázku"
+msgstr "Pridať otázku"
 
 #: frontend/src/components/VideoBlock.vue:130
 msgid "Add Quiz to Video"
-msgstr "Přidat kvíz do videa"
+msgstr "Pridať kvíz do videa"
 
 #: frontend/src/components/Controls/ChildTable.vue:75
 #: frontend/src/components/Settings/Coupons/CouponItems.vue:64
 msgid "Add Row"
-msgstr "Přidat řádek"
+msgstr "Pridať riadok"
 
 #: frontend/src/pages/ProfileEvaluator.vue:96
 msgid "Add Slot"
-msgstr "Přidat termín"
+msgstr "Pridať termín"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:40
 msgid "Add Test Case"
-msgstr "Přidat testovací případ"
+msgstr "Pridať testovací prípad"
 
 #: lms/templates/onboarding_header.html:26
 msgid "Add a Chapter"
-msgstr "Přidat kapitolu"
+msgstr "Pridať kapitolu"
 
 #: lms/templates/onboarding_header.html:33
 msgid "Add a Lesson"
-msgstr "Přidat lekci"
+msgstr "Pridať lekciu"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:590
 msgid "Add a chapter"
-msgstr "Přidat kapitolu"
+msgstr "Pridať kapitolu"
 
 #: frontend/src/components/Modals/BatchCourseModal.vue:4
 msgid "Add a course to the batch"
-msgstr "Přidat kurz do školicího kola"
+msgstr "Pridať kurz do školiaceho kola"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:591
 msgid "Add a lesson"
-msgstr "Přidat lekci"
+msgstr "Pridať lekciu"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:605
 msgid "Add a program"
-msgstr "Přidat program"
+msgstr "Pridať program"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseModal.vue:4
 msgid "Add a programming exercise to your lesson"
-msgstr "Přidat do lekce programovací cvičení"
+msgstr "Pridať do lekcie programovacie cvičenie"
 
 #: frontend/src/pages/QuizForm.vue:129
 msgid "Add a question to get started."
-msgstr "Začněte přidáním otázky."
+msgstr "Začnite pridaním otázky."
 
 #: frontend/src/components/AssessmentPlugin.vue:6
 msgid "Add a quiz to your lesson"
-msgstr "Přidat do lekce kvíz"
+msgstr "Pridať do lekcie kvíz"
 
 #: frontend/src/components/Modals/AssessmentModal.vue:4
 msgid "Add an assessment"
-msgstr "Přidat hodnocení"
+msgstr "Pridať hodnotenie"
 
 #: frontend/src/components/AssessmentPlugin.vue:7
 msgid "Add an assignment to your lesson"
-msgstr "Přidat do lekce úkol"
+msgstr "Pridať do lekcie úlohu"
 
 #: lms/lms/doctype/lms_question/lms_question.py:60
 msgid "Add at least one possible answer for this question: {0}"
-msgstr "Přidejte k této otázce alespoň jednu možnou odpověď: {0}"
+msgstr "Pridajte k tejto otázke aspoň jednu možnú odpoveď: {0}"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:554
 msgid "Add courses to your batch"
-msgstr "Přidat kurzy do školicího kola"
+msgstr "Pridať kurzy do školiaceho kola"
 
 #: frontend/src/components/Modals/Question.vue:211
 msgid "Add new question"
-msgstr "Přidat novou otázku"
+msgstr "Pridať novú otázku"
 
 #: frontend/src/components/Settings/Badges/Badges.vue:90
 #: frontend/src/components/Settings/Categories.vue:70
@@ -306,40 +315,40 @@ msgstr "Přidat novou otázku"
 #: frontend/src/components/Settings/Transactions/TransactionList.vue:101
 #: frontend/src/components/Settings/ZoomSettings.vue:88
 msgid "Add one to get started."
-msgstr "Začněte přidáním první položky."
+msgstr "Začnite pridaním prvej položky."
 
 #: frontend/src/components/Modals/QuizInVideo.vue:2
 msgid "Add quiz to this video"
-msgstr "Přidat kvíz do tohoto videa"
+msgstr "Pridať kvíz do tohto videa"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:57
 msgid "Add students to the batch to make an announcement"
-msgstr "Chcete-li odeslat oznámení, přidejte do školicího kola studenty"
+msgstr "Ak chcete odoslať oznámenie, pridajte do školiaceho kola študentov"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:533
 msgid "Add students to your batch"
-msgstr "Přidat studenty do školicího kola"
+msgstr "Pridať študentov do školiaceho kola"
 
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:33
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:55
 msgid "Add tag"
-msgstr "Přidat štítek"
+msgstr "Pridať štítok"
 
 #: frontend/src/components/Notes/InlineLessonMenu.vue:39
 msgid "Add to Notes"
-msgstr "Přidat do poznámek"
+msgstr "Pridať do poznámok"
 
 #: frontend/src/components/Modals/PageModal.vue:4
 msgid "Add web page to sidebar"
-msgstr "Přidat webovou stránku na postranní panel"
+msgstr "Pridať webovú stránku na bočný panel"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:461
 msgid "Add your first chapter"
-msgstr "Přidejte svou první kapitolu"
+msgstr "Pridajte svoju prvú kapitolu"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:481
 msgid "Add your first lesson"
-msgstr "Přidejte svou první lekci"
+msgstr "Pridajte svoju prvú lekciu"
 
 #. Label of the address (Link) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:141
@@ -350,16 +359,16 @@ msgstr "Adresa"
 
 #: frontend/src/pages/Billing.vue:120
 msgid "Address Line 1"
-msgstr "1. řádek adresy"
+msgstr "1. riadok adresy"
 
 #: frontend/src/pages/Billing.vue:125
 msgid "Address Line 2"
-msgstr "2. řádek adresy"
+msgstr "2. riadok adresy"
 
 #. Option for the 'Role' (Select) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Admin"
-msgstr "Správce"
+msgstr "Správca"
 
 #. Name of a role
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
@@ -369,74 +378,74 @@ msgstr "Administrátor"
 #: frontend/src/components/Settings/Members.vue:172
 #: frontend/src/pages/Batches/Batches.vue:326
 msgid "All"
-msgstr "Vše"
+msgstr "Všetko"
 
 #: frontend/src/pages/Batches/Batches.vue:53
 msgid "All Batches"
-msgstr "Všechna školicí kola"
+msgstr "Všetky školiace kolá"
 
 #: frontend/src/pages/Courses/Courses.vue:37 lms/lms/widgets/BreadCrumb.html:3
 msgid "All Courses"
-msgstr "Všechny kurzy"
+msgstr "Všetky kurzy"
 
 #: frontend/src/pages/Programs/Programs.vue:25
 #: frontend/src/pages/Programs/StudentPrograms.vue:5
 msgid "All Programs"
-msgstr "Všechny programy"
+msgstr "Všetky programy"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:58
 msgid "All questions should have the same marks if the limit is set."
-msgstr "Pokud je nastaven limit, všechny otázky musí mít stejný počet bodů."
+msgstr "Ak je nastavený limit, všetky otázky musia mať rovnaký počet bodov."
 
 #. Label of the allow_guest_access (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Allow Guest Access"
-msgstr "Povolit přístup hostům"
+msgstr "Povoliť prístup hosťom"
 
 #. Label of the allow_job_posting (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Allow Job Posting"
-msgstr "Povolit zveřejňování pracovních nabídek"
+msgstr "Povoliť zverejňovanie pracovných ponúk"
 
 #. Label of the allow_self_enrollment (Check) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:89
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Allow Self Enrollment"
-msgstr "Povolit samostatný zápis"
+msgstr "Povoliť samostatný zápis"
 
 #. Label of the allow_future (Check) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Allow accessing future dates"
-msgstr "Povolit přístup k budoucím datům"
+msgstr "Povoliť prístup k budúcim dátumom"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:21
 msgid "Allow this badge to be awarded to learners."
-msgstr "Povolit udělování tohoto odznaku studentům."
+msgstr "Povoliť udeľovanie tohto odznaku študentom."
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:24
 msgid "Allow this coupon to be used for discounts."
-msgstr "Povolit použití tohoto kupónu pro slevy."
+msgstr "Povoliť použitie tohto kupónu na zľavy."
 
 #: frontend/src/pages/Batches/BatchForm.vue:91
 msgid "Allow users to enroll in this batch on their own."
-msgstr "Povolit uživatelům, aby se do tohoto školicího kola zapsali sami."
+msgstr "Povoliť používateľom, aby sa do tohto školiaceho kola zapísali sami."
 
 #: frontend/src/pages/QuizForm.vue:214
 msgid "Allow users to view their past quiz attempts."
-msgstr "Povolit uživatelům zobrazit jejich předchozí pokusy o kvíz."
+msgstr "Povoliť používateľom zobraziť ich predchádzajúce pokusy v kvíze."
 
 #: lms/lms/user.py:34
 msgid "Already Registered"
-msgstr "Již jste zaregistrováni"
+msgstr "Už ste zaregistrovaní"
 
 #: frontend/src/components/CourseCreatorCard.vue:49
 msgid "Also teaching"
-msgstr "Vyučuje také"
+msgstr "Vyučuje tiež"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Amber"
-msgstr "Jantarová"
+msgstr "Jantárová"
 
 #. Label of the amount (Currency) field in DocType 'LMS Batch'
 #. Label of the course_price (Currency) field in DocType 'LMS Course'
@@ -448,48 +457,48 @@ msgstr "Jantarová"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Amount"
-msgstr "Částka"
+msgstr "Suma"
 
 #. Label of the amount_usd (Currency) field in DocType 'LMS Batch'
 #. Label of the amount_usd (Currency) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Amount (USD)"
-msgstr "Částka (USD)"
+msgstr "Suma (USD)"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:79
 msgid "Amount and currency are required for paid batches."
-msgstr "U placených školicích kol je nutné uvést částku a měnu."
+msgstr "Pri platených školiacich kolách je potrebné uviesť sumu a menu."
 
 #: lms/lms/doctype/lms_course/lms_course.py:91
 msgid "Amount and currency are required for paid certificates."
-msgstr "U placených certifikátů je nutné uvést částku a měnu."
+msgstr "Pri platených certifikátoch je potrebné uviesť sumu a menu."
 
 #: lms/lms/doctype/lms_course/lms_course.py:88
 msgid "Amount and currency are required for paid courses."
-msgstr "U placených kurzů je nutné uvést částku a měnu."
+msgstr "Pri platených kurzoch je potrebné uviesť sumu a menu."
 
 #. Label of the amount_with_gst (Currency) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:98
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Amount with GST"
-msgstr "Částka včetně GST"
+msgstr "Suma vrátane GST"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:30
 msgid "Announcement"
-msgstr "Oznámení"
+msgstr "Oznámenie"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:107
 msgid "Announcement has been sent successfully"
-msgstr "Oznámení bylo úspěšně odesláno"
+msgstr "Oznámenie bolo úspešne odoslané"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:99
 msgid "Announcement is required"
-msgstr "Oznámení je povinné"
+msgstr "Oznámenie je povinné"
 
 #: frontend/src/pages/Batches/components/Announcements.vue:4
 msgid "Announcements"
-msgstr "Oznámení"
+msgstr "Oznámenia"
 
 #. Label of the answer (Text Editor) field in DocType 'LMS Assignment'
 #. Label of the answer (Text Editor) field in DocType 'LMS Assignment
@@ -498,113 +507,127 @@ msgstr "Oznámení"
 #: lms/lms/doctype/lms_assignment/lms_assignment.json
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Answer"
-msgstr "Odpověď"
+msgstr "Odpoveď"
 
 #: frontend/src/pages/PersonaForm.vue:18
 msgid "Answer a few quick questions so we can set Frappe Learning up for you"
-msgstr "Odpovězte na několik krátkých otázek, abychom vám mohli Frappe Learning nastavit."
+msgstr ""
+"Odpovedzte na niekoľko krátkych otázok, aby sme vám mohli nastaviť Frappe "
+"Learning."
 
 #: frontend/src/components/Settings/BrandSettings.vue:63
 msgid "Appears in the left sidebar. Recommended size is 32x32 px in PNG or SVG"
-msgstr "Zobrazuje se v levém postranním panelu. Doporučená velikost je 32 × 32 px ve formátu PNG nebo SVG."
+msgstr ""
+"Zobrazuje sa v ľavom bočnom paneli. Odporúčaná veľkosť je 32 × 32 px vo "
+"formáte PNG alebo SVG."
 
 #: frontend/src/components/Settings/BrandSettings.vue:97
-msgid "Appears next to the title in your browser tab. Recommended size is 32x32 px in PNG or ICO"
+msgid ""
+"Appears next to the title in your browser tab. Recommended size is 32x32 px "
+"in PNG or ICO"
 msgstr ""
-"Zobrazuje se vedle názvu na kartě prohlížeče. Doporučená velikost je 32 × 32 px ve formátu PNG "
-"nebo ICO."
+"Zobrazuje sa vedľa názvu na karte prehliadača. Odporúčaná veľkosť je 32 × 32"
+" px vo formáte PNG alebo ICO."
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:79
 msgid "Applicable For"
-msgstr "Platí pro"
+msgstr "Platí pre"
 
 #. Label of the applicable_items (Table) field in DocType 'LMS Coupon'
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Applicable Items"
-msgstr "Položky, na které se vztahuje"
+msgstr "Položky, na ktoré sa vzťahuje"
 
 #: frontend/src/pages/JobApplications.vue:24
 msgid "Application"
-msgstr "Přihláška"
+msgstr "Žiadosť"
 
 #. Label of a field in the job-opportunity Web Form
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Application Form Link"
-msgstr "Odkaz na formulář přihlášky"
+msgstr "Odkaz na formulár žiadosti"
 
 #: frontend/src/pages/JobApplications.vue:13
 #: frontend/src/pages/JobApplications.vue:25
 msgid "Applications"
-msgstr "Přihlášky"
+msgstr "Žiadosti"
 
 #: frontend/src/pages/JobApplications.vue:346
 msgid "Applied On"
-msgstr "Podáno dne"
+msgstr "Podané dňa"
 
 #: frontend/src/pages/Billing.vue:81 frontend/src/pages/JobDetail.vue:62
 msgid "Apply"
-msgstr "Pokračovat"
+msgstr "Pokračovať"
 
 #. Label of the apply_gst (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Apply GST for India"
-msgstr "Použít GST pro Indii"
+msgstr "Použiť GST pre Indiu"
 
 #. Label of the apply_rounding (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Apply Rounding on Equivalent"
-msgstr "Zaokrouhlit ekvivalentní částku"
+msgstr "Zaokrúhliť ekvivalentnú sumu"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Approved"
-msgstr "Schváleno"
+msgstr "Schválené"
 
 #: frontend/src/components/Sidebar/Apps.vue:12
 msgid "Apps"
-msgstr "Aplikace"
+msgstr "Aplikácie"
 
 #: frontend/src/pages/Batches/Batches.vue:337
 msgid "Archived"
-msgstr "Archivováno"
+msgstr "Archivované"
 
 #: frontend/src/components/UpcomingEvaluations.vue:197
-msgid "Are you sure you want to cancel this evaluation? This action cannot be undone."
-msgstr "Opravdu chcete toto hodnocení zrušit? Tuto akci nelze vrátit zpět."
+msgid ""
+"Are you sure you want to cancel this evaluation? This action cannot be "
+"undone."
+msgstr "Naozaj chcete zrušiť toto hodnotenie? Túto akciu nemožno vrátiť späť."
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:237
 msgid ""
-"Are you sure you want to clear the demo data? This would delete the course \"A guide  to Frappe "
-"Learning\" along with all its associated data. This action cannot be undone."
+"Are you sure you want to clear the demo data? This would delete the course "
+"\"A guide  to Frappe Learning\" along with all its associated data. This "
+"action cannot be undone."
 msgstr ""
-"Opravdu chcete vymazat ukázková data? Tím se smaže kurz „Průvodce Frappe Learning“ včetně všech "
-"souvisejících dat. Tuto akci nelze vrátit zpět."
+"Naozaj chcete vymazať ukážkové údaje? Tým sa odstráni kurz „Sprievodca "
+"Frappe Learning“ vrátane všetkých súvisiacich údajov. Túto akciu nemožno "
+"vrátiť späť."
 
 #: frontend/src/pages/Programs/ProgramForm.vue:556
 msgid "Are you sure you want to delete this program? This action cannot be undone."
-msgstr "Opravdu chcete tento program smazat? Tuto akci nelze vrátit zpět."
+msgstr "Naozaj chcete odstrániť tento program? Túto akciu nemožno vrátiť späť."
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:33
 msgid "Are you sure you want to enroll?"
-msgstr "Opravdu se chcete zapsat?"
+msgstr "Naozaj sa chcete zapísať?"
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:180
 msgid "Are you sure you want to login to your Frappe Cloud dashboard?"
-msgstr "Opravdu se chcete přihlásit k ovládacímu panelu Frappe Cloud?"
+msgstr "Naozaj sa chcete prihlásiť do ovládacieho panela Frappe Cloud?"
 
 #: frontend/src/components/Quiz.vue:416
 msgid "Are you sure you want to submit the quiz?"
-msgstr "Opravdu chcete odeslat kvíz?"
+msgstr "Naozaj chcete odoslať kvíz?"
 
 #: frontend/src/pages/Batches/components/BatchDashboard.vue:11
 msgid ""
-"As a part of this batch's curriculum you will have to complete the following courses and "
-"assessments."
-msgstr "V rámci osnov tohoto školicího kola budete muset dokončit následující kurzy a hodnocení."
+"As a part of this batch's curriculum you will have to complete the following"
+" courses and assessments."
+msgstr ""
+"V rámci osnov tohto školiaceho kola budete musieť dokončiť nasledujúce "
+"kurzy a hodnotenia."
+
+
 
 #: frontend/src/pages/Lesson.vue:283
 msgid "Ask a question to get help from the community."
-msgstr "Položte otázku a získejte pomoc od komunity."
+msgstr "Položte otázku a získajte pomoc od komunity."
 
 #. Label of the assessment_tab (Tab Break) field in DocType 'LMS Batch'
 #. Label of the assessment (Table) field in DocType 'LMS Batch'
@@ -612,26 +635,26 @@ msgstr "Položte otázku a získejte pomoc od komunity."
 #: frontend/src/pages/Batches/components/Assessments.vue:208
 #: lms/lms/doctype/lms_batch/lms_batch.json lms/templates/assessments.html:11
 msgid "Assessment"
-msgstr "Hodnocení"
+msgstr "Hodnotenie"
 
 #. Label of the assessment_name (Dynamic Link) field in DocType 'LMS
 #. Assessment'
 #: lms/lms/doctype/lms_assessment/lms_assessment.json
 msgid "Assessment Name"
-msgstr "Název hodnocení"
+msgstr "Názov hodnotenia"
 
 #. Label of the assessment_type (Link) field in DocType 'LMS Assessment'
 #: lms/lms/doctype/lms_assessment/lms_assessment.json
 msgid "Assessment Type"
-msgstr "Typ hodnocení"
+msgstr "Typ hodnotenia"
 
 #: frontend/src/components/Modals/AssessmentModal.vue:93
 msgid "Assessment added successfully"
-msgstr "Hodnocení bylo úspěšně přidáno"
+msgstr "Hodnotenie bolo úspešne pridané"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:87
 msgid "Assessment {0} has already been added to this batch."
-msgstr "Hodnocení {0} již bylo do tohoto školicího kola přidáno."
+msgstr "Hodnotenie {0} už bolo pridané do tohto školiaceho kola."
 
 #. Label of the show_assessments (Check) field in DocType 'LMS Settings'
 #: frontend/src/components/Sidebar/AppSidebar.vue:608
@@ -640,27 +663,27 @@ msgstr "Hodnocení {0} již bylo do tohoto školicího kola přidáno."
 #: lms/lms/doctype/lms_settings/lms_settings.json
 #: lms/templates/assessments.html:3
 msgid "Assessments"
-msgstr "Hodnocení"
+msgstr "Hodnotenia"
 
 #: lms/lms/doctype/lms_badge/lms_badge.js:48
 msgid "Assign"
-msgstr "Přiřadit"
+msgstr "Priradiť"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:33
 msgid "Assign For"
-msgstr "Přiřadit pro"
+msgstr "Priradiť za"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:68
 msgid "Assign To"
-msgstr "Přiřadit uživateli"
+msgstr "Priradiť používateľovi"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:6
 msgid "Assign a Badge"
-msgstr "Přiřadit odznak"
+msgstr "Priradiť odznak"
 
 #: frontend/src/components/Settings/Badges/Badges.vue:227
 msgid "Assigned For"
-msgstr "Přiřazeno pro"
+msgstr "Priradené za"
 
 #. Label of the section_break_16 (Section Break) field in DocType 'Course
 #. Lesson'
@@ -673,88 +696,88 @@ msgstr "Přiřazeno pro"
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 #: lms/templates/assignment.html:3
 msgid "Assignment"
-msgstr "Úkol"
+msgstr "Úloha"
 
 #. Label of the assignment_attachment (Attach) field in DocType 'LMS Assignment
 #. Submission'
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Assignment Attachment"
-msgstr "Příloha úkolu"
+msgstr "Príloha úlohy"
 
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:107
 msgid "Assignment Progress"
-msgstr "Průběh úkolu"
+msgstr "Priebeh úlohy"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:221
 #: frontend/src/components/Settings/Badges/Badges.vue:210
 msgid "Assignment Submission"
-msgstr "Odevzdání úkolu"
+msgstr "Odovzdanie úlohy"
 
 #: frontend/src/pages/AssignmentSubmissionList.vue:222
 msgid "Assignment Submissions"
-msgstr "Odevzdané úkoly"
+msgstr "Odovzdané úlohy"
 
 #. Label of the assignment_title (Data) field in DocType 'LMS Assignment
 #. Submission'
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Assignment Title"
-msgstr "Název úkolu"
+msgstr "Názov úlohy"
 
 #: frontend/src/components/Modals/AssignmentForm.vue:152
 msgid "Assignment created successfully"
-msgstr "Úkol byl úspěšně vytvořen"
+msgstr "Úloha bola úspešne vytvorená"
 
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py:42
 msgid "Assignment for Lesson {0} by {1} already exists."
-msgstr "Úkol k lekci {0} od uživatele {1} již existuje."
+msgstr "Úloha k lekcii {0} od používateľa {1} už existuje."
 
 #: frontend/src/components/Assignment.vue:326
 msgid "Assignment submitted successfully"
-msgstr "Úkol byl úspěšně odevzdán"
+msgstr "Úloha bola úspešne odovzdaná"
 
 #: frontend/src/components/Modals/AssignmentForm.vue:167
 msgid "Assignment updated successfully"
-msgstr "Úkol byl úspěšně aktualizován"
+msgstr "Úloha bola úspešne aktualizovaná"
 
 #. Description of the 'Question' (Small Text) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Assignment will appear at the bottom of the lesson."
-msgstr "Úkol se zobrazí na konci lekce."
+msgstr "Úloha sa zobrazí na konci lekcie."
 
 #: frontend/src/components/Settings/Badges/Badges.vue:169
 #: frontend/src/components/Sidebar/AppSidebar.vue:612
 #: frontend/src/pages/Assignments.vue:315
 #: frontend/src/pages/Assignments.vue:322 lms/www/_lms.py:301
 msgid "Assignments"
-msgstr "Úkoly"
+msgstr "Úlohy"
 
 #: frontend/src/pages/Assignments.vue:310
 msgid "Assignments deleted successfully"
-msgstr "Úkoly byly úspěšně smazány"
+msgstr "Úlohy boli úspešne odstránené"
 
 #: lms/lms/doctype/lms_coupon/lms_coupon.py:30
 msgid "At least one applicable item is required"
-msgstr "Je nutná alespoň jedna platná položka"
+msgstr "Vyžaduje sa aspoň jedna položka, na ktorú sa kupón vzťahuje"
 
 #: lms/lms/doctype/lms_question/lms_question.py:49
 msgid "At least one option must be correct for this question."
-msgstr "U této otázky musí být alespoň jedna možnost správná."
+msgstr "Pri tejto otázke musí byť aspoň jedna možnosť správna."
 
 #: lms/lms/doctype/lms_programming_exercise/lms_programming_exercise.py:15
 msgid "At least one test case is required for the programming exercise."
-msgstr "Programovací cvičení musí obsahovat alespoň jeden testovací případ."
+msgstr "Programovacie cvičenie musí obsahovať aspoň jeden testovací prípad."
 
 #: frontend/src/components/Quiz.vue:442
 msgid "Attempted Questions"
-msgstr "Zodpovězené otázky"
+msgstr "Zodpovedané otázky"
 
 #: frontend/src/components/Modals/LiveClassAttendance.vue:4
 msgid "Attendance for Class - {0}"
-msgstr "Docházka na lekci – {0}"
+msgstr "Dochádzka na hodinu – {0}"
 
 #: frontend/src/components/Modals/LiveClassAttendance.vue:22
 msgid "Attended for"
-msgstr "Doba účasti"
+msgstr "Dĺžka účasti"
 
 #. Label of the attendees (Int) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
@@ -764,21 +787,21 @@ msgstr "Účastníci"
 #. Label of the attire (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Attire Preference"
-msgstr "Preferovaný oděv"
+msgstr "Preferovaný odev"
 
 #: frontend/src/pages/ProfileEvaluator.vue:146
 msgid "Authorize Google Calendar Access"
-msgstr "Povolit přístup ke Kalendáři Google"
+msgstr "Povoliť prístup ku Kalendáru Google"
 
 #. Label of the auto_recording (Select) field in DocType 'LMS Live Class'
 #: frontend/src/components/Modals/LiveClassModal.vue:72
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Auto Recording"
-msgstr "Automatické nahrávání"
+msgstr "Automatické nahrávanie"
 
 #: frontend/src/pages/ProfileEvaluator.vue:258
 msgid "Availability updated successfully"
-msgstr "Dostupnost byla úspěšně aktualizována"
+msgstr "Dostupnosť bola úspešne aktualizovaná"
 
 #: frontend/src/components/Modals/EvaluationModal.vue:24
 msgid "Available Slots"
@@ -786,41 +809,41 @@ msgstr "Dostupné termíny"
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:9
 msgid "Average Completion Rate"
-msgstr "Průměrná míra dokončení"
+msgstr "Priemerná miera dokončenia"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:12
 msgid "Average Feedback Received"
-msgstr "Průměrné hodnocení ze zpětné vazby"
+msgstr "Priemerné hodnotenie zo spätnej väzby"
 
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:20
 msgid "Average Progress %"
-msgstr "Průměrný pokrok v %"
+msgstr "Priemerný pokrok v %"
 
 #: frontend/src/components/CourseCard.vue:71
 #: frontend/src/pages/Courses/CourseDashboard.vue:13
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:71
 msgid "Average Rating"
-msgstr "Průměrné hodnocení"
+msgstr "Priemerné hodnotenie"
 
 #: frontend/src/components/Modals/VideoStatistics.vue:71
 msgid "Average Watch Time (mins)"
-msgstr "Průměrná doba sledování (min)"
+msgstr "Priemerný čas sledovania (min)"
 
 #: frontend/src/pages/PersonaForm.vue:145
 msgid "Award my first certificate"
-msgstr "Udělit svůj první certifikát"
+msgstr "Udeliť svoj prvý certifikát"
 
 #: frontend/src/pages/PersonaForm.vue:101
 msgid "Back"
-msgstr "Zpět"
+msgstr "Späť"
 
 #: frontend/src/pages/Lesson.vue:154 frontend/src/pages/Lesson.vue:193
 msgid "Back to Course"
-msgstr "Zpět na kurz"
+msgstr "Späť na kurz"
 
 #: frontend/src/components/Questionnaire.vue:145
 msgid "Back to previous question"
-msgstr "Zpět na předchozí otázku"
+msgstr "Späť na predchádzajúcu otázku"
 
 #. Label of the badge (Link) field in DocType 'LMS Badge Assignment'
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:31
@@ -838,43 +861,43 @@ msgstr "Popis odznaku"
 #. Label of the badge_image (Attach) field in DocType 'LMS Badge Assignment'
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.json
 msgid "Badge Image"
-msgstr "Obrázek odznaku"
+msgstr "Obrázok odznaku"
 
 #: lms/lms/doctype/lms_badge/lms_badge.js:56
 msgid "Badge assigned successfully"
-msgstr "Odznak byl úspěšně přiřazen"
+msgstr "Odznak bol úspešne priradený"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:130
 msgid "Badge assignment created successfully"
-msgstr "Přiřazení odznaku bylo úspěšně vytvořeno"
+msgstr "Priradenie odznaku bolo úspešne vytvorené"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:111
 msgid "Badge assignment updated successfully"
-msgstr "Přiřazení odznaku bylo úspěšně aktualizováno"
+msgstr "Priradenie odznaku bolo úspešne aktualizované"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignments.vue:164
 msgid "Badge assignments deleted successfully"
-msgstr "Přiřazení odznaků byla úspěšně smazána"
+msgstr "Priradenia odznakov boli úspešne odstránené"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:204
 msgid "Badge created successfully"
-msgstr "Odznak byl úspěšně vytvořen"
+msgstr "Odznak bol úspešne vytvorený"
 
 #: frontend/src/components/Settings/Badges/Badges.vue:196
 msgid "Badge deleted successfully"
-msgstr "Odznak byl úspěšně smazán"
+msgstr "Odznak bol úspešne odstránený"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:182
 msgid "Badge updated successfully"
-msgstr "Odznak byl úspěšně aktualizován"
+msgstr "Odznak bol úspešne aktualizovaný"
 
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.py:35
 msgid "Badge {0} has already been assigned to this {1}."
-msgstr "Odznak {0} je již přiřazen k {1}."
+msgstr "Odznak {0} je už priradený k tejto položke ({1})."
 
 #: lms/lms/doctype/lms_badge/lms_badge.py:75
 msgid "Badge {0} not found"
-msgstr "Odznak {0} nebyl nalezen"
+msgstr "Odznak {0} sa nenašiel"
 
 #. Label of the batch (Link) field in DocType 'LMS Batch Enrollment'
 #. Label of the batch (Link) field in DocType 'LMS Batch Feedback'
@@ -892,18 +915,18 @@ msgstr "Odznak {0} nebyl nalezen"
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Batch"
-msgstr "Školicí kolo"
+msgstr "Školiace kolo"
 
 #. Label of the batch_confirmation_template (Link) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Batch Confirmation Template"
-msgstr "Šablona potvrzení školicího kola"
+msgstr "Šablóna potvrdenia školiaceho kola"
 
 #. Name of a DocType
 #: lms/lms/doctype/batch_course/batch_course.json
 msgid "Batch Course"
-msgstr "Kurz školicího kola"
+msgstr "Kurz školiaceho kola"
 
 #. Label of the batch_details (Text Editor) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:197
@@ -911,32 +934,32 @@ msgstr "Kurz školicího kola"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/templates/emails/batch_confirmation.html:26
 msgid "Batch Details"
-msgstr "Podrobnosti školicího kola"
+msgstr "Podrobnosti školiaceho kola"
 
 #. Label of the batch_details_raw (HTML Editor) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Batch Details Raw"
-msgstr "Nezpracované údaje školicího kola"
+msgstr "Nespracované údaje školiaceho kola"
 
 #: frontend/src/pages/Batches/BatchForm.vue:35
 msgid "Batch End Date"
-msgstr "Datum ukončení školicího kola"
+msgstr "Dátum ukončenia školiaceho kola"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:227
 #: frontend/src/components/Settings/Badges/Badges.vue:208
 msgid "Batch Enrollment"
-msgstr "Zápis do školicího kola"
+msgstr "Zápis do školiaceho kola"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:25
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:23
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:21
 msgid "Batch Enrollment Confirmation"
-msgstr "Potvrzení zápisu do školicího kola"
+msgstr "Potvrdenie zápisu do školiaceho kola"
 
 #. Label of a Workspace Sidebar Item
 #: lms/workspace_sidebar/learning.json
 msgid "Batch Enrollments"
-msgstr "Zápisy do školicích kol"
+msgstr "Zápisy do školiacich kôl"
 
 #. Name of a role
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
@@ -960,87 +983,87 @@ msgstr "Zápisy do školicích kol"
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 msgid "Batch Evaluator"
-msgstr "Hodnotitel školicího kola"
+msgstr "Hodnotiteľ školiaceho kola"
 
 #. Label of a Workspace Sidebar Item
 #: lms/workspace_sidebar/learning.json
 msgid "Batch Feedback"
-msgstr "Zpětná vazba ke školicímu kolu"
+msgstr "Spätná väzba ku školiacemu kolu"
 
 #. Label of the batch_name (Link) field in DocType 'LMS Certificate Evaluation'
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Batch Name"
-msgstr "Název školicího kola"
+msgstr "Názov školiaceho kola"
 
 #. Label of the section_break_szgq (Section Break) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Batch Settings"
-msgstr "Nastavení školicího kola"
+msgstr "Nastavenia školiaceho kola"
 
 #: frontend/src/pages/Batches/BatchForm.vue:28
 msgid "Batch Start Date"
-msgstr "Datum zahájení školicího kola"
+msgstr "Dátum začiatku školiaceho kola"
 
 #: lms/templates/emails/batch_confirmation.html:11
 msgid "Batch Start Date:"
-msgstr "Datum zahájení školicího kola:"
+msgstr "Dátum začiatku školiaceho kola:"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:153
 msgid "Batch Summary"
-msgstr "Souhrn školicího kola"
+msgstr "Súhrn školiaceho kola"
 
 #. Label of the batch_title (Data) field in DocType 'LMS Certificate'
 #. Label of the batch_title (Data) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Batch Title"
-msgstr "Název školicího kola"
+msgstr "Názov školiaceho kola"
 
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:236
 msgid "Batch created successfully"
-msgstr "Školicí kolo bylo úspěšně vytvořeno"
+msgstr "Školiace kolo bolo úspešne vytvorené"
 
 #: frontend/src/pages/Batches/BatchForm.vue:579
 msgid "Batch deleted successfully"
-msgstr "Školicí kolo bylo úspěšně smazáno"
+msgstr "Školiace kolo bolo úspešne odstránené"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:52
 msgid "Batch end date cannot be before the batch start date"
-msgstr "Datum ukončení školicího kola nemůže předcházet datu zahájení školicího kola"
+msgstr "Dátum ukončenia školiaceho kola nemôže byť skorší ako dátum jeho začiatku"
 
 #: lms/lms/api.py:198
 msgid "Batch has already started."
-msgstr "Školicí kolo již začalo."
+msgstr "Školiace kolo sa už začalo."
 
 #: lms/lms/api.py:193
 msgid "Batch is sold out."
-msgstr "Školicí kolo je plně obsazeno."
+msgstr "Školiace kolo je vypredané."
 
 #: frontend/src/pages/Batches/BatchForm.vue:146
 msgid "Batch overview"
-msgstr "Přehled školicího kola"
+msgstr "Prehľad školiaceho kola"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:266
 msgid "Batch published"
-msgstr "Školicí kolo bylo zveřejněno"
+msgstr "Školiace kolo bolo zverejnené"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:57
 msgid "Batch start time cannot be greater than or equal to end time."
-msgstr "Čas zahájení školicího kola musí být dřívější než čas ukončení."
+msgstr "Čas začiatku školiaceho kola musí byť skorší ako čas ukončenia."
 
 #: frontend/src/pages/Batches/BatchDetail.vue:266
 msgid "Batch unpublished"
-msgstr "Zveřejnění školicího kola bylo zrušeno"
+msgstr "Zverejnenie školiaceho kola bolo zrušené"
 
 #: frontend/src/pages/Batches/BatchForm.vue:533
 msgid "Batch updated successfully"
-msgstr "Školicí kolo bylo úspěšně aktualizováno"
+msgstr "Školiace kolo bolo úspešne aktualizované"
 
 #: lms/templates/emails/batch_start_reminder.html:10
 #: lms/templates/emails/batch_start_reminder_recorded.html:19
 msgid "Batch:"
-msgstr "Školicí kolo:"
+msgstr "Školiace kolo:"
 
 #. Label of the batches (Check) field in DocType 'LMS Settings'
 #. Label of a Workspace Sidebar Item
@@ -1050,7 +1073,7 @@ msgstr "Školicí kolo:"
 #: lms/lms/doctype/lms_settings/lms_settings.json
 #: lms/workspace_sidebar/learning.json lms/www/_lms.py:132
 msgid "Batches"
-msgstr "Školicí kola"
+msgstr "Školiace kolá"
 
 #: lms/templates/emails/batch_confirmation.html:33
 #: lms/templates/emails/batch_start_reminder.html:31
@@ -1058,7 +1081,7 @@ msgstr "Školicí kola"
 #: lms/templates/emails/certification.html:20
 #: lms/templates/emails/live_class_reminder.html:28
 msgid "Best Regards"
-msgstr "S pozdravem"
+msgstr "S pozdravom"
 
 #. Label of the billing_details_section (Section Break) field in DocType 'LMS
 #. Payment'
@@ -1066,7 +1089,7 @@ msgstr "S pozdravem"
 #: frontend/src/pages/Billing.vue:8 frontend/src/pages/Billing.vue:473
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Billing Details"
-msgstr "Fakturační údaje"
+msgstr "Fakturačné údaje"
 
 #. Label of the billing_name (Data) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:55
@@ -1074,11 +1097,11 @@ msgstr "Fakturační údaje"
 #: frontend/src/pages/Billing.vue:115
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Billing Name"
-msgstr "Jméno pro fakturaci"
+msgstr "Fakturačné meno"
 
 #: frontend/src/components/Modals/EditProfile.vue:70
 msgid "Bio"
-msgstr "O mně"
+msgstr "O mne"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #. Option for the 'Color' (Select) field in DocType 'LMS Lesson Note'
@@ -1094,17 +1117,17 @@ msgstr "Obsah"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:186
 msgid "Book a free onboarding session with the Frappe team"
-msgstr "Rezervujte si bezplatnou úvodní schůzku s týmem Frappe"
+msgstr "Rezervujte si bezplatné úvodné stretnutie s tímom Frappe"
 
 #. Option for the 'Collaboration Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Both Individual and Team Work"
-msgstr "Individuální i týmová práce"
+msgstr "Individuálna aj tímová práca"
 
 #. Label of the branch (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Branch"
-msgstr "Obor"
+msgstr "Odbor"
 
 #: frontend/src/components/Settings/BrandSettings.vue:60
 msgid "Brand Logo"
@@ -1112,24 +1135,24 @@ msgstr "Logo značky"
 
 #: frontend/src/components/Settings/BrandSettings.vue:22
 msgid "Brand Name"
-msgstr "Název značky"
+msgstr "Názov značky"
 
 #: frontend/src/components/Settings/BrandSettings.vue:3
 msgid "Brand Settings"
-msgstr "Nastavení značky"
+msgstr "Nastavenia značky"
 
 #: frontend/src/pages/ProfileRoles.vue:28
 msgid "Build and manage courses, chapters, and lessons"
-msgstr "Vytváření a správa kurzů, kapitol a lekcí"
+msgstr "Vytváranie a správa kurzov, kapitol a lekcií"
 
 #. Option for the 'User Category' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:23
 msgid "Business Owner"
-msgstr "Majitel firmy"
+msgstr "Majiteľ firmy"
 
 #: frontend/src/components/CourseCardOverlay.vue:53
 msgid "Buy this course"
-msgstr "Koupit tento kurz"
+msgstr "Kúpiť tento kurz"
 
 #: lms/templates/emails/lms_message.html:11
 msgid "By"
@@ -1147,16 +1170,16 @@ msgstr "CGPA / 4"
 #: frontend/src/components/UpcomingEvaluations.vue:48
 #: frontend/src/components/UpcomingEvaluations.vue:202
 msgid "Cancel"
-msgstr "Zrušit"
+msgstr "Zrušiť"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Cancelled"
-msgstr "Zrušeno"
+msgstr "Zrušené"
 
 #: lms/lms/api.py:2524
 msgid "Cannot search for roles: {0}"
-msgstr "Role se nepodařilo vyhledat: {0}"
+msgstr "Role sa nepodarilo vyhľadať: {0}"
 
 #: frontend/src/pages/PersonaForm.vue:158
 msgid "Canvas"
@@ -1166,12 +1189,12 @@ msgstr "Canvas"
 #. 'User'
 #: lms/fixtures/custom_field.json
 msgid "Career Preference Details"
-msgstr "Podrobnosti o profesních preferencích"
+msgstr "Podrobnosti o profesijných preferenciách"
 
 #. Option for the 'Attire Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Casual Wear"
-msgstr "Neformální oblečení"
+msgstr "Neformálne oblečenie"
 
 #. Label of the category (Link) field in DocType 'LMS Batch'
 #. Label of the category (Data) field in DocType 'LMS Category'
@@ -1187,27 +1210,27 @@ msgstr "Neformální oblečení"
 #: lms/lms/doctype/lms_category/lms_category.json
 #: lms/lms/doctype/lms_course/lms_course.json lms/templates/signup-form.html:22
 msgid "Category"
-msgstr "Kategorie"
+msgstr "Kategória"
 
 #: frontend/src/components/Settings/Categories.vue:25
 msgid "Category Name"
-msgstr "Název kategorie"
+msgstr "Názov kategórie"
 
 #: frontend/src/components/Settings/Categories.vue:124
 msgid "Category added successfully"
-msgstr "Kategorie byla úspěšně přidána"
+msgstr "Kategória bola úspešne pridaná"
 
 #: frontend/src/utils/index.js:822
 msgid "Category created successfully"
-msgstr "Kategorie byla úspěšně vytvořena"
+msgstr "Kategória bola úspešne vytvorená"
 
 #: frontend/src/components/Settings/Categories.vue:184
 msgid "Category deleted successfully"
-msgstr "Kategorie byla úspěšně smazána"
+msgstr "Kategória bola úspešne odstránená"
 
 #: frontend/src/components/Settings/Categories.vue:164
 msgid "Category updated successfully"
-msgstr "Kategorie byla úspěšně aktualizována"
+msgstr "Kategória bola úspešne aktualizovaná"
 
 #. Label of the certificate (Link) field in DocType 'LMS Enrollment'
 #. Label of a shortcut in the Learning Workspace
@@ -1219,7 +1242,7 @@ msgstr "Certifikát"
 #. Label of the certification_template (Link) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Certificate Email Template"
-msgstr "Šablona e-mailu s certifikátem"
+msgstr "Šablóna e-mailu s certifikátom"
 
 #: lms/templates/emails/certification.html:13
 msgid "Certificate Link"
@@ -1227,7 +1250,7 @@ msgstr "Odkaz na certifikát"
 
 #: frontend/src/components/CourseCardOverlay.vue:139
 msgid "Certificate of completion"
-msgstr "Certifikát o absolvování"
+msgstr "Certifikát o absolvovaní"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:107
 msgid "Certificate price"
@@ -1235,7 +1258,7 @@ msgstr "Cena certifikátu"
 
 #: frontend/src/components/Modals/Event.vue:339
 msgid "Certificate saved successfully"
-msgstr "Certifikát byl úspěšně uložen"
+msgstr "Certifikát bol úspešne uložený"
 
 #. Label of a Workspace Sidebar Item
 #: frontend/src/pages/Profile.vue:262
@@ -1246,11 +1269,15 @@ msgstr "Certifikáty"
 
 #: frontend/src/pages/Batches/components/BulkCertificates.vue:119
 msgid "Certificates generated successfully"
-msgstr "Certifikáty byly úspěšně vygenerovány"
+msgstr "Certifikáty boli úspešne vygenerované"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:140
-msgid "Certificates render from a Print Format. Build or customize templates from the desk."
-msgstr "Certifikáty se generují z tiskového formátu. Šablony můžete vytvořit nebo upravit v administraci."
+msgid ""
+"Certificates render from a Print Format. Build or customize templates from "
+"the desk."
+msgstr ""
+"Certifikáty sa generujú z formátu tlače. Šablóny môžete vytvoriť alebo "
+"upraviť v administrácii."
 
 #. Label of the certification (Table) field in DocType 'User'
 #. Name of a DocType
@@ -1273,42 +1300,44 @@ msgstr "Certifikáty se generují z tiskového formátu. Šablony můžete vytvo
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 #: lms/lms/workspace/learning/learning.json
 msgid "Certification"
-msgstr "Certifikace"
+msgstr "Certifikácia"
 
 #. Label of the certification_details (Section Break) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Certification Details"
-msgstr "Podrobnosti certifikace"
+msgstr "Podrobnosti certifikácie"
 
 #. Label of the certification_name (Data) field in DocType 'Certification'
 #: lms/lms/doctype/certification/certification.json
 msgid "Certification Name"
-msgstr "Název certifikace"
+msgstr "Názov certifikácie"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:94
 msgid "Certification cannot be issued as the member has not completed the course."
-msgstr "Certifikaci nelze vystavit, protože člen kurz nedokončil."
+msgstr "Certifikát nemožno vydať, pretože člen nedokončil kurz."
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:77
 msgid "Certification cannot be issued as the member is not enrolled in this batch."
-msgstr "Certifikaci nelze vystavit, protože člen není zapsán do tohoto školicího kola."
+msgstr ""
+"Certifikát nemožno vydať, pretože člen nie je zapísaný do tohto "
+"školiaceho kola."
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:84
 msgid "Certification cannot be issued as the member is not enrolled in this course."
-msgstr "Certifikaci nelze vystavit, protože člen není zapsán do tohoto kurzu."
+msgstr "Certifikát nemožno vydať, pretože člen nie je zapísaný do tohto kurzu."
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:214
 msgid "Certification is not enabled for this course."
-msgstr "Certifikace není pro tento kurz povolena."
+msgstr "Certifikácia nie je pre tento kurz povolená."
 
 #. Label of the certifications (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Certifications"
-msgstr "Certifikace"
+msgstr "Certifikácie"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:10
 msgid "Certified"
-msgstr "Certifikováno"
+msgstr "Certifikovaní"
 
 #. Label of the certified_members (Check) field in DocType 'LMS Settings'
 #: frontend/src/pages/CertifiedParticipants.vue:20
@@ -1317,7 +1346,7 @@ msgstr "Certifikováno"
 #: frontend/src/pages/Statistics.vue:46
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Certified Members"
-msgstr "Certifikovaní členové"
+msgstr "Certifikovaní členovia"
 
 #: lms/www/_lms.py:333
 msgid "Certified Participants"
@@ -1326,11 +1355,11 @@ msgstr "Certifikovaní účastníci"
 #: frontend/src/components/Controls/ImageUploader.vue:14
 #: lms/templates/assignment.html:13
 msgid "Change"
-msgstr "Změnit"
+msgstr "Zmeniť"
 
 #: frontend/src/components/Assignment.vue:363
 msgid "Changes saved successfully"
-msgstr "Změny byly úspěšně uloženy"
+msgstr "Zmeny boli úspešne uložené"
 
 #. Label of the chapter (Link) field in DocType 'Chapter Reference'
 #. Label of the chapter (Link) field in DocType 'LMS Course Progress'
@@ -1350,23 +1379,23 @@ msgstr "Odkaz na kapitolu"
 
 #: frontend/src/components/Modals/ChapterModal.vue:147
 msgid "Chapter added successfully"
-msgstr "Kapitola byla úspěšně přidána"
+msgstr "Kapitola bola úspešne pridaná"
 
 #: frontend/src/components/CourseOutline.vue:253
 msgid "Chapter deleted successfully"
-msgstr "Kapitola byla úspěšně smazána"
+msgstr "Kapitola bola úspešne odstránená"
 
 #: frontend/src/components/CourseOutline.vue:242
 msgid "Chapter moved successfully"
-msgstr "Kapitola byla úspěšně přesunuta"
+msgstr "Kapitola bola úspešne presunutá"
 
 #: frontend/src/components/CourseOutline.vue:275
 msgid "Chapter renamed successfully"
-msgstr "Kapitola byla úspěšně přejmenována"
+msgstr "Kapitola bola úspešne premenovaná"
 
 #: frontend/src/components/Modals/ChapterModal.vue:182
 msgid "Chapter updated successfully"
-msgstr "Kapitola byla úspěšně aktualizována"
+msgstr "Kapitola bola úspešne aktualizovaná"
 
 #. Label of the chapters (Table) field in DocType 'LMS Course'
 #: frontend/src/pages/Courses/CourseDetail.vue:134
@@ -1377,48 +1406,48 @@ msgstr "Kapitoly"
 
 #: frontend/src/pages/Batches/BatchForm.vue:105
 msgid "Charge a fee for batch enrollment."
-msgstr "Zpoplatnit zápis do školicího kola."
+msgstr "Spoplatniť zápis do školiaceho kola."
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:34
 msgid "Charge learners to enroll in this course."
-msgstr "Zpoplatnit zápis studentů do tohoto kurzu."
+msgstr "Spoplatniť zápis študentov do tohto kurzu."
 
 #: frontend/src/components/Quiz.vue:309
 msgid "Check"
-msgstr "Zkontrolovat"
+msgstr "Skontrolovať"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:18
 msgid "Check All Submissions"
-msgstr "Zkontrolovat všechna odevzdání"
+msgstr "Skontrolovať všetky odovzdania"
 
 #: lms/templates/emails/mention_template.html:10
 msgid "Check Discussion"
-msgstr "Zobrazit diskuzi"
+msgstr "Zobraziť diskusiu"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:103
 msgid "Check Submission"
-msgstr "Zkontrolovat odevzdání"
+msgstr "Skontrolovať odovzdanie"
 
 #: frontend/src/components/Modals/AssignmentForm.vue:56
 #: frontend/src/pages/QuizForm.vue:39
 msgid "Check Submissions"
-msgstr "Zkontrolovat odevzdané práce"
+msgstr "Skontrolovať odovzdané práce"
 
 #: lms/templates/certificates_section.html:24
 msgid "Check out the {0} to know more about certification."
-msgstr "Další informace o certifikaci najdete v {0}."
+msgstr "Viac informácií o certifikácii nájdete tu: {0}."
 
 #: frontend/src/components/NoPermission.vue:17
 msgid "Checkout Courses"
-msgstr "Prohlédnout kurzy"
+msgstr "Prezrieť kurzy"
 
 #: lms/templates/emails/published_batch_notification.html:52
 msgid "Checkout the batch"
-msgstr "Zobrazit školicí kolo"
+msgstr "Zobraziť školiace kolo"
 
 #: lms/templates/emails/published_course_notification.html:36
 msgid "Checkout the course"
-msgstr "Zobrazit kurz"
+msgstr "Zobraziť kurz"
 
 #. Option for the 'Type' (Select) field in DocType 'LMS Question'
 #. Option for the 'Type' (Select) field in DocType 'LMS Quiz Question'
@@ -1429,15 +1458,15 @@ msgstr "Možnosti"
 
 #: frontend/src/components/Settings/PaymentGatewayDetails.vue:28
 msgid "Choose a payment provider to configure its credentials."
-msgstr "Vyberte poskytovatele plateb a nastavte jeho přístupové údaje."
+msgstr "Vyberte poskytovateľa platieb a nastavte jeho prihlasovacie údaje."
 
 #: frontend/src/components/Quiz.vue:922
 msgid "Choose all answers that apply"
-msgstr "Vyberte všechny platné odpovědi"
+msgstr "Vyberte všetky možnosti, ktoré platia"
 
 #: frontend/src/components/Modals/Question.vue:11
 msgid "Choose an existing question"
-msgstr "Vybrat existující otázku"
+msgstr "Vybrať existujúcu otázku"
 
 #: frontend/src/components/Controls/IconPicker.vue:25
 msgid "Choose an icon"
@@ -1445,11 +1474,11 @@ msgstr "Vyberte ikonu"
 
 #: frontend/src/components/Quiz.vue:923
 msgid "Choose one answer"
-msgstr "Vyberte jednu odpověď"
+msgstr "Vyberte jednu odpoveď"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAdd.vue:5
 msgid "Choose the email service provider you want to configure."
-msgstr "Vyberte poskytovatele e-mailové služby, kterého chcete nastavit."
+msgstr "Vyberte poskytovateľa e-mailových služieb, ktorého chcete nastaviť."
 
 #. Label of the city (Data) field in DocType 'User'
 #. Label of the location (Data) field in DocType 'Job Opportunity'
@@ -1457,11 +1486,11 @@ msgstr "Vyberte poskytovatele e-mailové služby, kterého chcete nastavit."
 #: lms/fixtures/custom_field.json
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "City"
-msgstr "Město"
+msgstr "Mesto"
 
 #: lms/templates/emails/live_class_reminder.html:10
 msgid "Class:"
-msgstr "Živá lekce:"
+msgstr "Živá lekcia:"
 
 #: frontend/src/components/Controls/ClearableCombobox.vue:14
 #: frontend/src/components/Controls/Link.vue:56
@@ -1469,20 +1498,20 @@ msgstr "Živá lekce:"
 #: frontend/src/components/Controls/MultiLink.vue:64
 #: frontend/src/components/Controls/MultiLink.vue:67
 msgid "Clear"
-msgstr "Vymazat"
+msgstr "Vymazať"
 
 #. Option for the 'Role Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Clearly Defined Role"
-msgstr "Jasně vymezená role"
+msgstr "Jasne vymedzená rola"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:31
 msgid "Click here"
-msgstr "Klikněte zde"
+msgstr "Kliknite sem"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:19
 msgid "Click to upload an image."
-msgstr "Kliknutím nahrajte obrázek."
+msgstr "Kliknutím nahrajte obrázok."
 
 #. Label of the client_id (Data) field in DocType 'LMS Zoom Settings'
 #. Label of the client_id (Data) field in DocType 'Zoom Settings'
@@ -1498,15 +1527,15 @@ msgstr "ID klienta"
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 #: lms/lms/doctype/zoom_settings/zoom_settings.json
 msgid "Client Secret"
-msgstr "Tajný klíč klienta"
+msgstr "Tajný kľúč klienta"
 
 #: frontend/src/components/Settings/Categories.vue:16
 msgid "Close"
-msgstr "Zavřít"
+msgstr "Zavrieť"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:69
 msgid "Close student view"
-msgstr "Zavřít zobrazení studenta"
+msgstr "Zavrieť zobrazenie študenta"
 
 #. Option for the 'Status' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -1514,16 +1543,16 @@ msgstr "Zavřít zobrazení studenta"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Closed"
-msgstr "Uzavřeno"
+msgstr "Uzavreté"
 
 #. Option for the 'Auto Recording' (Select) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Cloud"
-msgstr "V cloudu"
+msgstr "V cloude"
 
 #: frontend/src/pages/PersonaForm.vue:116
 msgid "Coaching or Training Institute"
-msgstr "Koučovací nebo školicí instituce"
+msgstr "Koučovacia alebo školiaca inštitúcia"
 
 #. Label of the code (Data) field in DocType 'LMS Coupon'
 #. Label of the code (Code) field in DocType 'LMS Programming Exercise
@@ -1537,20 +1566,20 @@ msgstr "Kód"
 #. Label of the collaboration (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Collaboration Preference"
-msgstr "Preferovaný způsob spolupráce"
+msgstr "Preferovaný spôsob spolupráce"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:213
 msgid "Collapse"
-msgstr "Sbalit"
+msgstr "Zbaliť"
 
 #. Label of the college (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "College Name"
-msgstr "Název vysoké školy"
+msgstr "Názov vysokej školy"
 
 #: frontend/src/pages/PersonaForm.vue:112
 msgid "College or University"
-msgstr "Vysoká škola nebo univerzita"
+msgstr "Vysoká škola alebo univerzita"
 
 #. Label of the card_gradient (Select) field in DocType 'LMS Course'
 #. Label of the color (Select) field in DocType 'LMS Lesson Note'
@@ -1560,32 +1589,32 @@ msgstr "Vysoká škola nebo univerzita"
 #: lms/lms/doctype/lms_lesson_note/lms_lesson_note.json
 #: lms/lms/doctype/lms_timetable_legend/lms_timetable_legend.json
 msgid "Color"
-msgstr "Barva"
+msgstr "Farba"
 
 #: frontend/src/pages/Batches/BatchForm.vue:272
 msgid "Comma separated keywords"
-msgstr "Klíčová slova oddělená čárkami"
+msgstr "Kľúčové slová oddelené čiarkami"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:71
 msgid "Comma separated keywords for SEO"
-msgstr "Klíčová slova pro SEO oddělená čárkami"
+msgstr "Kľúčové slová pre SEO oddelené čiarkami"
 
 #. Label of the comments (Text Editor) field in DocType 'LMS Assignment
 #. Submission'
 #: frontend/src/components/Assignment.vue:184
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Comments"
-msgstr "Komentáře"
+msgstr "Komentáre"
 
 #: frontend/src/components/Assignment.vue:162
 msgid "Comments by Evaluator"
-msgstr "Komentáře hodnotitele"
+msgstr "Komentáre hodnotiteľa"
 
 #. Description of the 'Meta Keywords' (Small Text) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Common keywords that will be used for all pages"
-msgstr "Společná klíčová slova použitá na všech stránkách"
+msgstr "Spoločné kľúčové slová použité na všetkých stránkach"
 
 #: frontend/src/pages/Lesson.vue:1082
 msgid "Community"
@@ -1596,20 +1625,20 @@ msgstr "Komunita"
 #: lms/job/doctype/lms_job_application/lms_job_application.json
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "Company"
-msgstr "Společnost"
+msgstr "Spoločnosť"
 
 #. Label of the section_break_6 (Section Break) field in DocType 'Job
 #. Opportunity'
 #: frontend/src/pages/JobForm.vue:87
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "Company Details"
-msgstr "Údaje o společnosti"
+msgstr "Údaje o spoločnosti"
 
 #. Label of the company_email_address (Data) field in DocType 'Job Opportunity'
 #: frontend/src/pages/JobForm.vue:102
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "Company Email Address"
-msgstr "E-mailová adresa společnosti"
+msgstr "E-mailová adresa spoločnosti"
 
 #. Label of the company_logo (Attach Image) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -1617,7 +1646,7 @@ msgstr "E-mailová adresa společnosti"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Company Logo"
-msgstr "Logo společnosti"
+msgstr "Logo spoločnosti"
 
 #. Label of the company_name (Data) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -1625,12 +1654,12 @@ msgstr "Logo společnosti"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Company Name"
-msgstr "Název společnosti"
+msgstr "Názov spoločnosti"
 
 #. Label of the company_type (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Company Type"
-msgstr "Typ společnosti"
+msgstr "Typ spoločnosti"
 
 #. Label of the company_website (Data) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -1638,15 +1667,15 @@ msgstr "Typ společnosti"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Company Website"
-msgstr "Web společnosti"
+msgstr "Webová stránka spoločnosti"
 
 #: frontend/src/pages/PersonaForm.vue:120
 msgid "Company or Workplace"
-msgstr "Společnost nebo pracoviště"
+msgstr "Spoločnosť alebo pracovisko"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:72
 msgid "Compiler Message"
-msgstr "Zpráva kompilátoru"
+msgstr "Správa kompilátora"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Course Progress'
 #: frontend/src/pages/Batches/components/BatchStudentProgress.vue:29
@@ -1654,73 +1683,75 @@ msgstr "Zpráva kompilátoru"
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.json
 #: lms/lms/widgets/CourseCard.html:75
 msgid "Complete"
-msgstr "Dokončeno"
+msgstr "Dokončené"
 
 #: lms/templates/emails/lms_invite_request_approved.html:7
 msgid "Complete Sign Up"
-msgstr "Dokončit registraci"
+msgstr "Dokončiť registráciu"
 
 #: lms/templates/emails/payment_reminder.html:15
 msgid "Complete Your Enrollment"
-msgstr "Dokončete svůj zápis"
+msgstr "Dokončite svoj zápis"
 
 #: lms/lms/doctype/lms_payment/lms_payment.py:89
 msgid "Complete Your Enrollment - Don't miss out!"
-msgstr "Dokončete svůj zápis – nenechte si tuto příležitost ujít!"
+msgstr "Dokončite svoj zápis – nenechajte si ujsť túto príležitosť!"
 
 #: frontend/src/components/VideoBlock.vue:148
-msgid "Complete the upcoming quiz to continue watching the video. The quiz will open in {0} {1}."
+msgid ""
+"Complete the upcoming quiz to continue watching the video. The quiz will "
+"open in {0} {1}."
 msgstr ""
-"Dokončete nadcházející kvíz, abyste mohli pokračovat ve sledování videa. Kvíz se otevře za {0} "
-"{1}."
+"Dokončite nasledujúci kvíz, aby ste mohli pokračovať v sledovaní videa. Kvíz"
+" sa otvorí o {0} {1}."
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:106
 #: frontend/src/components/Sidebar/AppSidebar.vue:132
 msgid "Complete your profile"
-msgstr "Dokončete svůj profil"
+msgstr "Dokončite svoj profil"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Certificate Request'
 #: frontend/src/components/StudentLessonSidebar.vue:9
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/widgets/CourseCard.html:78
 msgid "Completed"
-msgstr "Dokončeno"
+msgstr "Dokončené"
 
 #. Label of the enable_certification (Check) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Completion Certificate"
-msgstr "Certifikát o absolvování"
+msgstr "Certifikát o absolvovaní"
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:458
 msgid "Completion Rate"
-msgstr "Míra dokončení"
+msgstr "Miera dokončenia"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:62
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:75
 msgid "Completion certificate"
-msgstr "Certifikát o absolvování"
+msgstr "Certifikát o absolvovaní"
 
 #. Label of the condition (Code) field in DocType 'LMS Badge'
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:75
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Condition"
-msgstr "Podmínka"
+msgstr "Podmienka"
 
 #: lms/lms/doctype/lms_badge/lms_badge.py:17
 msgid "Condition must be in valid JSON format."
-msgstr "Podmínka musí být v platném formátu JSON."
+msgstr "Podmienka musí byť v platnom formáte JSON."
 
 #: lms/lms/doctype/lms_badge/lms_badge.py:22
 msgid "Condition must be valid python code."
-msgstr "Podmínka musí být platný kód jazyka Python."
+msgstr "Podmienka musí byť platný kód v jazyku Python."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.js:7
 msgid "Conduct Evaluation"
-msgstr "Provést hodnocení"
+msgstr "Vykonať hodnotenie"
 
 #: frontend/src/pages/Batches/BatchForm.vue:218
 msgid "Conferencing"
-msgstr "Videokonference"
+msgstr "Videokonferencie"
 
 #. Label of the conferencing_provider (Select) field in DocType 'LMS Batch'
 #. Label of the conferencing_provider (Select) field in DocType 'LMS Live
@@ -1729,67 +1760,67 @@ msgstr "Videokonference"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Conferencing Provider"
-msgstr "Poskytovatel videokonferencí"
+msgstr "Poskytovateľ videokonferencií"
 
 #: frontend/src/components/Sidebar/Configuration.vue:12
 msgid "Configuration"
-msgstr "Konfigurace"
+msgstr "Konfigurácia"
 
 #: frontend/src/components/Settings/PaymentGatewayDetails.vue:5
 msgid "Configure the credentials and options for this payment gateway."
-msgstr "Nastavte přístupové údaje a možnosti této platební brány."
+msgstr "Nastavte prihlasovacie údaje a možnosti tejto platobnej brány."
 
 #: frontend/src/components/Settings/BrandSettings.vue:4
 msgid "Configure your Brand Name, Logo, and Favicon"
-msgstr "Nastavte název značky, logo a faviconu"
+msgstr "Nastavte názov značky, logo a faviconu"
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:185
 #: frontend/src/components/Sidebar/UserDropdown.vue:242
 msgid "Confirm"
-msgstr "Potvrdit"
+msgstr "Potvrdiť"
 
 #: frontend/src/components/UpcomingEvaluations.vue:196
 msgid "Confirm Cancellation?"
-msgstr "Potvrdit zrušení?"
+msgstr "Potvrdiť zrušenie?"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:95
 msgid "Confirm Enrollment"
-msgstr "Potvrdit zápis"
+msgstr "Potvrdiť zápis"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:256
 msgid "Confirm Your Action"
-msgstr "Potvrďte svou akci"
+msgstr "Potvrďte svoju akciu"
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:236
 msgid "Confirm clearing demo data?"
-msgstr "Potvrdit vymazání ukázkových dat?"
+msgstr "Potvrdiť vymazanie ukážkových údajov?"
 
 #: frontend/src/pages/Batches/BatchForm.vue:557
 msgid "Confirm your action to delete"
-msgstr "Potvrďte smazání"
+msgstr "Potvrďte odstránenie"
 
 #. Label of the confirmation_email_sent (Check) field in DocType 'LMS Batch
 #. Enrollment'
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.json
 msgid "Confirmation Email Sent"
-msgstr "Potvrzovací e-mail byl odeslán"
+msgstr "Potvrdzovací e-mail bol odoslaný"
 
 #. Label of the confirmation_email_template (Link) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Confirmation Email Template"
-msgstr "Šablona potvrzovacího e-mailu"
+msgstr "Šablóna potvrdzovacieho e-mailu"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:33
 msgid "Congratulations on getting certified!"
-msgstr "Gratulujeme k získání certifikátu!"
+msgstr "Gratulujeme k získaniu certifikátu!"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:5
 msgid "Connect a Google Meet account to schedule and host live classes."
-msgstr "Připojte účet Google Meet pro plánování a pořádání živých lekcí."
+msgstr "Prepojte účet Google Meet na plánovanie a organizovanie živých lekcií."
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:5
 msgid "Connect a Zoom account to schedule and host live classes."
-msgstr "Připojte účet Zoom pro plánování a pořádání živých lekcí."
+msgstr "Prepojte účet Zoom na plánovanie a organizovanie živých lekcií."
 
 #. Label of the contact_us_tab (Tab Break) field in DocType 'LMS Settings'
 #: frontend/src/components/ContactUsEmail.vue:2
@@ -1800,20 +1831,20 @@ msgstr "Kontaktujte nás"
 #. Label of the contact_us_email (Data) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Contact Us Email"
-msgstr "Kontaktní e-mail"
+msgstr "Kontaktný e-mail"
 
 #. Label of the contact_us_url (Data) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Contact Us URL"
-msgstr "URL kontaktní stránky"
+msgstr "URL kontaktnej stránky"
 
 #: frontend/src/components/CourseCardOverlay.vue:63
 msgid "Contact the Administrator to enroll for this course"
-msgstr "Pro zápis do tohoto kurzu kontaktujte administrátora"
+msgstr "Pre zápis do tohto kurzu kontaktujte administrátora"
 
 #: frontend/src/pages/Lesson.vue:54
 msgid "Contact the Administrator to enroll for this course."
-msgstr "Pro zápis do tohoto kurzu kontaktujte administrátora."
+msgstr "Pre zápis do tohto kurzu kontaktujte administrátora."
 
 #. Label of the content (Text) field in DocType 'Course Lesson'
 #. Label of the content (Rating) field in DocType 'LMS Batch Feedback'
@@ -1837,7 +1868,7 @@ msgstr "Obsah je povinný"
 
 #: frontend/src/components/CourseCardOverlay.vue:32
 msgid "Continue Learning"
-msgstr "Pokračovat ve studiu"
+msgstr "Pokračovať v štúdiu"
 
 #. Option for the 'Type' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -1845,33 +1876,33 @@ msgstr "Pokračovat ve studiu"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Contract"
-msgstr "Smlouva"
+msgstr "Zmluva"
 
 #. Option for the 'Company Type' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Corporate Organization"
-msgstr "Firemní organizace"
+msgstr "Firemná organizácia"
 
 #: frontend/src/components/Quiz.vue:224
 msgid "Correct"
-msgstr "Správně"
+msgstr "Správne"
 
 #: frontend/src/components/Modals/Question.vue:88
 msgid "Correct Answer"
-msgstr "Správná odpověď"
+msgstr "Správna odpoveď"
 
 #: lms/lms/course_import_export.py:196
 msgid "Could not create the course ZIP file. Please try again later. Error: {0}"
-msgstr "Soubor ZIP kurzu se nepodařilo vytvořit. Zkuste to prosím později. Chyba: {0}"
+msgstr "Súbor ZIP kurzu sa nepodarilo vytvoriť. Skúste to, prosím, neskôr. Chyba: {0}"
 
 #: frontend/src/pages/QuizForm.vue:330
 msgid "Could not delete the quiz"
-msgstr "Kvíz se nepodařilo smazat"
+msgstr "Kvíz sa nepodarilo odstrániť"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:271
 #: frontend/src/pages/Courses/CourseDetail.vue:256
 msgid "Could not update publish status"
-msgstr "Stav zveřejnění se nepodařilo aktualizovat"
+msgstr "Stav zverejnenia sa nepodarilo aktualizovať"
 
 #. Label of the country (Link) field in DocType 'User'
 #. Label of the country (Link) field in DocType 'Job Opportunity'
@@ -1881,7 +1912,7 @@ msgstr "Stav zveřejnění se nepodařilo aktualizovat"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/lms/doctype/payment_country/payment_country.json
 msgid "Country"
-msgstr "Země"
+msgstr "Krajina"
 
 #. Label of the coupon (Link) field in DocType 'LMS Payment'
 #: lms/lms/doctype/lms_payment/lms_payment.json
@@ -1902,19 +1933,19 @@ msgstr "Podrobnosti kupónu"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:148
 msgid "Coupon created successfully"
-msgstr "Kupón byl úspěšně vytvořen"
+msgstr "Kupón bol úspešne vytvorený"
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:148
 msgid "Coupon deleted successfully"
-msgstr "Kupón byl úspěšně smazán"
+msgstr "Kupón bol úspešne odstránený"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:156
 msgid "Coupon updated successfully"
-msgstr "Kupón byl úspěšně aktualizován"
+msgstr "Kupón bol úspešne aktualizovaný"
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:135
 msgid "Coupon(s) deleted successfully"
-msgstr "Kupóny byly úspěšně smazány"
+msgstr "Kupóny boli úspešne odstránené"
 
 #. Label of the course (Link) field in DocType 'Batch Course'
 #. Label of the course (Link) field in DocType 'Course Chapter'
@@ -1984,7 +2015,7 @@ msgstr "Kapitola kurzu"
 #. Label of a shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Course Completed"
-msgstr "Kurz dokončen"
+msgstr "Kurz dokončený"
 
 #: frontend/src/pages/Statistics.vue:37
 msgid "Course Completions"
@@ -1992,12 +2023,12 @@ msgstr "Dokončené kurzy"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:110
 msgid "Course Content coming soon!"
-msgstr "Obsah kurzu bude brzy k dispozici!"
+msgstr "Obsah kurzu bude čoskoro k dispozícii!"
 
 #. Label of the course_count (Int) field in DocType 'LMS Program'
 #: lms/lms/doctype/lms_program/lms_program.json
 msgid "Course Count"
-msgstr "Počet kurzů"
+msgstr "Počet kurzov"
 
 #. Name of a role
 #: frontend/src/components/Modals/NewMemberModal.vue:54
@@ -2024,12 +2055,12 @@ msgstr "Počet kurzů"
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 msgid "Course Creator"
-msgstr "Tvůrce kurzu"
+msgstr "Tvorca kurzu"
 
 #. Label of a Card Break in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Course Data"
-msgstr "Data kurzu"
+msgstr "Údaje kurzu"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:11
 msgid "Course Description"
@@ -2042,12 +2073,12 @@ msgstr "Zápis do kurzu"
 
 #: frontend/src/pages/Statistics.vue:28
 msgid "Course Enrollments"
-msgstr "Zápisy do kurzů"
+msgstr "Zápisy do kurzov"
 
 #. Name of a DocType
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
 msgid "Course Evaluator"
-msgstr "Hodnotitel kurzu"
+msgstr "Hodnotiteľ kurzu"
 
 #. Name of a DocType
 #: lms/lms/doctype/course_instructor/course_instructor.json
@@ -2057,42 +2088,42 @@ msgstr "Lektor kurzu"
 #. Name of a DocType
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Course Lesson"
-msgstr "Lekce kurzu"
+msgstr "Lekcia kurzu"
 
 #: lms/www/_lms.py:94
 msgid "Course List"
-msgstr "Seznam kurzů"
+msgstr "Zoznam kurzov"
 
 #: lms/lms/report/course_progress_summary/course_progress_summary.py:58
 msgid "Course Name"
-msgstr "Název kurzu"
+msgstr "Názov kurzu"
 
 #. Label of the course_progress_section (Tab Break) field in DocType 'LMS
 #. Settings'
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:30
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Course Progress"
-msgstr "Průběh kurzu"
+msgstr "Priebeh kurzu"
 
 #. Name of a report
 #: lms/lms/report/course_progress_summary/course_progress_summary.json
 msgid "Course Progress Summary"
-msgstr "Souhrn průběhu kurzu"
+msgstr "Súhrn priebehu kurzu"
 
 #. Label of a Workspace Sidebar Item
 #: lms/workspace_sidebar/learning.json
 msgid "Course Reviews"
-msgstr "Recenze kurzu"
+msgstr "Recenzie kurzu"
 
 #. Label of the section_break_7 (Section Break) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Course Settings"
-msgstr "Nastavení kurzu"
+msgstr "Nastavenia kurzu"
 
 #. Label of a Card Break in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Course Stats"
-msgstr "Statistiky kurzu"
+msgstr "Štatistiky kurzu"
 
 #. Label of the title (Data) field in DocType 'Batch Course'
 #. Label of the course_title (Data) field in DocType 'Course Chapter'
@@ -2105,19 +2136,19 @@ msgstr "Statistiky kurzu"
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/doctype/lms_program_course/lms_program_course.json
 msgid "Course Title"
-msgstr "Název kurzu"
+msgstr "Názov kurzu"
 
 #: frontend/src/components/Modals/BatchCourseModal.vue:80
 msgid "Course added to batch successfully"
-msgstr "Kurz byl úspěšně přidán do školicího kola"
+msgstr "Kurz bol úspešne pridaný do školiaceho kola"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:438
 msgid "Course added to program successfully"
-msgstr "Kurz byl úspěšně přidán do programu"
+msgstr "Kurz bol úspešne pridaný do programu"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:440
 msgid "Course already added to program"
-msgstr "Kurz již byl do programu přidán"
+msgstr "Kurz už bol pridaný do programu"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:93
 msgid "Course content"
@@ -2125,15 +2156,15 @@ msgstr "Obsah kurzu"
 
 #: frontend/src/pages/Courses/NewCourseModal.vue:315
 msgid "Course created successfully"
-msgstr "Kurz byl úspěšně vytvořen"
+msgstr "Kurz bol úspešne vytvorený"
 
 #: frontend/src/components/CourseCreatorCard.vue:138
 msgid "Course creator"
-msgstr "tvůrce kurzu"
+msgstr "tvorca kurzu"
 
 #: frontend/src/pages/Courses/CourseForm.vue:248
 msgid "Course deleted successfully"
-msgstr "Kurz byl úspěšně smazán"
+msgstr "Kurz bol úspešne odstránený"
 
 #: frontend/src/pages/Courses/NewCourseModal.vue:79
 msgid "Course description"
@@ -2149,11 +2180,11 @@ msgstr "Editor kurzu"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:69
 msgid "Course or Batch is required to issue a certificate."
-msgstr "K vystavení certifikátu je nutné vybrat kurz nebo školicí kolo."
+msgstr "Na vydanie certifikátu je potrebné vybrať kurz alebo školiace kolo."
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:4
 msgid "Course overview"
-msgstr "Přehled kurzu"
+msgstr "Prehľad kurzu"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:53
 msgid "Course price"
@@ -2161,29 +2192,29 @@ msgstr "Cena kurzu"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:248
 msgid "Course published"
-msgstr "Kurz byl zveřejněn"
+msgstr "Kurz bol zverejnený"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:4
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:26
 #: frontend/src/pages/Courses/NewCourseModal.vue:64
 msgid "Course thumbnail"
-msgstr "Náhledový obrázek kurzu"
+msgstr "Náhľadový obrázok kurzu"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:248
 msgid "Course unpublished"
-msgstr "Zveřejnění kurzu bylo zrušeno"
+msgstr "Zverejnenie kurzu bolo zrušené"
 
 #: frontend/src/pages/Courses/CourseForm.vue:224
 msgid "Course updated successfully"
-msgstr "Kurz byl úspěšně aktualizován"
+msgstr "Kurz bol úspešne aktualizovaný"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:64
 msgid "Course {0} has already been added to this batch."
-msgstr "Kurz {0} již byl do tohoto školicího kola přidán."
+msgstr "Kurz {0} už bol pridaný do tohto školiaceho kola."
 
 #: lms/lms/doctype/lms_program/lms_program.py:22
 msgid "Course {0} has already been added to this program."
-msgstr "Kurz {0} již byl do tohoto programu přidán."
+msgstr "Kurz {0} už bol pridaný do tohto programu."
 
 #. Label of the courses (Table) field in DocType 'LMS Batch'
 #. Label of the show_courses (Check) field in DocType 'LMS Settings'
@@ -2214,26 +2245,28 @@ msgstr "Dokončené kurzy"
 
 #: frontend/src/pages/Home/AdminHome.vue:113
 msgid "Courses Created"
-msgstr "Vytvořené kurzy"
+msgstr "Vytvorené kurzy"
 
 #: frontend/src/pages/Batches/components/BatchCourses.vue:137
 msgid "Courses deleted successfully"
-msgstr "Kurzy byly úspěšně smazány"
+msgstr "Kurzy boli úspešne odstránené"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:39
 msgid "Courses in this Program"
-msgstr "Kurzy v tomto programu"
+msgstr "Kurzy v tomto programe"
 
 #: frontend/src/pages/Programs/ProgramDetail.vue:21
 msgid ""
-"Courses must be completed in order. You can only start the next course after completing the "
-"previous one."
-msgstr "Kurzy je nutné absolvovat v daném pořadí. Další kurz můžete zahájit až po dokončení předchozího."
+"Courses must be completed in order. You can only start the next course after"
+" completing the previous one."
+msgstr ""
+"Kurzy je potrebné absolvovať v určenom poradí. Ďalší kurz môžete začať až po"
+" dokončení predchádzajúceho."
 
 #. Label of the cover_image (Attach Image) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Cover Image"
-msgstr "Titulní obrázek"
+msgstr "Titulný obrázok"
 
 #: frontend/src/components/Controls/Link.vue:46
 #: frontend/src/components/Controls/Link.vue:49
@@ -2249,93 +2282,95 @@ msgstr "Titulní obrázek"
 #: frontend/src/pages/Programs/Programs.vue:15
 #: frontend/src/pages/Quizzes.vue:11
 msgid "Create"
-msgstr "Vytvořit"
+msgstr "Vytvoriť"
 
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.js:7
 msgid "Create Certificate"
-msgstr "Vytvořit certifikát"
+msgstr "Vytvoriť certifikát"
 
 #: frontend/src/pages/Home/AdminHome.vue:191
 msgid "Create Course"
-msgstr "Vytvořit kurz"
+msgstr "Vytvoriť kurz"
 
 #: frontend/src/components/Controls/Link.vue:65
 #: frontend/src/components/Controls/Link.vue:71
 #: frontend/src/components/Controls/MultiSelect.vue:85
 msgid "Create New"
-msgstr "Vytvořit novou položku"
+msgstr "Vytvoriť novú položku"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:7
 msgid "Create Program"
-msgstr "Vytvořit program"
+msgstr "Vytvoriť program"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:8
 msgid "Create Programming Exercise"
-msgstr "Vytvořit programovací cvičení"
+msgstr "Vytvoriť programovacie cvičenie"
 
 #: lms/templates/onboarding_header.html:19
 msgid "Create a Course"
-msgstr "Vytvořit kurz"
+msgstr "Vytvoriť kurz"
 
 #: frontend/src/components/Modals/LiveClassModal.vue:4
 msgid "Create a Live Class"
-msgstr "Vytvořit živou lekci"
+msgstr "Vytvoriť živú lekciu"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:598
 msgid "Create a batch"
-msgstr "Vytvořit školicí kolo"
+msgstr "Vytvoriť školiace kolo"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:589
 msgid "Create a course"
-msgstr "Vytvořit kurz"
+msgstr "Vytvoriť kurz"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:599
 msgid "Create a live class"
-msgstr "Vytvořit živou lekci"
+msgstr "Vytvoriť živú lekciu"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:122
 msgid "Create a new Badge"
-msgstr "Vytvořit nový odznak"
+msgstr "Vytvoriť nový odznak"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:5
 msgid "Create a reusable email template for your notifications."
-msgstr "Vytvořte opakovaně použitelnou e-mailovou šablonu pro oznámení."
+msgstr "Vytvorte opakovane použiteľnú e-mailovú šablónu pre svoje oznámenia."
 
 #: frontend/src/components/Modals/AssignmentForm.vue:8
 msgid "Create an Assignment"
-msgstr "Vytvořit úkol"
+msgstr "Vytvoriť úlohu"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:5
 msgid "Create and manage reusable email templates for your notifications."
-msgstr "Vytvářejte a spravujte opakovaně použitelné e-mailové šablony pro oznámení."
+msgstr ""
+"Vytvárajte a spravujte opakovane použiteľné e-mailové šablóny pre svoje "
+"oznámenia."
 
 #: frontend/src/components/CourseOutline.vue:34
 msgid "Create chapter"
-msgstr "Vytvořit kapitolu"
+msgstr "Vytvoriť kapitolu"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:523
 msgid "Create your first batch"
-msgstr "Vytvořte své první školicí kolo"
+msgstr "Vytvorte svoje prvé školiace kolo"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:449
 msgid "Create your first course"
-msgstr "Vytvořte svůj první kurz"
+msgstr "Vytvorte svoj prvý kurz"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:501
 msgid "Create your first quiz"
-msgstr "Vytvořte svůj první kvíz"
+msgstr "Vytvorte svoj prvý kvíz"
 
 #: frontend/src/pages/Courses/Courses.vue:320
 msgid "Created"
-msgstr "Vytvořeno"
+msgstr "Vytvorené"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:595
 msgid "Creating a batch"
-msgstr "Vytvoření školicího kola"
+msgstr "Vytvorenie školiaceho kola"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:586
 msgid "Creating a course"
-msgstr "Vytvoření kurzu"
+msgstr "Vytvorenie kurzu"
 
 #. Label of the currency (Link) field in DocType 'LMS Batch'
 #. Label of the currency (Link) field in DocType 'LMS Course'
@@ -2348,16 +2383,16 @@ msgstr "Vytvoření kurzu"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Currency"
-msgstr "Měna"
+msgstr "Mena"
 
 #. Label of the current_lesson (Link) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Current Lesson"
-msgstr "Aktuální lekce"
+msgstr "Aktuálna lekcia"
 
 #: frontend/src/pages/Home/Streak.vue:29
 msgid "Current Streak"
-msgstr "Aktuální série"
+msgstr "Aktuálna séria"
 
 #: frontend/src/pages/Batches/components/BatchDashboard.vue:7
 msgid "Curriculum"
@@ -2365,47 +2400,47 @@ msgstr "Osnovy"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:622
 msgid "Custom Certificate Templates"
-msgstr "Vlastní šablony certifikátů"
+msgstr "Vlastné šablóny certifikátov"
 
 #. Label of the custom_component (Code) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Custom HTML"
-msgstr "Vlastní HTML"
+msgstr "Vlastné HTML"
 
 #. Label of the custom_script (Code) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Custom Script (JavaScript)"
-msgstr "Vlastní skript (JavaScript)"
+msgstr "Vlastný skript (JavaScript)"
 
 #. Label of the custom_signup_content (HTML Editor) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Custom Signup Content"
-msgstr "Vlastní obsah registrační stránky"
+msgstr "Vlastný obsah registračnej stránky"
 
 #: frontend/src/pages/PersonaForm.vue:123
 msgid "Customer Academy"
-msgstr "Akademie pro zákazníky"
+msgstr "Akadémia pre zákazníkov"
 
 #. Label of the customisations_tab (Tab Break) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Customisations"
-msgstr "Přizpůsobení"
+msgstr "Prispôsobenia"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Cyan"
-msgstr "Azurová"
+msgstr "Azúrová"
 
 #. Label of the show_dashboard (Check) field in DocType 'LMS Settings'
 #: frontend/src/pages/Courses/CourseDetail.vue:312
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Dashboard"
-msgstr "Přehled"
+msgstr "Prehľad"
 
 #: frontend/src/pages/DataImport.vue:46
 msgid "Data Import"
-msgstr "Import dat"
+msgstr "Import údajov"
 
 #. Label of the date (Date) field in DocType 'LMS Batch Timetable'
 #. Label of the date (Date) field in DocType 'LMS Certificate Evaluation'
@@ -2420,11 +2455,11 @@ msgstr "Import dat"
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
 msgid "Date"
-msgstr "Datum"
+msgstr "Dátum"
 
 #: lms/templates/emails/live_class_reminder.html:13
 msgid "Date:"
-msgstr "Datum:"
+msgstr "Dátum:"
 
 #. Label of the day (Select) field in DocType 'Evaluator Schedule'
 #. Label of the day (Int) field in DocType 'LMS Batch Timetable'
@@ -2434,12 +2469,12 @@ msgstr "Datum:"
 #: lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Day"
-msgstr "Den"
+msgstr "Deň"
 
 #: lms/templates/emails/mentor_request_creation_email.html:2
 #: lms/templates/emails/mentor_request_status_update_email.html:2
 msgid "Dear"
-msgstr "Dobrý den"
+msgstr "Dobrý deň"
 
 #: lms/templates/emails/batch_confirmation.html:2
 #: lms/templates/emails/batch_start_reminder.html:2
@@ -2447,44 +2482,45 @@ msgstr "Dobrý den"
 #: lms/templates/emails/certification.html:2
 #: lms/templates/emails/live_class_reminder.html:2
 msgid "Dear "
-msgstr "Dobrý den, "
+msgstr "Dobrý deň, "
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:64
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:109
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:108
 msgid ""
-"Dear {{ member_name }},\\n\\nYou have been enrolled in our upcoming batch {{ batch_name "
-"}}.\\n\\nThanks,\\nFrappe Learning"
+"Dear {{ member_name }},\\n\\nYou have been enrolled in our upcoming batch {{"
+" batch_name }}.\\n\\nThanks,\\nFrappe Learning"
 msgstr ""
-"Dobrý den, {{ member_name }},\\n\\nbyli jste zapsáni do našeho nadcházejícího školicího kola {{ "
-"batch_name }}.\\n\\nDěkujeme,\\nFrappe Learning"
+"Dobrý deň, {{ member_name }},\\n\\nBoli ste zapísaní do nášho "
+"nadchádzajúceho školiaceho kola {{ batch_name }}.\\n\\nĎakujeme,\\nFrappe"
+" Learning"
 
 
 
 #: frontend/src/pages/QuizForm.vue:234
 msgid "Deduct marks for incorrect answers."
-msgstr "Odečítat body za nesprávné odpovědi."
+msgstr "Odpočítavať body za nesprávne odpovede."
 
 #. Label of the default_currency (Link) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Default Currency"
-msgstr "Výchozí měna"
+msgstr "Predvolená mena"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:201
 msgid "Default Inbox"
-msgstr "Výchozí účet pro příjem"
+msgstr "Predvolený účet pre prijímanie"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:203
 msgid "Default Sending"
-msgstr "Výchozí účet pro odesílání"
+msgstr "Predvolený účet pre odosielanie"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:199
 msgid "Default Sending & Inbox"
-msgstr "Výchozí účet pro odesílání a příjem"
+msgstr "Predvolený účet pre odosielanie a prijímanie"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:5
 msgid "Define a badge and the criteria for awarding it to learners."
-msgstr "Definujte odznak a kritéria pro jeho udělení studentům."
+msgstr "Definujte odznak a kritériá na jeho udelenie študentom."
 
 #. Label of the degree_type (Data) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
@@ -2511,110 +2547,118 @@ msgstr "Typ titulu"
 #: frontend/src/pages/Programs/ProgramForm.vue:561
 #: frontend/src/pages/QuizForm.vue:319
 msgid "Delete"
-msgstr "Smazat"
+msgstr "Odstrániť"
 
 #: frontend/src/components/ChapterRow.vue:55
 msgid "Delete Chapter"
-msgstr "Smazat kapitolu"
+msgstr "Odstrániť kapitolu"
 
 #: frontend/src/pages/Courses/CourseForm.vue:261
 msgid "Delete Course"
-msgstr "Smazat kurz"
+msgstr "Odstrániť kurz"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:555
 msgid "Delete Program"
-msgstr "Smazat program"
+msgstr "Odstrániť program"
 
 #: frontend/src/pages/QuizForm.vue:42 frontend/src/pages/QuizForm.vue:45
 msgid "Delete quiz"
-msgstr "Smazat kvíz"
+msgstr "Odstrániť kvíz"
 
 #: frontend/src/components/CourseOutline.vue:371
 msgid "Delete this chapter?"
-msgstr "Smazat tuto kapitolu?"
+msgstr "Odstrániť túto kapitolu?"
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:121
 msgid "Delete this coupon?"
-msgstr "Smazat tento kupón?"
+msgstr "Odstrániť tento kupón?"
 
 #: frontend/src/components/CourseOutline.vue:345
 msgid "Delete this lesson?"
-msgstr "Smazat tuto lekci?"
+msgstr "Odstrániť túto lekciu?"
 
 #: frontend/src/pages/QuizForm.vue:313
 msgid "Delete this quiz?"
-msgstr "Smazat tento kvíz?"
+msgstr "Odstrániť tento kvíz?"
 
 #: frontend/src/components/Settings/Members.vue:293
 msgid "Delete user"
-msgstr "Smazat uživatele"
+msgstr "Odstrániť používateľa"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:101
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:83
 #: frontend/src/components/Settings/Members.vue:114
 msgid "Delete {0}?"
-msgstr "Smazat {0}?"
+msgstr "Odstrániť {0}?"
 
 #: frontend/src/pages/Courses/CourseForm.vue:262
 msgid ""
-"Deleting the course will also delete all its chapters and lessons. Are you sure you want to "
-"delete this course?"
-msgstr "Smazáním kurzu se smažou také všechny jeho kapitoly a lekce. Opravdu chcete tento kurz smazat?"
+"Deleting the course will also delete all its chapters and lessons. Are you "
+"sure you want to delete this course?"
+msgstr ""
+"Odstránením kurzu sa odstránia aj všetky jeho kapitoly a lekcie. Naozaj "
+"chcete tento kurz odstrániť?"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:257
 msgid ""
-"Deleting these exercises will permanently remove them from the system, along with all associated "
-"submissions. This action is irreversible. Are you sure you want to proceed?"
+"Deleting these exercises will permanently remove them from the system, along"
+" with all associated submissions. This action is irreversible. Are you sure "
+"you want to proceed?"
 msgstr ""
-"Smazáním těchto cvičení je trvale odstraníte ze systému včetně všech souvisejících odevzdání. "
-"Tuto akci nelze vrátit zpět. Opravdu chcete pokračovat?"
+"Odstránením týchto cvičení ich natrvalo odstránite zo systému vrátane "
+"všetkých súvisiacich odovzdaní. Táto akcia je nezvratná. Naozaj chcete "
+"pokračovať?"
 
 #: frontend/src/pages/Batches/BatchForm.vue:558
 msgid ""
-"Deleting this batch will also delete all its data including enrolled students, linked courses, "
-"assessments, feedback and discussions. Are you sure you want to continue?"
+"Deleting this batch will also delete all its data including enrolled "
+"students, linked courses, assessments, feedback and discussions. Are you "
+"sure you want to continue?"
 msgstr ""
-"Smazáním tohoto školicího kola se smažou také všechna jeho data včetně zapsaných studentů, "
-"propojených kurzů, hodnocení, zpětné vazby a diskuzí. Opravdu chcete pokračovat?"
+"Odstránením tohto školiaceho kola sa odstránia aj všetky jeho údaje "
+"vrátane zapísaných študentov, prepojených kurzov, hodnotení, spätnej "
+"väzby a diskusií. Naozaj chcete pokračovať?"
 
 
 
 #: frontend/src/components/CourseOutline.vue:372
 msgid ""
-"Deleting this chapter will also delete all its lessons and permanently remove it from the course."
-" This action cannot be undone. Are you sure you want to continue?"
+"Deleting this chapter will also delete all its lessons and permanently "
+"remove it from the course. This action cannot be undone. Are you sure you "
+"want to continue?"
 msgstr ""
-"Smazáním této kapitoly se smažou také všechny její lekce a kapitola bude z kurzu trvale "
-"odstraněna. Tuto akci nelze vrátit zpět. Opravdu chcete pokračovat?"
+"Odstránením tejto kapitoly sa odstránia aj všetky jej lekcie a kapitola sa "
+"natrvalo odstráni z kurzu. Túto akciu nemožno vrátiť späť. Naozaj chcete "
+"pokračovať?"
 
 #: frontend/src/components/CourseOutline.vue:346
 msgid ""
-"Deleting this lesson will permanently remove it from the course. This action cannot be undone. "
-"Are you sure you want to continue?"
+"Deleting this lesson will permanently remove it from the course. This action"
+" cannot be undone. Are you sure you want to continue?"
 msgstr ""
-"Smazáním této lekce ji trvale odstraníte z kurzu. Tuto akci nelze vrátit zpět. Opravdu chcete "
-"pokračovat?"
+"Odstránením tejto lekcie ju natrvalo odstránite z kurzu. Túto akciu nemožno "
+"vrátiť späť. Naozaj chcete pokračovať?"
 
 #: frontend/src/pages/QuizForm.vue:314
 msgid ""
-"Deleting this quiz permanently removes it and its submissions. This action cannot be undone. Are "
-"you sure you want to continue?"
+"Deleting this quiz permanently removes it and its submissions. This action "
+"cannot be undone. Are you sure you want to continue?"
 msgstr ""
-"Smazáním tohoto kvízu trvale odstraníte kvíz i všechna jeho odevzdání. Tuto akci nelze vrátit "
-"zpět. Opravdu chcete pokračovat?"
+"Odstránením tohto kvízu natrvalo odstránite kvíz aj všetky jeho odovzdania. "
+"Túto akciu nemožno vrátiť späť. Naozaj chcete pokračovať?"
 
 #: lms/lms/api.py:887
 msgid "Deletion not allowed for {0}"
-msgstr "Smazání není pro {0} povoleno"
+msgstr "Odstránenie nie je pre {0} povolené"
 
 #. Label of the demo_data_present (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Demo Data Present"
-msgstr "Ukázková data jsou k dispozici"
+msgstr "Ukážkové údaje sú k dispozícii"
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:258
 msgid "Demo data cleared successfully"
-msgstr "Ukázková data byla úspěšně vymazána"
+msgstr "Ukážkové údaje boli úspešne vymazané"
 
 #. Label of the description (Text Editor) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -2641,7 +2685,7 @@ msgstr "Popis"
 
 #: frontend/src/components/Sidebar/Apps.vue:49
 msgid "Desk"
-msgstr "Administrace"
+msgstr "Administrácia"
 
 #: frontend/src/components/Modals/DiscussionModal.vue:20
 #: frontend/src/pages/Batches/BatchForm.vue:7
@@ -2651,26 +2695,26 @@ msgstr "Podrobnosti"
 
 #: frontend/src/components/Modals/DiscussionModal.vue:70
 msgid "Details cannot be empty."
-msgstr "Podrobnosti nesmí být prázdné."
+msgstr "Podrobnosti nesmú byť prázdne."
 
 #: frontend/src/pages/Courses/CourseImportModal.vue:28
 msgid "Device"
-msgstr "Zařízení"
+msgstr "Zariadenie"
 
 #. Label of the disable_pwa (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Disable PWA"
-msgstr "Zakázat PWA"
+msgstr "Zakázať PWA"
 
 #. Label of the disable_self_learning (Check) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Disable Self Learning"
-msgstr "Zakázat samostatné studium"
+msgstr "Zakázať samostatné štúdium"
 
 #. Label of the disable_signup (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Disable Signup"
-msgstr "Zakázat registraci"
+msgstr "Zakázať registráciu"
 
 #: frontend/src/components/Settings/Badges/Badges.vue:48
 #: frontend/src/components/Settings/Coupons/CouponList.vue:38
@@ -2678,48 +2722,52 @@ msgstr "Zakázat registraci"
 #: frontend/src/components/Settings/PaymentGateways.vue:50
 #: frontend/src/components/Settings/ZoomSettings.vue:60
 msgid "Disabled"
-msgstr "Zakázáno"
+msgstr "Zakázané"
 
 #: frontend/src/components/DiscussionReplies.vue:63
 #: lms/lms/widgets/NoPreviewModal.html:25
 msgid "Discard"
-msgstr "Zahodit"
+msgstr "Zahodiť"
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:163
 #: frontend/src/pages/Billing.vue:41
 msgid "Discount"
-msgstr "Sleva"
+msgstr "Zľava"
 
 #. Label of the discount_amount (Currency) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:61
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:123
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Discount Amount"
-msgstr "Výše slevy"
+msgstr "Výška zľavy"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:54
 msgid "Discount Percentage"
-msgstr "Procento slevy"
+msgstr "Percento zľavy"
 
 #. Label of the discount_type (Select) field in DocType 'LMS Coupon'
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:38
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Discount Type"
-msgstr "Typ slevy"
+msgstr "Typ zľavy"
 
 #. Label of the show_discussions (Check) field in DocType 'LMS Settings'
 #: frontend/src/pages/Batches/BatchDetail.vue:94
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Discussions"
-msgstr "Diskuze"
+msgstr "Diskusie"
 
 #: frontend/src/pages/QuizForm.vue:207
 msgid "Display correct answers after each question is attempted."
-msgstr "Po zodpovězení každé otázky zobrazit správné odpovědi."
+msgstr "Po zodpovedaní každej otázky zobraziť správne odpovede."
 
 #: frontend/src/components/Quiz.vue:25
-msgid "Do not refresh the page or close this window. If you do, the quiz will be submitted automatically."
-msgstr "Neobnovujte stránku ani nezavírejte toto okno. V opačném případě bude kvíz automaticky odeslán."
+msgid ""
+"Do not refresh the page or close this window. If you do, the quiz will be "
+"submitted automatically."
+msgstr ""
+"Neobnovujte stránku ani nezatvárajte toto okno. Inak sa kvíz automaticky "
+"odošle."
 
 #. Option for the 'File Type' (Select) field in DocType 'Course Lesson'
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment'
@@ -2732,37 +2780,41 @@ msgstr "Dokument"
 
 #: frontend/src/components/Settings/Coupons/CouponItems.vue:15
 msgid "Document Name"
-msgstr "Název dokumentu"
+msgstr "Názov dokumentu"
 
 #: frontend/src/components/Settings/Coupons/CouponItems.vue:12
 msgid "Document Type"
 msgstr "Typ dokumentu"
 
 #: lms/templates/emails/payment_reminder.html:11
-msgid "Don’t miss this opportunity to enhance your skills. Click below to complete your enrollment"
-msgstr "Nenechte si ujít příležitost rozšířit své dovednosti. Kliknutím níže dokončete zápis."
+msgid ""
+"Don’t miss this opportunity to enhance your skills. Click below to complete "
+"your enrollment"
+msgstr ""
+"Nenechajte si ujsť príležitosť rozšíriť svoje zručnosti. Kliknutím nižšie "
+"dokončite zápis."
 
 #: frontend/src/pages/Courses/CourseImportModal.vue:23
 msgid "Drag and drop a ZIP file, or upload from your"
-msgstr "Přetáhněte sem soubor ZIP nebo jej nahrajte ze svého"
+msgstr "Presuňte sem súbor ZIP alebo ho nahrajte zo svojho"
 
 #. Label of the dream_companies (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Dream Companies"
-msgstr "Vysněné společnosti"
+msgstr "Vysnívané spoločnosti"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:12
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:176
 msgid "Duplicate"
-msgstr "Duplikovat"
+msgstr "Duplikovať"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:3
 msgid "Duplicate Template"
-msgstr "Duplikovat šablonu"
+msgstr "Duplikovať šablónu"
 
 #: lms/lms/doctype/lms_question/lms_question.py:37
 msgid "Duplicate options found for this question."
-msgstr "U této otázky byly nalezeny duplicitní možnosti."
+msgstr "Pri tejto otázke sa našli duplicitné možnosti."
 
 #. Label of the duration (Data) field in DocType 'LMS Batch Timetable'
 #. Label of the duration (Int) field in DocType 'LMS Live Class'
@@ -2771,17 +2823,17 @@ msgstr "U této otázky byly nalezeny duplicitní možnosti."
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 msgid "Duration"
-msgstr "Délka"
+msgstr "Trvanie"
 
 #. Label of the duration (Data) field in DocType 'LMS Quiz'
 #: frontend/src/components/Modals/LiveClassModal.vue:33
 #: frontend/src/pages/QuizForm.vue:170 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Duration (in minutes)"
-msgstr "Délka (v minutách)"
+msgstr "Trvanie (v minútach)"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:57
 msgid "Each user can only receive this badge one time."
-msgstr "Každý uživatel může tento odznak získat pouze jednou."
+msgstr "Každý používateľ môže tento odznak získať iba raz."
 
 #: frontend/src/components/DiscussionReplies.vue:41
 #: frontend/src/components/Modals/ChapterModal.vue:8
@@ -2791,101 +2843,101 @@ msgstr "Každý uživatel může tento odznak získat pouze jednou."
 #: frontend/src/pages/JobDetail.vue:45 frontend/src/pages/Lesson.vue:125
 #: frontend/src/pages/Profile.vue:44
 msgid "Edit"
-msgstr "Upravit"
+msgstr "Upraviť"
 
 #: frontend/src/components/Modals/AssignmentForm.vue:9
 msgid "Edit Assignment"
-msgstr "Upravit úkol"
+msgstr "Upraviť úlohu"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:121
 msgid "Edit Badge"
-msgstr "Upravit odznak"
+msgstr "Upraviť odznak"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:7
 msgid "Edit Badge Assignment"
-msgstr "Upravit přiřazení odznaku"
+msgstr "Upraviť priradenie odznaku"
 
 #: frontend/src/components/ChapterRow.vue:48
 #: frontend/src/components/Modals/ChapterModal.vue:4
 msgid "Edit Chapter"
-msgstr "Upravit kapitolu"
+msgstr "Upraviť kapitolu"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:3
 msgid "Edit Coupon"
-msgstr "Upravit kupón"
+msgstr "Upraviť kupón"
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:3
 msgid "Edit Email"
-msgstr "Upravit e-mail"
+msgstr "Upraviť e-mail"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:5
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:3
 msgid "Edit Email Template"
-msgstr "Upravit e-mailovou šablonu"
+msgstr "Upraviť e-mailovú šablónu"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:105
 msgid "Edit Google Meet Account"
-msgstr "Upravit účet Google Meet"
+msgstr "Upraviť účet Google Meet"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:4
 msgid "Edit Member"
-msgstr "Upravit člena"
+msgstr "Upraviť člena"
 
 #: frontend/src/components/Settings/PaymentGatewayDetails.vue:69
 msgid "Edit Payment Gateway"
-msgstr "Upravit platební bránu"
+msgstr "Upraviť platobnú bránu"
 
 #: frontend/src/components/Modals/EditProfile.vue:6
 #: frontend/src/pages/Profile.vue:124
 msgid "Edit Profile"
-msgstr "Upravit profil"
+msgstr "Upraviť profil"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:7
 msgid "Edit Program"
-msgstr "Upravit program"
+msgstr "Upraviť program"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:9
 msgid "Edit Programming Exercise"
-msgstr "Upravit programovací cvičení"
+msgstr "Upraviť programovacie cvičenie"
 
 #: frontend/src/pages/QuizForm.vue:250
 msgid "Edit Question"
-msgstr "Upravit otázku"
+msgstr "Upraviť otázku"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:114
 msgid "Edit Zoom Account"
-msgstr "Upravit účet Zoom"
+msgstr "Upraviť účet Zoom"
 
 #: frontend/src/components/Modals/LessonModal.vue:62
 msgid "Edit lesson"
-msgstr "Upravit lekci"
+msgstr "Upraviť lekciu"
 
 #: frontend/src/components/Settings/Members.vue:289
 msgid "Edit member"
-msgstr "Upravit člena"
+msgstr "Upraviť člena"
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:4
 msgid "Edit your email account"
-msgstr "Upravit e-mailový účet"
+msgstr "Upraviť e-mailový účet"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:4
 msgid "Edit your reusable email template."
-msgstr "Upravte svou opakovaně použitelnou e-mailovou šablonu."
+msgstr "Upravte svoju opakovane použiteľnú e-mailovú šablónu."
 
 #. Label of the education (Table) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Education"
-msgstr "Vzdělání"
+msgstr "Vzdelanie"
 
 #. Name of a DocType
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Education Detail"
-msgstr "Údaj o vzdělání"
+msgstr "Údaj o vzdelaní"
 
 #. Label of the education_details (Section Break) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Education Details"
-msgstr "Údaje o vzdělání"
+msgstr "Údaje o vzdelaní"
 
 #. Option for the 'Send Notification for Published Courses' (Select) field in
 #. DocType 'LMS Settings'
@@ -2899,7 +2951,7 @@ msgstr "E-mail"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:234
 msgid "Email Account deleted successfully"
-msgstr "E-mailový účet byl úspěšně smazán"
+msgstr "E-mailový účet bol úspešne odstránený"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:3
 msgid "Email Accounts"
@@ -2913,34 +2965,34 @@ msgstr "E-mailová adresa"
 #. Label of the email_sent (Check) field in DocType 'LMS Course Interest'
 #: lms/lms/doctype/lms_course_interest/lms_course_interest.json
 msgid "Email Sent"
-msgstr "E-mail odeslán"
+msgstr "E-mail odoslaný"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:118
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:147
 msgid "Email Template created successfully"
-msgstr "E-mailová šablona byla úspěšně vytvořena"
+msgstr "E-mailová šablóna bola úspešne vytvorená"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:197
 msgid "Email Template deleted successfully"
-msgstr "E-mailová šablona byla úspěšně smazána"
+msgstr "E-mailová šablóna bola úspešne odstránená"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:147
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:152
 msgid "Email Template updated successfully"
-msgstr "E-mailová šablona byla úspěšně aktualizována"
+msgstr "E-mailová šablóna bola úspešne aktualizovaná"
 
 #. Label of the email_templates_tab (Tab Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Email Templates"
-msgstr "E-mailové šablony"
+msgstr "E-mailové šablóny"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAdd.vue:167
 msgid "Email account created"
-msgstr "E-mailový účet byl vytvořen"
+msgstr "E-mailový účet bol vytvorený"
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:158
 msgid "Email account updated successfully"
-msgstr "E-mailový účet byl úspěšně aktualizován"
+msgstr "E-mailový účet bol úspešne aktualizovaný"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:168
 msgid "Email is required"
@@ -2949,11 +3001,11 @@ msgstr "E-mail je povinný"
 #: frontend/src/components/ContactUsEmail.vue:51
 #: frontend/src/pages/JobApplications.vue:300
 msgid "Email sent successfully"
-msgstr "E-mail byl úspěšně odeslán"
+msgstr "E-mail bol úspešne odoslaný"
 
 #: lms/lms/email_account.py:65
 msgid "Email service {0} is not supported"
-msgstr "E-mailová služba {0} není podporována"
+msgstr "E-mailová služba {0} nie je podporovaná"
 
 #. Label of the show_emails (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
@@ -2963,31 +3015,33 @@ msgstr "E-maily"
 #. Option for the 'User Category' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:25
 msgid "Employee"
-msgstr "Zaměstnanec"
+msgstr "Zamestnanec"
 
 #. Label of the enable (Check) field in DocType 'Zoom Settings'
 #: lms/lms/doctype/zoom_settings/zoom_settings.json
 msgid "Enable"
-msgstr "Povolit"
+msgstr "Povoliť"
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:27
-msgid "Enable Google API in Google Settings to send calendar invites for evaluations."
+msgid ""
+"Enable Google API in Google Settings to send calendar invites for "
+"evaluations."
 msgstr ""
-"Chcete-li odesílat pozvánky na hodnocení do kalendáře, povolte rozhraní Google API v nastavení "
-"Google."
+"Ak chcete odosielať pozvánky na hodnotenia do kalendára, povoľte rozhranie "
+"Google API v nastaveniach Google."
 
 #. Label of the enable_negative_marking (Check) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:233 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Enable Negative Marking"
-msgstr "Povolit záporné bodování"
+msgstr "Povoliť záporné bodovanie"
 
 #: frontend/src/pages/Batches/BatchForm.vue:131
 msgid "Enable evaluations for batch participants."
-msgstr "Povolit hodnocení účastníků školicího kola."
+msgstr "Povoliť hodnotenia účastníkov školiaceho kola."
 
 #: frontend/src/components/Modals/ChapterModal.vue:27
 msgid "Enable this only if you want to upload a SCORM package as a chapter."
-msgstr "Tuto možnost povolte pouze tehdy, chcete-li nahrát balíček SCORM jako kapitolu."
+msgstr "Túto možnosť povoľte iba vtedy, ak chcete nahrať balík SCORM ako kapitolu."
 
 #. Label of the enabled (Check) field in DocType 'LMS Badge'
 #. Label of the enabled (Check) field in DocType 'LMS Coupon'
@@ -3008,22 +3062,24 @@ msgstr "Tuto možnost povolte pouze tehdy, chcete-li nahrát balíček SCORM jak
 #: lms/lms/doctype/lms_google_meet_settings/lms_google_meet_settings.json
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 msgid "Enabled"
-msgstr "Povoleno"
+msgstr "Povolené"
 
 #: frontend/src/pages/Batches/components/BulkCertificates.vue:51
-msgid "Enabling this will publish the certificate on the certified participants page."
-msgstr "Po povolení se certifikát zveřejní na stránce certifikovaných účastníků."
+msgid ""
+"Enabling this will publish the certificate on the certified participants "
+"page."
+msgstr "Po povolení sa certifikát zverejní na stránke certifikovaných účastníkov."
 
 #. Label of the end_date (Date) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:22
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "End Date"
-msgstr "Datum ukončení"
+msgstr "Dátum ukončenia"
 
 #. Label of the end_date (Date) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "End Date (or expected)"
-msgstr "Datum ukončení (nebo předpokládané)"
+msgstr "Dátum ukončenia (alebo predpokladaný)"
 
 #. Label of the end_time (Time) field in DocType 'Evaluator Schedule'
 #. Label of the end_time (Time) field in DocType 'LMS Batch'
@@ -3040,65 +3096,65 @@ msgstr "Datum ukončení (nebo předpokládané)"
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
 msgid "End Time"
-msgstr "Čas ukončení"
+msgstr "Čas ukončenia"
 
 #: frontend/src/pages/Batches/components/LiveClass.vue:97
 #: frontend/src/pages/Home/AdminHome.vue:100
 #: frontend/src/pages/Home/StudentHome.vue:65
 msgid "Ended"
-msgstr "Ukončeno"
+msgstr "Ukončené"
 
 #. Label of the enforce_assignment_completion (Check) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Enforce Assignment Completion"
-msgstr "Vyžadovat dokončení úkolu"
+msgstr "Vyžadovať dokončenie úlohy"
 
 #. Label of the enforce_course_order (Check) field in DocType 'LMS Program'
 #: frontend/src/pages/Programs/ProgramForm.vue:34
 #: lms/lms/doctype/lms_program/lms_program.json
 msgid "Enforce Course Order"
-msgstr "Vynutit pořadí kurzů"
+msgstr "Vynútiť poradie kurzov"
 
 #. Label of the enforce_quiz_completion (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Enforce Quiz Completion"
-msgstr "Vyžadovat dokončení kvízu"
+msgstr "Vyžadovať dokončenie kvízu"
 
 #. Label of the enforce_video_completion (Check) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Enforce Video Completion"
-msgstr "Vyžadovat zhlédnutí videa"
+msgstr "Vyžadovať zhliadnutie videa"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:50
 #: frontend/src/pages/Courses/CourseDetail.vue:82
 #: frontend/src/pages/Courses/CourseEnrollmentModal.vue:41
 msgid "Enroll"
-msgstr "Zapsat"
+msgstr "Zapísať sa"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:171
 msgid "Enroll Member to Program"
-msgstr "Zapsat člena do programu"
+msgstr "Zapísať člena do programu"
 
 #: frontend/src/components/CourseCardOverlay.vue:76
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:101
 msgid "Enroll Now"
-msgstr "Zapsat se nyní"
+msgstr "Zapísať sa teraz"
 
 #: frontend/src/components/Modals/StudentModal.vue:4
 msgid "Enroll a Student"
-msgstr "Zapsat studenta"
+msgstr "Zapísať študenta"
 
 #: frontend/src/pages/Billing.vue:209
 msgid "Enroll for Free"
-msgstr "Zapsat se zdarma"
+msgstr "Zapísať sa bezplatne"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:35
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:132
 #: frontend/src/pages/Courses/CourseDashboard.vue:32
 msgid "Enroll students to track their progress here."
-msgstr "Zapište studenty, abyste zde mohli sledovat jejich pokrok."
+msgstr "Zapíšte študentov, aby ste tu mohli sledovať ich pokrok."
 
 #: frontend/src/pages/Batches/Batches.vue:340
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:5
@@ -3106,34 +3162,34 @@ msgstr "Zapište studenty, abyste zde mohli sledovat jejich pokrok."
 #: frontend/src/pages/Courses/Courses.vue:323
 #: frontend/src/pages/Programs/StudentPrograms.vue:101
 msgid "Enrolled"
-msgstr "Zapsáno"
+msgstr "Zapísaní"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:293
 #: frontend/src/pages/Courses/CourseDashboard.vue:442
 msgid "Enrolled On"
-msgstr "Datum zápisu"
+msgstr "Dátum zápisu"
 
 #: frontend/src/components/CourseCard.vue:62
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:64
 msgid "Enrolled Students"
-msgstr "Zapsaní studenti"
+msgstr "Zapísaní študenti"
 
 #: frontend/src/pages/Batches/BatchForm.vue:83
 msgid "Enrollment & Certification"
-msgstr "Zápis a certifikace"
+msgstr "Zápis a certifikácia"
 
 #: frontend/src/pages/Batches/BatchForm.vue:170
 msgid "Enrollment Confirmation Email Template"
-msgstr "Šablona e-mailu s potvrzením zápisu"
+msgstr "Šablóna e-mailu s potvrdením zápisu"
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:147
 msgid "Enrollment Confirmation for {0}"
-msgstr "Potvrzení zápisu do {0}"
+msgstr "Potvrdenie zápisu do {0}"
 
 #: lms/lms/web_template/lms_statistics/lms_statistics.html:14
 #: lms/templates/statistics.html:20
 msgid "Enrollment Count"
-msgstr "Počet zápisů"
+msgstr "Počet zápisov"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:5
 msgid "Enrollment for Program {0}"
@@ -3142,11 +3198,11 @@ msgstr "Zápis do programu {0}"
 #. Label of the enrollment_from_batch (Link) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Enrollment from Batch"
-msgstr "Zápis prostřednictvím školicího kola"
+msgstr "Zápis prostredníctvom školiaceho kola"
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:57
 msgid "Enrollment in this batch is restricted. Please contact the Administrator."
-msgstr "Zápis do tohoto školicího kola je omezen. Kontaktujte administrátora."
+msgstr "Zápis do tohto školiaceho kola je obmedzený. Kontaktujte administrátora."
 
 #. Label of the enrollments (Int) field in DocType 'LMS Course'
 #. Label of a chart in the Learning Workspace
@@ -3160,29 +3216,31 @@ msgstr "Zápisy"
 
 #: frontend/src/components/Settings/BrandSettings.vue:32
 msgid "Enter Brand Name"
-msgstr "Zadejte název značky"
+msgstr "Zadajte názov značky"
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:32
-msgid "Enter Client Id and Client Secret in Google Settings to send calendar invites for evaluations."
+msgid ""
+"Enter Client Id and Client Secret in Google Settings to send calendar "
+"invites for evaluations."
 msgstr ""
-"Chcete-li odesílat pozvánky na hodnocení do kalendáře, zadejte ID klienta a tajný klíč klienta v "
-"nastavení Google."
+"Ak chcete odosielať pozvánky na hodnotenia do kalendára, zadajte ID klienta "
+"a tajný kľúč klienta v nastaveniach Google."
 
 #: frontend/src/pages/Billing.vue:64
 msgid "Enter a Coupon Code"
-msgstr "Zadejte kód kupónu"
+msgstr "Zadajte kód kupónu"
 
 #: frontend/src/components/Assignment.vue:129
 msgid "Enter a URL"
-msgstr "Zadejte URL"
+msgstr "Zadajte URL"
 
 #: frontend/src/pages/JobApplications.vue:138
 msgid "Enter email subject"
-msgstr "Zadejte předmět e-mailu"
+msgstr "Zadajte predmet e-mailu"
 
 #: frontend/src/pages/JobApplications.vue:144
 msgid "Enter reply to email"
-msgstr "Zadejte adresu pro odpověď"
+msgstr "Zadajte adresu na odpoveď"
 
 #: frontend/src/components/CourseOutline.vue:214
 #: frontend/src/components/CourseOutline.vue:257
@@ -3193,77 +3251,77 @@ msgstr "Chyba"
 
 #: frontend/src/components/Controls/Uploader.vue:103
 msgid "Error Uploading File"
-msgstr "Chyba při nahrávání souboru"
+msgstr "Chyba pri nahrávaní súboru"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:156
 msgid "Error creating Google Meet Account"
-msgstr "Chyba při vytváření účtu Google Meet"
+msgstr "Chyba pri vytváraní účtu Google Meet"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:168
 msgid "Error creating Zoom Account"
-msgstr "Chyba při vytváření účtu Zoom"
+msgstr "Chyba pri vytváraní účtu Zoom"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:209
 msgid "Error creating badge"
-msgstr "Chyba při vytváření odznaku"
+msgstr "Chyba pri vytváraní odznaku"
 
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:252
 msgid "Error creating batch"
-msgstr "Chyba při vytváření školicího kola"
+msgstr "Chyba pri vytváraní školiaceho kola"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:123
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:152
 msgid "Error creating email template"
-msgstr "Chyba při vytváření e-mailové šablony"
+msgstr "Chyba pri vytváraní e-mailovej šablóny"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:291
 msgid "Error creating live class. Please try again. {0}"
-msgstr "Chyba při vytváření živé lekce. Zkuste to prosím znovu. {0}"
+msgstr "Chyba pri vytváraní živej lekcie. Skúste to, prosím, znova. {0}"
 
 #: frontend/src/pages/Quizzes.vue:245
 msgid "Error creating quiz: {0}"
-msgstr "Chyba při vytváření kvízu: {0}"
+msgstr "Chyba pri vytváraní kvízu: {0}"
 
 #: frontend/src/components/Settings/GoogleMeetSettings.vue:178
 msgid "Error deleting Google Meet Account"
-msgstr "Chyba při mazání účtu Google Meet"
+msgstr "Chyba pri odstraňovaní účtu Google Meet"
 
 #: frontend/src/components/Settings/Badges/Badges.vue:199
 msgid "Error deleting badge"
-msgstr "Chyba při mazání odznaku"
+msgstr "Chyba pri odstraňovaní odznaku"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:238
 msgid "Error deleting email account"
-msgstr "Chyba při mazání e-mailového účtu"
+msgstr "Chyba pri odstraňovaní e-mailového účtu"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:201
 msgid "Error deleting email template"
-msgstr "Chyba při mazání e-mailové šablony"
+msgstr "Chyba pri odstraňovaní e-mailovej šablóny"
 
 #: frontend/src/components/Settings/PaymentGateways.vue:149
 msgid "Error deleting payment gateways"
-msgstr "Chyba při mazání platebních bran"
+msgstr "Chyba pri odstraňovaní platobných brán"
 
 #: lms/lms/course_import_export.py:298
 msgid "Error downloading file"
-msgstr "Chyba při stahování souboru"
+msgstr "Chyba pri sťahovaní súboru"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:196
 msgid "Error updating Google Meet Account"
-msgstr "Chyba při aktualizaci účtu Google Meet"
+msgstr "Chyba pri aktualizácii účtu Google Meet"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:206
 msgid "Error updating Zoom Account"
-msgstr "Chyba při aktualizaci účtu Zoom"
+msgstr "Chyba pri aktualizácii účtu Zoom"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:152
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:156
 msgid "Error updating email template"
-msgstr "Chyba při aktualizaci e-mailové šablony"
+msgstr "Chyba pri aktualizácii e-mailovej šablóny"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:242
 msgid "Error uploading file"
-msgstr "Chyba při nahrávání souboru"
+msgstr "Chyba pri nahrávaní súboru"
 
 #. Label of the evaluation (Check) field in DocType 'LMS Batch'
 #. Label of a Link in the Learning Workspace
@@ -3273,46 +3331,48 @@ msgstr "Chyba při nahrávání souboru"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/workspace/learning/learning.json
 msgid "Evaluation"
-msgstr "Hodnocení"
+msgstr "Hodnotenie"
 
 #. Label of the section_break_6 (Section Break) field in DocType 'LMS
 #. Certificate Evaluation'
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Evaluation Details"
-msgstr "Podrobnosti hodnocení"
+msgstr "Podrobnosti hodnotenia"
 
 #. Label of the evaluation_end_date (Date) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:136
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Evaluation End Date"
-msgstr "Datum ukončení hodnocení"
+msgstr "Dátum ukončenia hodnotenia"
 
 #. Label of a Link in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Evaluation Request"
-msgstr "Žádost o hodnocení"
+msgstr "Žiadosť o hodnotenie"
 
 #. Label of a Workspace Sidebar Item
 #: lms/workspace_sidebar/learning.json
 msgid "Evaluation Requests"
-msgstr "Žádosti o hodnocení"
+msgstr "Žiadosti o hodnotenie"
 
 #: frontend/src/components/UpcomingEvaluations.vue:209
 msgid "Evaluation cancelled successfully"
-msgstr "Hodnocení bylo úspěšně zrušeno"
+msgstr "Hodnotenie bolo úspešne zrušené"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:92
 msgid "Evaluation end date cannot be less than the batch end date."
-msgstr "Datum ukončení hodnocení nesmí být dřívější než datum ukončení školicího kola."
+msgstr ""
+"Dátum ukončenia hodnotenia nesmie byť skorší ako dátum ukončenia "
+"školiaceho kola."
 
 #: frontend/src/components/Modals/Event.vue:279
 msgid "Evaluation saved successfully"
-msgstr "Hodnocení bylo úspěšně uloženo"
+msgstr "Hodnotenie bolo úspešne uložené"
 
 #. Label of a Workspace Sidebar Item
 #: lms/workspace_sidebar/learning.json
 msgid "Evaluations"
-msgstr "Hodnocení"
+msgstr "Hodnotenia"
 
 #. Label of the evaluator (Link) field in DocType 'Batch Course'
 #. Label of the evaluator (Link) field in DocType 'Course Evaluator'
@@ -3336,7 +3396,7 @@ msgstr "Hodnocení"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/templates/upcoming_evals.html:33
 msgid "Evaluator"
-msgstr "Hodnotitel"
+msgstr "Hodnotiteľ"
 
 #. Label of the evaluator_name (Data) field in DocType 'LMS Certificate'
 #. Label of the evaluator_name (Data) field in DocType 'LMS Certificate
@@ -3346,16 +3406,16 @@ msgstr "Hodnotitel"
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Evaluator Name"
-msgstr "Jméno hodnotitele"
+msgstr "Meno hodnotiteľa"
 
 #. Name of a DocType
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 msgid "Evaluator Schedule"
-msgstr "Rozvrh hodnotitele"
+msgstr "Rozvrh hodnotiteľa"
 
 #: lms/lms/doctype/lms_course/lms_course.py:81
 msgid "Evaluator is required for paid certificates."
-msgstr "U placených certifikátů je hodnotitel povinný."
+msgstr "Pri platených certifikátoch sa vyžaduje hodnotiteľ."
 
 #. Label of the event (Select) field in DocType 'LMS Badge'
 #. Label of the event (Link) field in DocType 'LMS Live Class'
@@ -3363,28 +3423,28 @@ msgstr "U placených certifikátů je hodnotitel povinný."
 #: lms/lms/doctype/lms_badge/lms_badge.json
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Event"
-msgstr "Událost"
+msgstr "Udalosť"
 
 #. Label of the exercise (Link) field in DocType 'LMS Programming Exercise
 #. Submission'
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:283
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 msgid "Exercise"
-msgstr "Cvičení"
+msgstr "Cvičenie"
 
 #. Label of the exercise_title (Data) field in DocType 'LMS Programming
 #. Exercise Submission'
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 msgid "Exercise Title"
-msgstr "Název cvičení"
+msgstr "Názov cvičenia"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:280
 msgid "Exercise deleted successfully"
-msgstr "Cvičení bylo úspěšně smazáno"
+msgstr "Cvičenie bolo úspešne odstránené"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:213
 msgid "Expand"
-msgstr "Rozbalit"
+msgstr "Rozbaliť"
 
 #. Label of the expected_output (Data) field in DocType 'LMS Test Case'
 #. Label of the expected_output (Data) field in DocType 'LMS Test Case
@@ -3393,30 +3453,30 @@ msgstr "Rozbalit"
 #: lms/lms/doctype/lms_test_case/lms_test_case.json
 #: lms/lms/doctype/lms_test_case_submission/lms_test_case_submission.json
 msgid "Expected Output"
-msgstr "Očekávaný výstup"
+msgstr "Očakávaný výstup"
 
 #. Label of the expiration_date (Data) field in DocType 'Certification'
 #: lms/lms/doctype/certification/certification.json
 msgid "Expiration Date"
-msgstr "Datum vypršení platnosti"
+msgstr "Dátum skončenia platnosti"
 
 #. Label of the expires_on (Date) field in DocType 'LMS Coupon'
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:46
 #: frontend/src/components/Settings/Coupons/CouponList.vue:170
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Expires On"
-msgstr "Platnost do"
+msgstr "Platí do"
 
 #. Label of the expiry_date (Date) field in DocType 'LMS Certificate'
 #: frontend/src/components/Modals/Event.vue:148
 #: frontend/src/pages/Batches/components/BulkCertificates.vue:31
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
 msgid "Expiry Date"
-msgstr "Datum vypršení platnosti"
+msgstr "Dátum skončenia platnosti"
 
 #: lms/lms/doctype/lms_coupon/lms_coupon.py:26
 msgid "Expiry date cannot be in the past"
-msgstr "Datum vypršení platnosti nemůže být v minulosti"
+msgstr "Dátum skončenia platnosti nemôže byť v minulosti"
 
 #. Label of the explanation_1 (Small Text) field in DocType 'LMS Question'
 #. Label of the explanation_3 (Small Text) field in DocType 'LMS Question'
@@ -3430,21 +3490,21 @@ msgstr "Datum vypršení platnosti nemůže být v minulosti"
 #: frontend/src/components/Modals/Question.vue:83
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Explanation"
-msgstr "Vysvětlení"
+msgstr "Vysvetlenie"
 
 #. Label of the explanation_2 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Explanation "
-msgstr "Vysvětlení "
+msgstr "Vysvetlenie "
 
 #: lms/lms/web_template/course_cards/course_cards.html:15
 #: lms/lms/web_template/recently_published_courses/recently_published_courses.html:16
 msgid "Explore More"
-msgstr "Prozkoumat další"
+msgstr "Preskúmať ďalšie"
 
 #: frontend/src/pages/Courses/CourseForm.vue:281
 msgid "Export"
-msgstr "Exportovat"
+msgstr "Exportovať"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Assignment
 #. Submission'
@@ -3454,7 +3514,7 @@ msgstr "Exportovat"
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Fail"
-msgstr "Neúspěšné"
+msgstr "Neúspešné"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Programming Exercise
 #. Submission'
@@ -3463,51 +3523,51 @@ msgstr "Neúspěšné"
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 #: lms/lms/doctype/lms_test_case_submission/lms_test_case_submission.json
 msgid "Failed"
-msgstr "Neúspěšné"
+msgstr "Neúspešné"
 
 #: lms/lms/doctype/lms_badge/lms_badge.js:58
 msgid "Failed to assign badge"
-msgstr "Odznak se nepodařilo přiřadit"
+msgstr "Odznak sa nepodarilo priradiť"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:135
 msgid "Failed to create badge assignment: "
-msgstr "Přiřazení odznaku se nepodařilo vytvořit: "
+msgstr "Priradenie odznaku sa nepodarilo vytvoriť: "
 
 #: frontend/src/components/Settings/EmailAccount/EmailAdd.vue:173
 msgid "Failed to create email account, Invalid credentials"
-msgstr "E-mailový účet se nepodařilo vytvořit: neplatné přístupové údaje"
+msgstr "E-mailový účet sa nepodarilo vytvoriť: neplatné prihlasovacie údaje"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:148
 msgid "Failed to enroll in program: {0}"
-msgstr "Do programu se nepodařilo zapsat: {0}"
+msgstr "Do programu sa nepodarilo zapísať: {0}"
 
 #: lms/lms/doctype/lms_live_class/lms_live_class.py:223
 msgid "Failed to fetch attendance data from Zoom for class {0}: {1}"
-msgstr "Nepodařilo se načíst údaje o docházce ze služby Zoom pro lekci {0}: {1}"
+msgstr "Nepodarilo sa načítať údaje o dochádzke zo služby Zoom pre lekciu {0}: {1}"
 
 #: frontend/src/pages/Profile.vue:284
 msgid "Failed to refresh session"
-msgstr "Relaci se nepodařilo obnovit"
+msgstr "Reláciu sa nepodarilo obnoviť"
 
 #: frontend/src/components/ContactUsEmail.vue:57
 msgid "Failed to send email"
-msgstr "E-mail se nepodařilo odeslat"
+msgstr "E-mail sa nepodarilo odoslať"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:373
 msgid "Failed to submit. Please try again. {0}"
-msgstr "Odeslání se nezdařilo. Zkuste to znovu. {0}"
+msgstr "Odoslanie zlyhalo. Skúste to znova. {0}"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:116
 msgid "Failed to update badge assignment: "
-msgstr "Přiřazení odznaku se nepodařilo aktualizovat: "
+msgstr "Priradenie odznaku sa nepodarilo aktualizovať: "
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:160
 msgid "Failed to update email account, Invalid credentials"
-msgstr "E-mailový účet se nepodařilo aktualizovat: neplatné přístupové údaje"
+msgstr "E-mailový účet sa nepodarilo aktualizovať: neplatné prihlasovacie údaje"
 
 #: frontend/src/utils/index.js:886
 msgid "Failed to update meta tags {0}"
-msgstr "Meta tagy se nepodařilo aktualizovat: {0}"
+msgstr "Meta značky sa nepodarilo aktualizovať: {0}"
 
 #: frontend/src/components/Settings/BrandSettings.vue:94
 msgid "Favicon"
@@ -3519,18 +3579,18 @@ msgstr "Favicon"
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:15
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Featured"
-msgstr "Doporučené"
+msgstr "Odporúčané"
 
 #. Label of the feedback (Small Text) field in DocType 'LMS Batch Feedback'
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:6
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:51
 #: lms/lms/doctype/lms_batch_feedback/lms_batch_feedback.json
 msgid "Feedback"
-msgstr "Zpětná vazba"
+msgstr "Spätná väzba"
 
 #: frontend/src/components/Assignment.vue:70
 msgid "Feel free to make edits to your submission if needed."
-msgstr "V případě potřeby můžete své odevzdání upravit."
+msgstr "V prípade potreby môžete svoje odovzdanie upraviť."
 
 #. Label of the field_to_check (Select) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
@@ -3540,77 +3600,77 @@ msgstr "Kontrolované pole"
 #. Label of the major (Data) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Field of Major/Study"
-msgstr "Hlavní obor studia"
+msgstr "Hlavný študijný odbor"
 
 #. Label of the file_type (Select) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "File Type"
-msgstr "Typ souboru"
+msgstr "Typ súboru"
 
 #: lms/lms/course_import_export.py:286
 msgid "File not found"
-msgstr "Soubor nebyl nalezen"
+msgstr "Súbor sa nenašiel"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:250
 msgid "File type of {0} is not allowed in quiz answers."
-msgstr "Typ souboru {0} není v odpovědích na kvíz povolen."
+msgstr "Typ súboru {0} nie je povolený v odpovediach na kvíz."
 
 #: frontend/src/pages/Courses/CourseImportModal.vue:144
 #: frontend/src/pages/Courses/CourseImportModal.vue:160
 msgid "File upload failed. Please try again."
-msgstr "Nahrání souboru se nezdařilo. Zkuste to znovu."
+msgstr "Nahratie súboru zlyhalo. Skúste to znova."
 
 #: frontend/src/components/AssessmentPlugin.vue:54
 msgid "Filter assignments by course"
-msgstr "Filtrovat úkoly podle kurzu"
+msgstr "Filtrovať úlohy podľa kurzu"
 
 #: frontend/src/components/Settings/Transactions/TransactionList.vue:15
 msgid "Filter by Billing Name"
-msgstr "Filtrovat podle fakturačního jména"
+msgstr "Filtrovať podľa fakturačného mena"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:23
 msgid "Filter by Exercise"
-msgstr "Filtrovat podle cvičení"
+msgstr "Filtrovať podľa cvičenia"
 
 #: frontend/src/components/Settings/Transactions/TransactionList.vue:20
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:29
 msgid "Filter by Member"
-msgstr "Filtrovat podle člena"
+msgstr "Filtrovať podľa člena"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:41
 msgid "Filter by Status"
-msgstr "Filtrovat podle stavu"
+msgstr "Filtrovať podľa stavu"
 
 #: frontend/src/components/Modals/EditProfile.vue:34
 #: frontend/src/components/Modals/EditProfile.vue:143
 #: frontend/src/components/Modals/NewMemberModal.vue:29
 msgid "First Name"
-msgstr "Jméno"
+msgstr "Meno"
 
 #. Option for the 'Time Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Fixed 9-5"
-msgstr "Pevná pracovní doba 9–17"
+msgstr "Pevný pracovný čas 9 – 17"
 
 #. Option for the 'Discount Type' (Select) field in DocType 'LMS Coupon'
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Fixed Amount"
-msgstr "Pevná částka"
+msgstr "Pevná suma"
 
 #. Label of the fixed_amount_discount (Int) field in DocType 'LMS Coupon'
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Fixed Amount Discount"
-msgstr "Sleva pevnou částkou"
+msgstr "Zľava pevnou sumou"
 
 #. Option for the 'Time Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Flexible Time"
-msgstr "Flexibilní pracovní doba"
+msgstr "Flexibilný pracovný čas"
 
 #. Option for the 'Attire Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Formal Wear"
-msgstr "Formální oblečení"
+msgstr "Formálne oblečenie"
 
 #. Label of a Desktop Icon
 #: lms/desktop_icon/frappe_learning.json
@@ -3620,7 +3680,7 @@ msgstr "Frappe Learning"
 #: frontend/src/components/CourseCardOverlay.vue:222
 #: lms/lms/widgets/CourseCard.html:114
 msgid "Free"
-msgstr "Zdarma"
+msgstr "Zadarmo"
 
 #. Option for the 'Type' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -3628,24 +3688,24 @@ msgstr "Zdarma"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Freelance"
-msgstr "Práce na volné noze"
+msgstr "Práca na voľnej nohe"
 
 #. Option for the 'User Category' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:27
 msgid "Freelancer/Just looking"
-msgstr "Pracovník na volné noze / pouze se rozhlížím"
+msgstr "Pracovník na voľnej nohe / iba sa rozhliadam"
 
 #. Option for the 'Grade Type' (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "French (e.g. Distinction)"
-msgstr "Francouzské (např. vyznamenání)"
+msgstr "Francúzske (napr. vyznamenanie)"
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Friday"
-msgstr "Pátek"
+msgstr "Piatok"
 
 #. Label of the unavailable_from (Date) field in DocType 'Course Evaluator'
 #: frontend/src/pages/ProfileEvaluator.vue:106
@@ -3660,7 +3720,7 @@ msgstr "Od "
 #. Label of the from_date (Date) field in DocType 'Work Experience'
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "From Date"
-msgstr "Datum od"
+msgstr "Dátum od"
 
 #. Label of the full_name (Data) field in DocType 'Course Evaluator'
 #. Label of the full_name (Data) field in DocType 'LMS Program Member'
@@ -3669,7 +3729,7 @@ msgstr "Datum od"
 #: lms/lms/doctype/lms_program_member/lms_program_member.json
 #: lms/templates/signup-form.html:5
 msgid "Full Name"
-msgstr "Celé jméno"
+msgstr "Celé meno"
 
 #. Option for the 'Type' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -3677,7 +3737,7 @@ msgstr "Celé jméno"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Full Time"
-msgstr "Plný úvazek"
+msgstr "Plný úväzok"
 
 #. Name of a DocType
 #. Label of the function (Data) field in DocType 'Function'
@@ -3685,11 +3745,11 @@ msgstr "Plný úvazek"
 #: lms/lms/doctype/function/function.json
 #: lms/lms/doctype/preferred_function/preferred_function.json
 msgid "Function"
-msgstr "Pracovní oblast"
+msgstr "Pracovná oblasť"
 
 #: frontend/src/pages/Billing.vue:46
 msgid "GST Amount"
-msgstr "Částka GST"
+msgstr "Suma GST"
 
 #: frontend/src/pages/Billing.vue:167
 msgid "GST Number"
@@ -3708,42 +3768,46 @@ msgstr "Brána"
 #. Label of the general_tab (Tab Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "General"
-msgstr "Obecné"
+msgstr "Všeobecné"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:287
 msgid "Generate Certificates"
-msgstr "Vygenerovat certifikáty"
+msgstr "Vygenerovať certifikáty"
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.js:15
 msgid "Generate Google Meet Link"
-msgstr "Vygenerovat odkaz Google Meet"
+msgstr "Vygenerovať odkaz Google Meet"
 
 #: frontend/src/components/CourseCardOverlay.vue:89
 msgid "Get Certificate"
-msgstr "Získat certifikát"
+msgstr "Získať certifikát"
 
 #: frontend/src/components/CertificationLinks.vue:34
 #: frontend/src/components/CertificationLinks.vue:50
 #: frontend/src/components/CourseCard.vue:128
 #: frontend/src/pages/CertifiedParticipants.vue:12
 msgid "Get Certified"
-msgstr "Získat certifikaci"
+msgstr "Získať certifikáciu"
 
 #: lms/templates/onboarding_header.html:8
 msgid "Get Started"
-msgstr "Začít"
+msgstr "Začať"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:168
 msgid "Get the Payments app"
-msgstr "Získat aplikaci Payments"
+msgstr "Získať aplikáciu Payments"
 
 #: frontend/src/components/InstallPrompt.vue:9
 msgid "Get the app on your device for easy access & a better experience!"
-msgstr "Nainstalujte si aplikaci do zařízení pro snadnější přístup a lepší uživatelský zážitek!"
+msgstr ""
+"Nainštalujte si aplikáciu do zariadenia pre jednoduchší prístup a lepší "
+"používateľský zážitok!"
 
 #: frontend/src/components/InstallPrompt.vue:45
 msgid "Get the app on your iPhone for easy access & a better experience"
-msgstr "Nainstalujte si aplikaci do iPhonu pro snadnější přístup a lepší uživatelský zážitek"
+msgstr ""
+"Nainštalujte si aplikáciu do iPhonu pre jednoduchší prístup a lepší "
+"používateľský zážitok"
 
 #: frontend/src/components/Modals/EditProfile.vue:48
 msgid "GitHub ID"
@@ -3762,14 +3826,14 @@ msgstr "Go"
 
 #: frontend/src/components/Layouts/SettingsLayout.vue:12
 msgid "Go back"
-msgstr "Zpět"
+msgstr "Späť"
 
 #. Label of the google_calendar (Link) field in DocType 'LMS Google Meet
 #. Settings'
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:41
 #: lms/lms/doctype/lms_google_meet_settings/lms_google_meet_settings.json
 msgid "Google Calendar"
-msgstr "Kalendář Google"
+msgstr "Kalendár Google"
 
 #: frontend/src/pages/PersonaForm.vue:157
 msgid "Google Classroom"
@@ -3798,15 +3862,15 @@ msgstr "Účet Google Meet"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:149
 msgid "Google Meet Account created successfully"
-msgstr "Účet Google Meet byl úspěšně vytvořen"
+msgstr "Účet Google Meet bol úspešne vytvorený"
 
 #: frontend/src/components/Settings/GoogleMeetSettings.vue:173
 msgid "Google Meet Account deleted successfully"
-msgstr "Účet Google Meet byl úspěšně smazán"
+msgstr "Účet Google Meet bol úspešne odstránený"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:189
 msgid "Google Meet Account updated successfully"
-msgstr "Účet Google Meet byl úspěšně aktualizován"
+msgstr "Účet Google Meet bol úspešne aktualizovaný"
 
 #. Label of the google_meet_link (Data) field in DocType 'LMS Certificate
 #. Request'
@@ -3823,7 +3887,7 @@ msgstr "Známka"
 #. Label of the grade_assignment (Check) field in DocType 'LMS Assignment'
 #: lms/lms/doctype/lms_assignment/lms_assignment.json
 msgid "Grade Assignment"
-msgstr "Ohodnotit úkol"
+msgstr "Ohodnotiť úlohu"
 
 #. Label of the grade_type (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
@@ -3832,22 +3896,22 @@ msgstr "Typ známky"
 
 #: frontend/src/components/Assignment.vue:173
 msgid "Grading"
-msgstr "Hodnocení"
+msgstr "Hodnotenie"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:56
 #: frontend/src/components/Settings/Badges/Badges.vue:241
 msgid "Grant Only Once"
-msgstr "Udělit pouze jednou"
+msgstr "Udeliť iba raz"
 
 #. Label of the grant_only_once (Check) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Grant only once"
-msgstr "Udělit pouze jednou"
+msgstr "Udeliť iba raz"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Gray"
-msgstr "Šedá"
+msgstr "Sivá"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #. Option for the 'Color' (Select) field in DocType 'LMS Lesson Note'
@@ -3858,13 +3922,13 @@ msgstr "Zelená"
 
 #: lms/templates/signup-form.html:56
 msgid "Have an account? Login"
-msgstr "Máte účet? Přihlaste se"
+msgstr "Máte účet? Prihláste sa"
 
 #. Label of the headline (Data) field in DocType 'User'
 #: frontend/src/components/Modals/EditProfile.vue:42
 #: lms/fixtures/custom_field.json
 msgid "Headline"
-msgstr "Titulek"
+msgstr "Nadpis"
 
 #: lms/lms/widgets/HelloWorld.html:13
 msgid "Hello"
@@ -3873,24 +3937,24 @@ msgstr "Ahoj"
 #: lms/templates/emails/published_batch_notification.html:4
 #: lms/templates/emails/published_course_notification.html:4
 msgid "Hello Learner"
-msgstr "Dobrý den"
+msgstr "Dobrý deň"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:193
 msgid "Help"
-msgstr "Nápověda"
+msgstr "Pomoc"
 
 #: lms/templates/courses_created.html:15
 msgid "Help others learn something new by creating a course."
-msgstr "Pomozte ostatním naučit se něco nového vytvořením kurzu."
+msgstr "Pomôžte ostatným naučiť sa niečo nové vytvorením kurzu."
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:36
 msgid "Help us improve by providing your feedback."
-msgstr "Pomozte nám zlepšit se a poskytněte nám zpětnou vazbu."
+msgstr "Pomôžte nám zlepšovať sa a poskytnite nám spätnú väzbu."
 
 #: lms/templates/emails/published_batch_notification.html:7
 #: lms/templates/emails/published_course_notification.html:7
 msgid "Here are the details:"
-msgstr "Podrobnosti:"
+msgstr "Tu sú podrobnosti:"
 
 #: frontend/src/pages/Home/Home.vue:6
 msgid "Hey"
@@ -3920,25 +3984,25 @@ msgstr "Ahoj,"
 #. Label of the hide_private (Check) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Hide my Private Information from others"
-msgstr "Skrýt mé soukromé údaje před ostatními"
+msgstr "Skryť moje súkromné údaje pred ostatnými"
 
 #: frontend/src/components/Notes/InlineLessonMenu.vue:12
 msgid "Highlight"
-msgstr "Zvýraznit"
+msgstr "Zvýrazniť"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:16
 msgid "Highlight on the homepage."
-msgstr "Zvýraznit na domovské stránce."
+msgstr "Zvýrazniť na domovskej stránke."
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:110
 msgid "Highlight what makes you unique and show your skills."
-msgstr "Zdůrazněte, čím jste jedineční, a představte své dovednosti."
+msgstr "Zdôraznite, čím ste jedineční, a predstavte svoje zručnosti."
 
 #. Label of the highlighted_text (Small Text) field in DocType 'LMS Lesson
 #. Note'
 #: lms/lms/doctype/lms_lesson_note/lms_lesson_note.json
 msgid "Highlighted Text"
-msgstr "Zvýrazněný text"
+msgstr "Zvýraznený text"
 
 #. Option for the 'Open to' (Select) field in DocType 'User'
 #: frontend/src/components/UserAvatar.vue:21
@@ -3949,46 +4013,48 @@ msgstr "Nábor"
 
 #: frontend/src/pages/Home/Home.vue:172
 msgid "Home"
-msgstr "Domů"
+msgstr "Domov"
 
 #. Label of the host (Link) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Host"
-msgstr "Hostitel"
+msgstr "Hostiteľ"
 
 #: frontend/src/components/LessonHelp.vue:2
 #: frontend/src/pages/Courses/CourseDetail.vue:51
 msgid "How to edit a lesson"
-msgstr "Jak upravit lekci"
+msgstr "Ako upraviť lekciu"
 
 #. Option for the 'Work Mode' (Select) field in DocType 'Job Opportunity'
 #: frontend/src/pages/JobForm.vue:294 frontend/src/pages/Jobs.vue:341
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "Hybrid"
-msgstr "Hybridní"
+msgstr "Hybridné"
 
 #. Label of the current (Check) field in DocType 'Work Experience'
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "I am currently working here"
-msgstr "Zde aktuálně pracuji"
+msgstr "Momentálne tu pracujem"
 
 #: lms/templates/emails/certification.html:6
 msgid ""
-"I am delighted to inform you that you have successfully earned your certification for the {0} "
-"course. Congratulations!"
-msgstr "S potěšením vám oznamuji, že jste úspěšně získali certifikaci za kurz {0}. Gratulujeme!"
+"I am delighted to inform you that you have successfully earned your "
+"certification for the {0} course. Congratulations!"
+msgstr ""
+"S potešením vám oznamujeme, že ste úspešne získali certifikáciu za kurz {0}."
+" Gratulujeme!"
 
 #: frontend/src/pages/ProfileAbout.vue:166
 msgid "I am happy to announce that I earned the {0} badge on {1} at {2}"
-msgstr "S radostí oznamuji získání odznaku {0} dne {1} na platformě {2}."
+msgstr "S radosťou oznamujem získanie odznaku {0} dňa {1} na platforme {2}."
 
 #: frontend/src/pages/ProfileEvaluator.vue:101
 msgid "I am unavailable"
-msgstr "Nejsem k dispozici"
+msgstr "Nie som k dispozícii"
 
 #: frontend/src/pages/Billing.vue:185
 msgid "I consent to my personal information being stored for invoicing"
-msgstr "Souhlasím s uložením svých osobních údajů pro účely fakturace"
+msgstr "Súhlasím s uložením svojich osobných údajov na účely fakturácie"
 
 #: frontend/src/pages/QuizForm.vue:436
 msgid "ID"
@@ -4003,41 +4069,55 @@ msgstr "Ikona"
 #. Label of the user_category (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Identify User Category"
-msgstr "Určit kategorii uživatele"
+msgstr "Určiť kategóriu používateľa"
 
 #: frontend/src/components/Quiz.vue:67
-msgid "If you answer incorrectly, {0} {1} will be deducted from your score for each incorrect answer."
-msgstr "Za každou nesprávnou odpověď se z vašeho skóre odečte {0} {1}."
+msgid ""
+"If you answer incorrectly, {0} {1} will be deducted from your score for each"
+" incorrect answer."
+msgstr "Za každú nesprávnu odpoveď sa z vášho skóre odpočíta {0} {1}."
 
 #: lms/templates/emails/mentor_request_creation_email.html:5
 msgid "If you are not any more interested to mentor the course"
-msgstr "Pokud již nemáte zájem být mentorem kurzu"
+msgstr "Ak už nemáte záujem byť mentorom kurzu"
 
 #: frontend/src/components/Quiz.vue:44
-msgid "If you fail to do so, the quiz will be automatically submitted when the timer ends."
-msgstr "Pokud tak neučiníte, kvíz bude po vypršení časového limitu automaticky odeslán."
+msgid ""
+"If you fail to do so, the quiz will be automatically submitted when the "
+"timer ends."
+msgstr "Ak tak neurobíte, kvíz sa po uplynutí časového limitu automaticky odošle."
 
 #: lms/templates/emails/payment_reminder.html:19
-msgid "If you have any questions or need assistance, feel free to reach out to our support team."
-msgstr "Máte-li jakékoli dotazy nebo potřebujete pomoc, obraťte se na náš tým podpory."
+msgid ""
+"If you have any questions or need assistance, feel free to reach out to our "
+"support team."
+msgstr ""
+"Ak máte akékoľvek otázky alebo potrebujete pomoc, obráťte sa na náš tím "
+"podpory."
 
 #: lms/templates/emails/batch_confirmation.html:29
 #: lms/templates/emails/batch_start_reminder.html:27
 #: lms/templates/emails/batch_start_reminder_recorded.html:30
 #: lms/templates/emails/live_class_reminder.html:24
 msgid "If you have any questions or require assistance, feel free to contact us."
-msgstr "Máte-li jakékoli dotazy nebo potřebujete pomoc, neváhejte nás kontaktovat."
+msgstr "Ak máte akékoľvek otázky alebo potrebujete pomoc, neváhajte nás kontaktovať."
 
 #. Description of the 'Amount (USD)' (Currency) field in DocType 'LMS Batch'
 #. Description of the 'Amount (USD)' (Currency) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_course/lms_course.json
-msgid "If you set an amount here, then the USD equivalent setting will not get applied."
-msgstr "Pokud zde nastavíte částku, nepoužije se nastavení ekvivalentu v USD."
+msgid ""
+"If you set an amount here, then the USD equivalent setting will not get "
+"applied."
+msgstr "Ak tu nastavíte sumu, nepoužije sa nastavenie ekvivalentu v USD."
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:80
-msgid "If you want open ended questions then make sure each question in the quiz is of open ended type."
-msgstr "Chcete-li používat otevřené otázky, musí být všechny otázky v kvízu typu otevřená otázka."
+msgid ""
+"If you want open ended questions then make sure each question in the quiz is"
+" of open ended type."
+msgstr ""
+"Ak chcete používať otvorené otázky, všetky otázky v kvíze musia byť typu "
+"otvorená otázka."
 
 #. Option for the 'File Type' (Select) field in DocType 'Course Lesson'
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment'
@@ -4048,33 +4128,33 @@ msgstr "Chcete-li používat otevřené otázky, musí být všechny otázky v k
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Image"
-msgstr "Obrázek"
+msgstr "Obrázok"
 
 #: frontend/src/components/Modals/EditCoverImage.vue:58
 #: frontend/src/components/UnsplashImageBrowser.vue:52
 msgid "Image search powered by"
-msgstr "Vyhledávání obrázků zajišťuje"
+msgstr "Vyhľadávanie obrázkov zabezpečuje"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:269
 msgid "Image: Corrupted Data Stream"
-msgstr "Obrázek: poškozený datový proud"
+msgstr "Obrázok: poškodený dátový prúd"
 
 #: frontend/src/components/Sidebar/Configuration.vue:32
 #: frontend/src/pages/Courses/CourseImportModal.vue:78
 msgid "Import"
-msgstr "Importovat"
+msgstr "Importovať"
 
 #: frontend/src/pages/Batches/Batches.vue:18
 msgid "Import Batch"
-msgstr "Importovat školicí kolo"
+msgstr "Importovať školiace kolo"
 
 #: frontend/src/pages/Courses/Courses.vue:338
 msgid "Import via Data Import Tool"
-msgstr "Importovat pomocí nástroje pro import dat"
+msgstr "Importovať pomocou nástroja na import údajov"
 
 #: frontend/src/pages/Courses/Courses.vue:348
 msgid "Import via ZIP"
-msgstr "Importovat ze souboru ZIP"
+msgstr "Importovať zo súboru ZIP"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Certificate
 #. Evaluation'
@@ -4083,14 +4163,14 @@ msgstr "Importovat ze souboru ZIP"
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "In Progress"
-msgstr "Probíhá"
+msgstr "Prebieha"
 
 #. Option for the 'Send Notification for Published Courses' (Select) field in
 #. DocType 'LMS Settings'
 #. Option for the 'Send Notification for Published Batches' (Select) field in
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "In-app"
-msgstr "V aplikaci"
+msgstr "V aplikácii"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:205
 msgid "Inbox"
@@ -4099,25 +4179,25 @@ msgstr "Doručená pošta"
 #. Label of the include_in_preview (Check) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Include In Preview"
-msgstr "Zahrnout do náhledu"
+msgstr "Zahrnúť do náhľadu"
 
 #: frontend/src/pages/LessonForm.vue:9
 msgid "Include in preview"
-msgstr "Zahrnout do náhledu"
+msgstr "Zahrnúť do náhľadu"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Course Progress'
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.json
 msgid "Incomplete"
-msgstr "Nedokončeno"
+msgstr "Nedokončené"
 
 #: frontend/src/components/Quiz.vue:231
 msgid "Incorrect"
-msgstr "Nesprávně"
+msgstr "Nesprávne"
 
 #. Option for the 'Collaboration Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Individual Work"
-msgstr "Individuální práce"
+msgstr "Individuálna práca"
 
 #. Name of a DocType
 #. Label of the industry (Data) field in DocType 'Industry'
@@ -4125,7 +4205,7 @@ msgstr "Individuální práce"
 #: lms/lms/doctype/industry/industry.json
 #: lms/lms/doctype/preferred_industry/preferred_industry.json
 msgid "Industry"
-msgstr "Odvětví"
+msgstr "Odvetvie"
 
 #. Label of the input (Data) field in DocType 'LMS Test Case'
 #. Label of the input (Data) field in DocType 'LMS Test Case Submission'
@@ -4137,17 +4217,17 @@ msgstr "Vstup"
 
 #: frontend/src/components/InstallPrompt.vue:18
 msgid "Install"
-msgstr "Nainstalovat"
+msgstr "Nainštalovať"
 
 #: frontend/src/components/InstallPrompt.vue:4
 #: frontend/src/components/InstallPrompt.vue:32
 msgid "Install Frappe Learning"
-msgstr "Nainstalovat Frappe Learning"
+msgstr "Nainštalovať Frappe Learning"
 
 #. Label of the institution_name (Data) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Institution Name"
-msgstr "Název instituce"
+msgstr "Názov inštitúcie"
 
 #. Label of the instructor (Link) field in DocType 'Course Instructor'
 #: frontend/src/components/Settings/Members.vue:174
@@ -4158,7 +4238,7 @@ msgstr "Lektor"
 #. Label of the instructor_content (Text) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Instructor Content"
-msgstr "Obsah pro lektora"
+msgstr "Obsah pre lektora"
 
 #. Label of the instructor_notes (Markdown Editor) field in DocType 'Course
 #. Lesson'
@@ -4182,16 +4262,16 @@ msgstr "Poznámky lektora"
 #: lms/lms/doctype/lms_batch_feedback/lms_batch_feedback.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Instructors"
-msgstr "Lektoři"
+msgstr "Lektori"
 
 #: lms/templates/assignment.html:17
 msgid "Instructors Comments"
-msgstr "Komentáře lektora"
+msgstr "Komentáre lektora"
 
 #. Label of a Link in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Interest"
-msgstr "Zájem"
+msgstr "Záujem"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:578
 #: frontend/src/components/Sidebar/AppSidebar.vue:581
@@ -4208,7 +4288,7 @@ msgstr "Neplatné ID kvízu v obsahu"
 
 #: lms/lms/course_import_export.py:771
 msgid "Invalid ZIP file"
-msgstr "Neplatný soubor ZIP"
+msgstr "Neplatný súbor ZIP"
 
 #: lms/lms/api.py:629
 msgid "Invalid chapter."
@@ -4216,35 +4296,35 @@ msgstr "Neplatná kapitola."
 
 #: lms/lms/course_import_export.py:339
 msgid "Invalid course ZIP: Missing course.json"
-msgstr "Neplatný soubor ZIP kurzu: chybí course.json"
+msgstr "Neplatný súbor ZIP kurzu: chýba course.json"
 
 #: lms/lms/api.py:1174 lms/lms/api.py:1179
 msgid "Invalid course or chapter name"
-msgstr "Neplatný název kurzu nebo kapitoly"
+msgstr "Neplatný názov kurzu alebo kapitoly"
 
 #: lms/lms/api.py:890
 msgid "Invalid document name"
-msgstr "Neplatný název dokumentu"
+msgstr "Neplatný názov dokumentu"
 
 #: lms/lms/doctype/course_lesson/course_lesson.py:177
 msgid "Invalid file path"
-msgstr "Neplatná cesta k souboru"
+msgstr "Neplatná cesta k súboru"
 
 #: lms/lms/api.py:1198 lms/lms/api.py:1201
 msgid "Invalid file path in package"
-msgstr "Neplatná cesta k souboru v balíčku"
+msgstr "Neplatná cesta k súboru v balíku"
 
 #: lms/lms/api.py:728
 msgid "Invalid role filter."
-msgstr "Neplatný filtr rolí."
+msgstr "Neplatný filter rolí."
 
 #: lms/lms/api.py:730
 msgid "Invalid search query."
-msgstr "Neplatný vyhledávací dotaz."
+msgstr "Neplatný vyhľadávací dopyt."
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:512
 msgid "Invite your team and students"
-msgstr "Pozvěte svůj tým a studenty"
+msgstr "Pozvite svoj tím a študentov"
 
 #. Label of the is_correct (Check) field in DocType 'LMS Option'
 #. Label of the is_correct_1 (Check) field in DocType 'LMS Question'
@@ -4262,19 +4342,19 @@ msgstr "Pozvěte svůj tým a studenty"
 #: lms/lms/doctype/lms_question/lms_question.json
 #: lms/lms/doctype/lms_quiz_result/lms_quiz_result.json
 msgid "Is Correct"
-msgstr "Je správná"
+msgstr "Je správna"
 
 #. Label of the is_scorm_chapter (Check) field in DocType 'LMS Course Progress'
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.json
 msgid "Is SCORM Chapter"
-msgstr "Je kapitolou SCORM"
+msgstr "Je kapitola SCORM"
 
 #. Label of the is_scorm_package (Check) field in DocType 'Course Chapter'
 #. Label of the is_scorm_package (Check) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_chapter/course_chapter.json
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Is SCORM Package"
-msgstr "Je balíčkem SCORM"
+msgstr "Je balík SCORM"
 
 #. Label of the issue_date (Date) field in DocType 'Certification'
 #. Label of the issue_date (Date) field in DocType 'LMS Certificate'
@@ -4283,20 +4363,20 @@ msgstr "Je balíčkem SCORM"
 #: lms/lms/doctype/certification/certification.json
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
 msgid "Issue Date"
-msgstr "Datum vydání"
+msgstr "Dátum vydania"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:619
 msgid "Issue a Certificate"
-msgstr "Vydat certifikát"
+msgstr "Vydať certifikát"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:64
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:77
 msgid "Issue a free certificate when learners complete the course."
-msgstr "Po dokončení kurzu vystavit studentům bezplatný certifikát."
+msgstr "Po dokončení kurzu vydať študentom bezplatný certifikát."
 
 #: frontend/src/pages/Batches/BatchForm.vue:98
 msgid "Issue certificates to batch participants."
-msgstr "Vystavit certifikáty účastníkům školicího kola."
+msgstr "Vydať certifikáty účastníkom školiaceho kola."
 
 #. Label of the issued_on (Date) field in DocType 'LMS Badge Assignment'
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:36
@@ -4304,19 +4384,19 @@ msgstr "Vystavit certifikáty účastníkům školicího kola."
 #: frontend/src/pages/Courses/CourseCertification.vue:27
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.json
 msgid "Issued On"
-msgstr "Vydáno dne"
+msgstr "Vydané dňa"
 
 #: frontend/src/pages/ProfileAbout.vue:75
 #: frontend/src/pages/ProfileCertificates.vue:20
 #: lms/templates/certificates_section.html:11
 msgid "Issued on"
-msgstr "Vydáno dne"
+msgstr "Vydané dňa"
 
 #. Label of the items_in_sidebar_section (Section Break) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Items in Sidebar"
-msgstr "Položky v postranním panelu"
+msgstr "Položky v bočnom paneli"
 
 #: lms/templates/signup-form.html:6
 msgid "Jane Doe"
@@ -4331,22 +4411,22 @@ msgstr "JavaScript"
 #. Label of the job (Link) field in DocType 'LMS Job Application'
 #: lms/job/doctype/lms_job_application/lms_job_application.json
 msgid "Job"
-msgstr "Pracovní pozice"
+msgstr "Pracovná pozícia"
 
 #: frontend/src/pages/JobForm.vue:22
 msgid "Job Details"
-msgstr "Podrobnosti pracovní nabídky"
+msgstr "Podrobnosti pracovnej ponuky"
 
 #: lms/www/_lms.py:192
 msgid "Job Openings"
-msgstr "Volná pracovní místa"
+msgstr "Voľné pracovné miesta"
 
 #. Name of a DocType
 #. Title of the job-opportunity Web Form
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Job Opportunity"
-msgstr "Pracovní příležitost"
+msgstr "Pracovná príležitosť"
 
 #. Label of the job_title (Data) field in DocType 'Job Opportunity'
 #. Label of the job_title (Data) field in DocType 'LMS Job Application'
@@ -4355,7 +4435,7 @@ msgstr "Pracovní příležitost"
 #: lms/job/doctype/lms_job_application/lms_job_application.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Job Title"
-msgstr "Název pozice"
+msgstr "Názov pozície"
 
 #. Label of the jobs (Check) field in DocType 'LMS Settings'
 #. Label of the jobs_tab (Tab Break) field in DocType 'LMS Settings'
@@ -4364,45 +4444,45 @@ msgstr "Název pozice"
 #: frontend/src/pages/Jobs.vue:348
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Jobs"
-msgstr "Pracovní nabídky"
+msgstr "Pracovné ponuky"
 
 #: frontend/src/pages/Batches/components/LiveClass.vue:86
 #: frontend/src/pages/Home/AdminHome.vue:89
 #: frontend/src/pages/Home/StudentHome.vue:54
 #: lms/templates/upcoming_evals.html:15
 msgid "Join"
-msgstr "Připojit se"
+msgstr "Pripojiť sa"
 
 #: frontend/src/components/UpcomingEvaluations.vue:93
 msgid "Join Call"
-msgstr "Připojit se k hovoru"
+msgstr "Pripojiť sa k hovoru"
 
 #: frontend/src/components/Modals/Event.vue:79
 msgid "Join Meeting"
-msgstr "Připojit se ke schůzce"
+msgstr "Pripojiť sa k stretnutiu"
 
 #. Label of the join_url (Small Text) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Join URL"
-msgstr "Adresa URL pro připojení"
+msgstr "URL na pripojenie"
 
 #. Label of the joined_at (Datetime) field in DocType 'LMS Live Class
 #. Participant'
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 msgid "Joined At"
-msgstr "Čas připojení"
+msgstr "Čas pripojenia"
 
 #: frontend/src/components/Modals/LiveClassAttendance.vue:16
 msgid "Joined at"
-msgstr "Připojeno v"
+msgstr "Pripojené o"
 
 #: frontend/src/components/CommandPalette/CommandPalette.vue:194
 msgid "Jump to"
-msgstr "Přejít na"
+msgstr "Prejsť na"
 
 #: frontend/src/pages/PersonaForm.vue:149
 msgid "Just exploring"
-msgstr "Jen se rozhlížím"
+msgstr "Iba sa rozhliadam"
 
 #: frontend/src/pages/PersonaForm.vue:161
 msgid "Kajabi"
@@ -4410,22 +4490,22 @@ msgstr "Kajabi"
 
 #: frontend/src/pages/Home/Streak.vue:13
 msgid "Keep going,"
-msgstr "Jen tak dál,"
+msgstr "Len tak ďalej,"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_assessment/lms_assessment.json
 msgid "LMS Assessment"
-msgstr "Hodnocení LMS"
+msgstr "Hodnotenie LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_assignment/lms_assignment.json
 msgid "LMS Assignment"
-msgstr "Úkol LMS"
+msgstr "Úloha LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "LMS Assignment Submission"
-msgstr "Odevzdání úkolu LMS"
+msgstr "Odovzdanie úlohy LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_badge/lms_badge.json
@@ -4435,7 +4515,7 @@ msgstr "Odznak LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.json
 msgid "LMS Badge Assignment"
-msgstr "Přiřazení odznaku LMS"
+msgstr "Priradenie odznaku LMS"
 
 #. Name of a DocType
 #. Option for the 'Reference DocType' (Select) field in DocType 'LMS Coupon
@@ -4446,27 +4526,27 @@ msgstr "Přiřazení odznaku LMS"
 #: lms/lms/doctype/lms_coupon_item/lms_coupon_item.json
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "LMS Batch"
-msgstr "Školicí kolo LMS"
+msgstr "Školiace kolo LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.json
 msgid "LMS Batch Enrollment"
-msgstr "Zápis do školicího kola LMS"
+msgstr "Zápis do školiaceho kola LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_batch_feedback/lms_batch_feedback.json
 msgid "LMS Batch Feedback"
-msgstr "Zpětná vazba ke školicímu kolu LMS"
+msgstr "Spätná väzba ku školiacemu kolu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
 msgid "LMS Batch Timetable"
-msgstr "Rozvrh školicího kola LMS"
+msgstr "Rozvrh školiaceho kola LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_category/lms_category.json
 msgid "LMS Category"
-msgstr "Kategorie LMS"
+msgstr "Kategória LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
@@ -4476,12 +4556,12 @@ msgstr "Certifikát LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "LMS Certificate Evaluation"
-msgstr "Hodnocení certifikátu LMS"
+msgstr "Hodnotenie certifikátu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "LMS Certificate Request"
-msgstr "Žádost o certifikát LMS"
+msgstr "Žiadosť o certifikát LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
@@ -4507,22 +4587,22 @@ msgstr "Kurz LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_course_interest/lms_course_interest.json
 msgid "LMS Course Interest"
-msgstr "Zájem o kurz LMS"
+msgstr "Záujem o kurz LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_course_mentor_mapping/lms_course_mentor_mapping.json
 msgid "LMS Course Mentor Mapping"
-msgstr "Přiřazení mentora ke kurzu LMS"
+msgstr "Priradenie mentora ku kurzu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.json
 msgid "LMS Course Progress"
-msgstr "Průběh kurzu LMS"
+msgstr "Priebeh kurzu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_course_review/lms_course_review.json
 msgid "LMS Course Review"
-msgstr "Recenze kurzu LMS"
+msgstr "Recenzia kurzu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
@@ -4532,32 +4612,32 @@ msgstr "Zápis do LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_google_meet_settings/lms_google_meet_settings.json
 msgid "LMS Google Meet Settings"
-msgstr "Nastavení Google Meet pro LMS"
+msgstr "Nastavenia Google Meet pre LMS"
 
 #. Name of a DocType
 #: lms/job/doctype/lms_job_application/lms_job_application.json
 msgid "LMS Job Application"
-msgstr "Žádost o pracovní pozici LMS"
+msgstr "Žiadosť o pracovnú pozíciu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_lesson_note/lms_lesson_note.json
 msgid "LMS Lesson Note"
-msgstr "Poznámka k lekci LMS"
+msgstr "Poznámka k lekcii LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "LMS Live Class"
-msgstr "Živá lekce LMS"
+msgstr "Živá lekcia LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 msgid "LMS Live Class Participant"
-msgstr "Účastník živé lekce LMS"
+msgstr "Účastník živej lekcie LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_option/lms_option.json
 msgid "LMS Option"
-msgstr "Možnost LMS"
+msgstr "Možnosť LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_payment/lms_payment.json
@@ -4582,12 +4662,12 @@ msgstr "Člen programu LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_programming_exercise/lms_programming_exercise.json
 msgid "LMS Programming Exercise"
-msgstr "Programovací cvičení LMS"
+msgstr "Programovacie cvičenie LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 msgid "LMS Programming Exercise Submission"
-msgstr "Odevzdání programovacího cvičení LMS"
+msgstr "Odovzdanie programovacieho cvičenia LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_question/lms_question.json
@@ -4607,22 +4687,22 @@ msgstr "Otázka kvízu LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_quiz_result/lms_quiz_result.json
 msgid "LMS Quiz Result"
-msgstr "Výsledek kvízu LMS"
+msgstr "Výsledok kvízu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
 msgid "LMS Quiz Submission"
-msgstr "Odevzdání kvízu LMS"
+msgstr "Odovzdanie kvízu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "LMS Settings"
-msgstr "Nastavení LMS"
+msgstr "Nastavenia LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_sidebar_item/lms_sidebar_item.json
 msgid "LMS Sidebar Item"
-msgstr "Položka postranního panelu LMS"
+msgstr "Položka bočného panela LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_source/lms_source.json
@@ -4657,17 +4737,17 @@ msgstr "Zdroj LMS"
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 #: lms/lms/doctype/user_skill/user_skill.json
 msgid "LMS Student"
-msgstr "Student LMS"
+msgstr "Študent LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_test_case/lms_test_case.json
 msgid "LMS Test Case"
-msgstr "Testovací případ LMS"
+msgstr "Testovací prípad LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_test_case_submission/lms_test_case_submission.json
 msgid "LMS Test Case Submission"
-msgstr "Odevzdání testovacího případu LMS"
+msgstr "Odovzdanie testovacieho prípadu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_timetable_legend/lms_timetable_legend.json
@@ -4677,22 +4757,22 @@ msgstr "Legenda rozvrhu LMS"
 #. Name of a DocType
 #: lms/lms/doctype/lms_timetable_template/lms_timetable_template.json
 msgid "LMS Timetable Template"
-msgstr "Šablona rozvrhu LMS"
+msgstr "Šablóna rozvrhu LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 msgid "LMS Video Watch Duration"
-msgstr "Doba sledování videa LMS"
+msgstr "Dĺžka sledovania videa LMS"
 
 #. Name of a DocType
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 msgid "LMS Zoom Settings"
-msgstr "Nastavení Zoomu pro LMS"
+msgstr "Nastavenia Zoomu pre LMS"
 
 #. Label of the label (Data) field in DocType 'LMS Timetable Legend'
 #: lms/lms/doctype/lms_timetable_legend/lms_timetable_legend.json
 msgid "Label"
-msgstr "Popisek"
+msgstr "Popisok"
 
 #. Label of the language (Select) field in DocType 'LMS Programming Exercise'
 #: frontend/src/components/Modals/EditProfile.vue:64
@@ -4706,41 +4786,41 @@ msgstr "Jazyk"
 #: frontend/src/components/Modals/EditProfile.vue:144
 #: frontend/src/components/Modals/NewMemberModal.vue:36
 msgid "Last Name"
-msgstr "Příjmení"
+msgstr "Priezvisko"
 
 #. Label of the launch_file (Code) field in DocType 'Course Chapter'
 #: lms/lms/doctype/course_chapter/course_chapter.json
 msgid "Launch File"
-msgstr "Spouštěcí soubor"
+msgstr "Spúšťací súbor"
 
 #: frontend/src/pages/PersonaForm.vue:148
 msgid "Launch a paid course"
-msgstr "Zahájit placený kurz"
+msgstr "Spustiť platený kurz"
 
 #. Name of a Workspace
 #. Title of a Workspace Sidebar
 #: frontend/src/pages/PersonaForm.vue:13
 #: lms/lms/workspace/learning/learning.json lms/workspace_sidebar/learning.json
 msgid "Learning"
-msgstr "Vzdělávání"
+msgstr "Vzdelávanie"
 
 #: frontend/src/pages/Home/Streak.vue:2
 msgid "Learning Consistency"
-msgstr "Pravidelnost studia"
+msgstr "Pravidelnosť štúdia"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:603
 msgid "Learning Paths"
-msgstr "Studijní cesty"
+msgstr "Študijné cesty"
 
 #. Label of the left_at (Datetime) field in DocType 'LMS Live Class
 #. Participant'
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 msgid "Left At"
-msgstr "Čas odpojení"
+msgstr "Čas odpojenia"
 
 #: frontend/src/components/Modals/LiveClassAttendance.vue:19
 msgid "Left at"
-msgstr "Odpojeno v"
+msgstr "Odpojené o"
 
 #. Label of the lesson (Link) field in DocType 'Lesson Reference'
 #. Label of the lesson (Link) field in DocType 'LMS Assignment Submission'
@@ -4760,62 +4840,62 @@ msgstr "Odpojeno v"
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
 #: lms/lms/workspace/learning/learning.json
 msgid "Lesson"
-msgstr "Lekce"
+msgstr "Lekcia"
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:231
 msgid "Lesson Completion"
-msgstr "Dokončení lekce"
+msgstr "Dokončenie lekcie"
 
 #. Label of the lesson_dwell_time (Int) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Lesson Dwell Time (seconds)"
-msgstr "Doba strávená v lekci (sekundy)"
+msgstr "Čas strávený v lekcii (sekundy)"
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:19
 msgid "Lesson Dwell Time must be at least 1 second."
-msgstr "Doba strávená v lekci musí být alespoň 1 sekunda."
+msgstr "Čas strávený v lekcii musí byť aspoň 1 sekunda."
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:451
 msgid "Lesson Index"
-msgstr "Pořadí lekce"
+msgstr "Poradie lekcie"
 
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:42
 msgid "Lesson Progress"
-msgstr "Průběh lekce"
+msgstr "Priebeh lekcie"
 
 #. Name of a DocType
 #: lms/lms/doctype/lesson_reference/lesson_reference.json
 msgid "Lesson Reference"
-msgstr "Odkaz na lekci"
+msgstr "Odkaz na lekciu"
 
 #. Label of the lesson_title (Data) field in DocType 'Scheduled Flow'
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
 msgid "Lesson Title"
-msgstr "Název lekce"
+msgstr "Názov lekcie"
 
 #: frontend/src/components/Modals/LessonModal.vue:170
 msgid "Lesson created"
-msgstr "Lekce vytvořena"
+msgstr "Lekcia vytvorená"
 
 #: frontend/src/pages/LessonForm.vue:537
 msgid "Lesson created successfully"
-msgstr "Lekce byla úspěšně vytvořena"
+msgstr "Lekcia bola úspešne vytvorená"
 
 #: frontend/src/components/CourseOutline.vue:210
 msgid "Lesson deleted successfully"
-msgstr "Lekce byla úspěšně smazána"
+msgstr "Lekcia bola úspešne odstránená"
 
 #: frontend/src/components/CourseOutline.vue:231
 msgid "Lesson moved successfully"
-msgstr "Lekce byla úspěšně přesunuta"
+msgstr "Lekcia bola úspešne presunutá"
 
 #: frontend/src/pages/LessonForm.vue:29
 msgid "Lesson title"
-msgstr "Název lekce"
+msgstr "Názov lekcie"
 
 #: frontend/src/components/Modals/LessonModal.vue:148
 msgid "Lesson updated"
-msgstr "Lekce aktualizována"
+msgstr "Lekcia aktualizovaná"
 
 #. Label of the lessons (Table) field in DocType 'Course Chapter'
 #. Group in Course Chapter's connections
@@ -4827,34 +4907,38 @@ msgstr "Lekce aktualizována"
 #: lms/lms/doctype/course_chapter/course_chapter.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Lessons"
-msgstr "Lekce"
+msgstr "Lekcie"
 
 #: lms/lms/web_template/lms_statistics/lms_statistics.html:14
 #: lms/templates/statistics.html:36
 msgid "Lessons Completed"
-msgstr "Dokončené lekce"
+msgstr "Dokončené lekcie"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:23
 msgid "Let users enroll themselves."
-msgstr "Umožnit uživatelům, aby se zapsali sami."
+msgstr "Umožniť používateľom, aby sa zapísali sami."
 
 #: lms/templates/onboarding_header.html:11
-msgid "Lets start setting up your content on the LMS so that you can reclaim time and focus on growth."
-msgstr "Začněme nastavovat obsah v LMS, abyste získali více času a mohli se soustředit na růst."
+msgid ""
+"Lets start setting up your content on the LMS so that you can reclaim time "
+"and focus on growth."
+msgstr ""
+"Začnime nastavovať obsah v LMS, aby ste získali viac času a mohli sa "
+"sústrediť na rast."
 
 #. Option for the 'Grade Type' (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Letter Grade (e.g. A, B-)"
-msgstr "Písmenná známka (např. A, B-)"
+msgstr "Písmenová známka (napr. A, B-)"
 
 #. Label of the limit_questions_to (Int) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:227 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Limit Questions To"
-msgstr "Omezit počet otázek na"
+msgstr "Obmedziť počet otázok na"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:53
 msgid "Limit cannot be greater than or equal to the number of questions in the quiz."
-msgstr "Limit nesmí být větší než počet otázek v kvízu ani se mu rovnat."
+msgstr "Limit nesmie byť väčší alebo rovný počtu otázok v kvíze."
 
 #: frontend/src/pages/ProfileAbout.vue:96
 msgid "LinkedIn"
@@ -4864,7 +4948,7 @@ msgstr "LinkedIn"
 #: frontend/src/components/Modals/EditProfile.vue:46
 #: lms/fixtures/custom_field.json
 msgid "LinkedIn ID"
-msgstr "ID na LinkedInu"
+msgstr "ID na LinkedIne"
 
 #. Label of the live_class (Link) field in DocType 'LMS Live Class Participant'
 #. Label of the show_live_class (Check) field in DocType 'LMS Settings'
@@ -4872,11 +4956,11 @@ msgstr "ID na LinkedInu"
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Live Class"
-msgstr "Živá lekce"
+msgstr "Živá lekcia"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:310
 msgid "Live answer checking is not enabled for this quiz."
-msgstr "Pro tento kvíz není zapnuta průběžná kontrola odpovědí."
+msgstr "Pre tento kvíz nie je zapnutá priebežná kontrola odpovedí."
 
 #. Label of the livecode_url (Data) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
@@ -4897,12 +4981,12 @@ msgstr "URL služby LiveCode"
 #: frontend/src/pages/QuizSubmissionList.vue:39
 #: frontend/src/pages/Quizzes.vue:108
 msgid "Load More"
-msgstr "Načíst více"
+msgstr "Načítať viac"
 
 #. Option for the 'Auto Recording' (Select) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Local"
-msgstr "Lokálně"
+msgstr "Lokálne"
 
 #. Label of a field in the job-opportunity Web Form
 #. Label of the location (Data) field in DocType 'Education Detail'
@@ -4912,85 +4996,85 @@ msgstr "Lokálně"
 #: lms/lms/doctype/education_detail/education_detail.json
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "Location"
-msgstr "Místo"
+msgstr "Miesto"
 
 #. Label of the location_preference (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Location Preference"
-msgstr "Preferované místo"
+msgstr "Preferované miesto"
 
 #: frontend/src/components/NoPermission.vue:26
 #: frontend/src/components/QuizBlock.vue:9 frontend/src/pages/Lesson.vue:60
 msgid "Login"
-msgstr "Přihlásit se"
+msgstr "Prihlásiť sa"
 
 #: frontend/src/components/Sidebar/UserDropdown.vue:179
 msgid "Login to Frappe Cloud?"
-msgstr "Přihlásit se do Frappe Cloud?"
+msgstr "Prihlásiť sa do Frappe Cloud?"
 
 #: frontend/src/pages/JobDetail.vue:74
 msgid "Login to apply"
-msgstr "Pro podání žádosti se přihlaste"
+msgstr "Ak chcete podať žiadosť, prihláste sa"
 
 #: frontend/src/pages/Home/Streak.vue:37
 msgid "Longest Streak"
-msgstr "Nejdelší série"
+msgstr "Najdlhšia séria"
 
 #: frontend/src/components/Modals/EditProfile.vue:61
 msgid "Looking for new work or hiring talent?"
-msgstr "Hledáte novou práci nebo nové talenty?"
+msgstr "Hľadáte novú prácu alebo nové talenty?"
 
 #: lms/templates/emails/payment_reminder.html:23
 msgid "Looking forward to seeing you enrolled!"
-msgstr "Těšíme se, až se zapíšete!"
+msgstr "Tešíme sa, že sa zapíšete!"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:68
 msgid "Make Announcement"
-msgstr "Vytvořit oznámení"
+msgstr "Vytvoriť oznámenie"
 
 #. Label of the default_home (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Make LMS the default home"
-msgstr "Nastavit LMS jako výchozí domovskou stránku"
+msgstr "Nastaviť LMS ako predvolenú domovskú stránku"
 
 #: frontend/src/components/Notes/Notes.vue:7
 msgid "Make notes for quick revision. Press / for menu."
-msgstr "Pište si poznámky pro rychlé opakování. Nabídku otevřete stisknutím /."
+msgstr "Robte si poznámky na rýchle opakovanie. Ponuku otvoríte stlačením /."
 
 #: frontend/src/components/Modals/Event.vue:125
 msgid "Make this certificate visible to the participant."
-msgstr "Zpřístupnit tento certifikát účastníkovi."
+msgstr "Sprístupniť tento certifikát účastníkovi."
 
 #: frontend/src/pages/ProfileRoles.vue:35
 msgid "Manage batches, review and grade submissions"
-msgstr "Spravujte školicí kola, kontrolujte a známkujte odevzdané práce"
+msgstr "Spravujte školiace kolá, kontrolujte a známkujte odovzdané práce"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:150
 msgid "Manage templates"
-msgstr "Spravovat šablony"
+msgstr "Spravovať šablóny"
 
 #: frontend/src/pages/Home/Home.vue:143
 msgid "Manage your courses and batches at a glance"
-msgstr "Mějte přehled o svých kurzech a školicích kolech"
+msgstr "Majte prehľad o svojich kurzoch a školiacich kolách"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:5
 msgid "Manage your email accounts and configure incoming and outgoing settings."
-msgstr "Spravujte své e-mailové účty a nastavte příchozí a odchozí poštu."
+msgstr "Spravujte svoje e-mailové účty a nastavte prichádzajúcu a odchádzajúcu poštu."
 
 #. Option for the 'User Category' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:24
 msgid "Manager (Sales/Marketing/Customer)"
-msgstr "Manažer (prodej/marketing/zákaznická péče)"
+msgstr "Manažér (predaj/marketing/starostlivosť o zákazníkov)"
 
 #. Label of the manifest_file (Code) field in DocType 'Course Chapter'
 #: lms/lms/doctype/course_chapter/course_chapter.json
 msgid "Manifest File"
-msgstr "Soubor manifestu"
+msgstr "Súbor manifestu"
 
 #. Option for the 'Event' (Select) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Manual Assignment"
-msgstr "Ruční přiřazení"
+msgstr "Ručné priradenie"
 
 #: frontend/src/components/Quiz.vue:148
 msgid "Mark"
@@ -4998,15 +5082,15 @@ msgstr "Bod"
 
 #: frontend/src/components/Notifications/NotificationPanel.vue:25
 msgid "Mark all as read"
-msgstr "Označit vše jako přečtené"
+msgstr "Označiť všetko ako prečítané"
 
 #: frontend/src/components/Quiz.vue:251
 msgid "Mark for review"
-msgstr "Označit ke kontrole"
+msgstr "Označiť na kontrolu"
 
 #: frontend/src/components/Modals/Question.vue:89
 msgid "Mark this option as a correct answer."
-msgstr "Označit tuto možnost jako správnou odpověď."
+msgstr "Označiť túto možnosť ako správnu odpoveď."
 
 #. Label of the marks (Int) field in DocType 'LMS Quiz Question'
 #. Label of the marks (Int) field in DocType 'LMS Quiz Result'
@@ -5022,53 +5106,57 @@ msgstr "Body"
 #. Label of the marks_to_cut (Int) field in DocType 'LMS Quiz'
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Marks To Cut"
-msgstr "Body k odečtení"
+msgstr "Body na odpočítanie"
 
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py:41
-msgid "Marks for question number {0} cannot be greater than the marks allotted for that question."
-msgstr "Počet bodů za otázku č. {0} nesmí být vyšší než počet bodů přidělených této otázce."
+msgid ""
+"Marks for question number {0} cannot be greater than the marks allotted for "
+"that question."
+msgstr ""
+"Počet bodov za otázku č. {0} nesmie byť vyšší ako počet bodov pridelených "
+"tejto otázke."
 
 #. Label of the marks_out_of (Int) field in DocType 'LMS Quiz Result'
 #: frontend/src/pages/QuizSubmission.vue:70
 #: lms/lms/doctype/lms_quiz_result/lms_quiz_result.json
 msgid "Marks out of"
-msgstr "Bodů z"
+msgstr "Bodov z"
 
 #: frontend/src/pages/QuizForm.vue:239
 msgid "Marks to Deduct"
-msgstr "Odečítané body"
+msgstr "Odpočítavané body"
 
 #. Label of the max_attempts (Int) field in DocType 'LMS Quiz'
 #: frontend/src/pages/Quizzes.vue:282 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Max Attempts"
-msgstr "Max. počet pokusů"
+msgstr "Max. počet pokusov"
 
 #: frontend/src/pages/QuizForm.vue:164
 msgid "Maximum Attempts"
-msgstr "Maximální počet pokusů"
+msgstr "Maximálny počet pokusov"
 
 #. Label of the medium (Select) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:162
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:72
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Medium"
-msgstr "Forma výuky"
+msgstr "Forma výučby"
 
 #. Label of the medium (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Medium ID"
-msgstr "ID na Mediumu"
+msgstr "ID na Medium"
 
 #: lms/templates/emails/batch_confirmation.html:16
 #: lms/templates/emails/batch_start_reminder.html:19
 #: lms/templates/emails/batch_start_reminder_recorded.html:22
 msgid "Medium:"
-msgstr "Forma výuky:"
+msgstr "Forma výučby:"
 
 #. Label of the meeting_id (Data) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Meeting ID"
-msgstr "ID schůzky"
+msgstr "ID stretnutia"
 
 #. Label of the member (Link) field in DocType 'LMS Assignment Submission'
 #. Label of the member (Link) field in DocType 'LMS Badge Assignment'
@@ -5131,12 +5219,12 @@ msgstr "Člen"
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:40
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Member Consent"
-msgstr "Souhlas člena"
+msgstr "Súhlas člena"
 
 #. Label of the member_count (Int) field in DocType 'LMS Program'
 #: lms/lms/doctype/lms_program/lms_program.json
 msgid "Member Count"
-msgstr "Počet členů"
+msgstr "Počet členov"
 
 #. Label of the member_image (Attach Image) field in DocType 'LMS Badge
 #. Assignment'
@@ -5163,7 +5251,7 @@ msgstr "Počet členů"
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 msgid "Member Image"
-msgstr "Obrázek člena"
+msgstr "Obrázok člena"
 
 #. Label of the member_name (Data) field in DocType 'LMS Assignment Submission'
 #. Label of the member_name (Data) field in DocType 'LMS Badge Assignment'
@@ -5200,7 +5288,7 @@ msgstr "Obrázek člena"
 #: lms/lms/doctype/lms_zoom_settings/lms_zoom_settings.json
 #: lms/lms/report/course_progress_summary/course_progress_summary.py:71
 msgid "Member Name"
-msgstr "Jméno člena"
+msgstr "Meno člena"
 
 #. Label of the member_type (Select) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
@@ -5220,39 +5308,39 @@ msgstr "Typ člena"
 #: lms/lms/doctype/lms_live_class_participant/lms_live_class_participant.json
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 msgid "Member Username"
-msgstr "Uživatelské jméno člena"
+msgstr "Používateľské meno člena"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:185
 msgid "Member added successfully"
-msgstr "Člen byl úspěšně přidán"
+msgstr "Člen bol úspešne pridaný"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:461
 msgid "Member added to program successfully"
-msgstr "Člen byl úspěšně přidán do programu"
+msgstr "Člen bol úspešne pridaný do programu"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:463
 msgid "Member already added to program"
-msgstr "Člen již byl do programu přidán"
+msgstr "Člen už bol pridaný do programu"
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:68
 msgid "Member already enrolled in this batch"
-msgstr "Člen je již zapsán do tohoto školicího kola"
+msgstr "Člen je už zapísaný do tohto školiaceho kola"
 
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.py:66
 msgid "Member does not meet the criteria for the badge {0}."
-msgstr "Člen nesplňuje kritéria pro odznak {0}."
+msgstr "Člen nespĺňa kritériá pre odznak {0}."
 
 #: frontend/src/components/Modals/NewMemberModal.vue:211
 msgid "Member updated"
-msgstr "Člen byl aktualizován"
+msgstr "Člen bol aktualizovaný"
 
 #: lms/lms/doctype/lms_program/lms_program.py:32
 msgid "Member {0} has already been added to this program."
-msgstr "Člen {0} již byl do tohoto programu přidán."
+msgstr "Člen {0} už bol pridaný do tohto programu."
 
 #: frontend/src/pages/Programs/ProgramForm.vue:105
 msgid "Members"
-msgstr "Členové"
+msgstr "Členovia"
 
 #. Label of the mentor (Link) field in DocType 'LMS Course Mentor Mapping'
 #. Option for the 'Member Type' (Select) field in DocType 'LMS Enrollment'
@@ -5264,13 +5352,13 @@ msgstr "Mentor"
 #. Label of the mentor_name (Data) field in DocType 'LMS Course Mentor Mapping'
 #: lms/lms/doctype/lms_course_mentor_mapping/lms_course_mentor_mapping.json
 msgid "Mentor Name"
-msgstr "Jméno mentora"
+msgstr "Meno mentora"
 
 #. Label of the mentor_request_section (Section Break) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Mentor Request"
-msgstr "Žádost o mentora"
+msgstr "Žiadosť o mentora"
 
 #. Label of the mentor_request_creation (Link) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
@@ -5278,7 +5366,7 @@ msgstr "Žádost o mentora"
 #: lms/patches/create_mentor_request_email_templates.py:16
 #: lms/patches/create_mentor_request_email_templates.py:26
 msgid "Mentor Request Creation Template"
-msgstr "Šablona vytvoření žádosti o mentora"
+msgstr "Šablóna vytvorenia žiadosti o mentora"
 
 #. Label of the mentor_request_status_update (Link) field in DocType 'LMS
 #. Settings'
@@ -5287,16 +5375,16 @@ msgstr "Šablona vytvoření žádosti o mentora"
 #: lms/patches/create_mentor_request_email_templates.py:34
 #: lms/patches/create_mentor_request_email_templates.py:44
 msgid "Mentor Request Status Update Template"
-msgstr "Šablona aktualizace stavu žádosti o mentora"
+msgstr "Šablóna aktualizácie stavu žiadosti o mentora"
 
 #: frontend/src/components/ContactUsEmail.vue:13
 #: frontend/src/pages/JobApplications.vue:148
 msgid "Message"
-msgstr "Zpráva"
+msgstr "Správa"
 
 #: frontend/src/pages/JobApplications.vue:296
 msgid "Message is required"
-msgstr "Zpráva je povinná"
+msgstr "Správa je povinná"
 
 #. Label of the meta_description (Small Text) field in DocType 'LMS Settings'
 #: frontend/src/pages/Batches/BatchForm.vue:262
@@ -5310,18 +5398,18 @@ msgstr "Meta popis"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Meta Image"
-msgstr "Meta obrázek"
+msgstr "Meta obrázok"
 
 #. Label of the meta_keywords (Small Text) field in DocType 'LMS Settings'
 #: frontend/src/pages/Batches/BatchForm.vue:269
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Meta Keywords"
-msgstr "Meta klíčová slova"
+msgstr "Meta kľúčové slová"
 
 #: frontend/src/pages/Batches/BatchForm.vue:257
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:47
 msgid "Meta Tags"
-msgstr "Meta tagy"
+msgstr "Meta značky"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:59
 msgid "Meta description"
@@ -5329,20 +5417,20 @@ msgstr "Meta popis"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:68
 msgid "Meta keywords"
-msgstr "Meta klíčová slova"
+msgstr "Meta kľúčové slová"
 
 #: lms/lms/api.py:1730
 msgid "Meta tags should be a list."
-msgstr "Meta tagy musí být zadány jako seznam."
+msgstr "Meta značky musia byť zadané ako zoznam."
 
 #. Label of the milestone (Check) field in DocType 'LMS Batch Timetable'
 #: lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
 msgid "Milestone"
-msgstr "Milník"
+msgstr "Míľnik"
 
 #: lms/lms/doctype/lms_question/lms_question.py:54
 msgid "Minimum two options are required for multiple choice questions."
-msgstr "U otázek s výběrem z více možností jsou vyžadovány alespoň dvě možnosti."
+msgstr "Pri otázkach s výberom z viacerých možností sa vyžadujú aspoň dve možnosti."
 
 #. Name of a role
 #: frontend/src/components/Modals/NewMemberModal.vue:64
@@ -5386,7 +5474,7 @@ msgstr "Moderátor"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:295
 msgid "Modified"
-msgstr "Upraveno"
+msgstr "Upravené"
 
 #: lms/lms/doctype/lms_badge/lms_badge.js:38
 msgid "Modified By"
@@ -5394,22 +5482,22 @@ msgstr "Upravil(a)"
 
 #: lms/lms/api.py:175
 msgid "Module Name is incorrect or does not exist."
-msgstr "Název modulu je nesprávný nebo modul neexistuje."
+msgstr "Názov modulu je nesprávny alebo modul neexistuje."
 
 #: lms/lms/api.py:171
 msgid "Module is incorrect."
-msgstr "Modul je nesprávný."
+msgstr "Modul je nesprávny."
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Monday"
-msgstr "Pondělí"
+msgstr "Pondelok"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:627
 msgid "Monetization"
-msgstr "Monetizace"
+msgstr "Monetizácia"
 
 #: frontend/src/pages/PersonaForm.vue:156
 msgid "Moodle"
@@ -5417,16 +5505,16 @@ msgstr "Moodle"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:52
 msgid "More"
-msgstr "Více"
+msgstr "Viac"
 
 #. Label of the multiple (Check) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Multiple Correct Answers"
-msgstr "Více správných odpovědí"
+msgstr "Viac správnych odpovedí"
 
 #: frontend/src/pages/Home/StudentHome.vue:112
 msgid "My Batches"
-msgstr "Moje školicí kola"
+msgstr "Moje školiace kolá"
 
 #: frontend/src/pages/Home/StudentHome.vue:80
 msgid "My Courses"
@@ -5438,15 +5526,15 @@ msgstr "Moje poznámky"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:121
 msgid "My Profile"
-msgstr "Můj profil"
+msgstr "Môj profil"
 
 #: frontend/src/pages/ProfileEvaluator.vue:4
 msgid "My availability"
-msgstr "Moje dostupnost"
+msgstr "Moja dostupnosť"
 
 #: frontend/src/pages/ProfileEvaluator.vue:136
 msgid "My calendar"
-msgstr "Můj kalendář"
+msgstr "Môj kalendár"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:21
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:22
@@ -5455,12 +5543,12 @@ msgstr "Můj kalendář"
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:288
 #: frontend/src/pages/Courses/CourseDashboard.vue:432
 msgid "Name"
-msgstr "Název"
+msgstr "Názov"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:122
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:122
 msgid "Name is required"
-msgstr "Název je povinný"
+msgstr "Názov je povinný"
 
 #. Option for the 'Event' (Select) field in DocType 'LMS Badge'
 #: frontend/src/components/Settings/Badges/BadgeAssignments.vue:12
@@ -5476,11 +5564,11 @@ msgstr "Název je povinný"
 #: frontend/src/components/Settings/ZoomSettings.vue:12
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "New"
-msgstr "Přidat"
+msgstr "Pridať"
 
 #: frontend/src/pages/Batches/Batches.vue:11 lms/www/_lms.py:164
 msgid "New Batch"
-msgstr "Nové školicí kolo"
+msgstr "Nové školiace kolo"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:3
 msgid "New Coupon"
@@ -5493,7 +5581,7 @@ msgstr "Nový kurz"
 #: frontend/src/components/Modals/EmailTemplateModal.vue:5
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:3
 msgid "New Email Template"
-msgstr "Nová e-mailová šablona"
+msgstr "Nová e-mailová šablóna"
 
 #: frontend/src/components/Settings/GoogleMeetAccountForm.vue:104
 msgid "New Google Meet Account"
@@ -5501,15 +5589,15 @@ msgstr "Nový účet Google Meet"
 
 #: frontend/src/pages/JobForm.vue:313 frontend/src/pages/JobForm.vue:325
 msgid "New Job"
-msgstr "Nová pracovní nabídka"
+msgstr "Nová pracovná ponuka"
 
 #: lms/job/doctype/lms_job_application/lms_job_application.py:31
 msgid "New Job Applicant"
-msgstr "Nový uchazeč o práci"
+msgstr "Nový uchádzač o prácu"
 
 #: frontend/src/components/Settings/PaymentGatewayDetails.vue:68
 msgid "New Payment Gateway"
-msgstr "Nová platební brána"
+msgstr "Nová platobná brána"
 
 #: frontend/src/pages/QuizForm.vue:73
 msgid "New Question"
@@ -5517,7 +5605,7 @@ msgstr "Nová otázka"
 
 #: lms/www/new-sign-up.html:3
 msgid "New Sign Up"
-msgstr "Nová registrace"
+msgstr "Nová registrácia"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:114
 msgid "New Zoom Account"
@@ -5525,49 +5613,49 @@ msgstr "Nový účet Zoom"
 
 #: lms/lms/utils.py:469
 msgid "New comment in batch {0}"
-msgstr "Nový komentář v školicím kole {0}"
+msgstr "Nový komentár v školiacom kole {0}"
 
 #: frontend/src/components/Modals/LessonModal.vue:62
 msgid "New lesson"
-msgstr "Nová lekce"
+msgstr "Nová lekcia"
 
 #: lms/lms/utils.py:460
 msgid "New reply on the topic {0} in course {1}"
-msgstr "Nová odpověď v tématu {0} v kurzu {1}"
+msgstr "Nová odpoveď v téme {0} v kurze {1}"
 
 #: frontend/src/components/Discussions.vue:11
 #: frontend/src/components/Discussions.vue:95
 msgid "New {0}"
-msgstr "Přidat {0}"
+msgstr "Pridať {0}"
 
 #: frontend/src/components/Quiz.vue:320 frontend/src/pages/Lesson.vue:145
 #: frontend/src/pages/Lesson.vue:181
 msgid "Next"
-msgstr "Další"
+msgstr "Ďalej"
 
 #: frontend/src/components/Questionnaire.vue:146
 msgid "Next question"
-msgstr "Další otázka"
+msgstr "Ďalšia otázka"
 
 #: lms/templates/assessments.html:58
 msgid "No Assessments"
-msgstr "Žádná hodnocení"
+msgstr "Žiadne hodnotenia"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignments.vue:78
 msgid "No Assignments"
-msgstr "Žádné úkoly"
+msgstr "Žiadne úlohy"
 
 #: frontend/src/pages/PersonaForm.vue:166
 msgid "No LMS yet"
-msgstr "Zatím žádný LMS"
+msgstr "Zatiaľ žiadny LMS"
 
 #: lms/templates/notifications.html:26
 msgid "No Notifications"
-msgstr "Žádná oznámení"
+msgstr "Žiadne oznámenia"
 
 #: frontend/src/components/Quiz.vue:408
 msgid "No Quiz submissions found"
-msgstr "Nebyla nalezena žádná odevzdání kvízu"
+msgstr "Nenašli sa žiadne odovzdania kvízu"
 
 #. Option for the 'Auto Recording' (Select) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
@@ -5576,69 +5664,69 @@ msgstr "Bez záznamu"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:13
 msgid "No Submissions"
-msgstr "Žádná odevzdání"
+msgstr "Žiadne odovzdania"
 
 #: lms/templates/upcoming_evals.html:43
 msgid "No Upcoming Evaluations"
-msgstr "Žádná nadcházející hodnocení"
+msgstr "Žiadne nadchádzajúce hodnotenia"
 
 #: frontend/src/pages/Batches/components/Announcements.vue:28
 msgid "No announcements have been made yet for this batch"
-msgstr "Pro toto školicí kolo zatím nebyla zveřejněna žádná oznámení"
+msgstr "Pre toto školiace kolo zatiaľ neboli zverejnené žiadne oznámenia"
 
 #: frontend/src/pages/Batches/components/Assessments.vue:73
 msgid "No assessments added to this batch"
-msgstr "K tomuto školicímu kolu nebyla přidána žádná hodnocení"
+msgstr "K tomuto školiacemu kolu neboli pridané žiadne hodnotenia"
 
 #: lms/lms/doctype/lms_live_class/lms_live_class.py:77
 msgid ""
-"No calendar is configured for the conferencing provider. Please set up a calendar to create "
-"events."
+"No calendar is configured for the conferencing provider. Please set up a "
+"calendar to create events."
 msgstr ""
-"Pro poskytovatele videokonferencí není nastaven žádný kalendář. Chcete-li vytvářet události, "
-"nastavte kalendář."
+"Pre poskytovateľa videokonferencií nie je nastavený žiadny kalendár. Ak "
+"chcete vytvárať udalosti, nastavte kalendár."
 
 #: lms/templates/certificates_section.html:23
 msgid "No certificates"
-msgstr "Žádné certifikáty"
+msgstr "Žiadne certifikáty"
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:148
 msgid "No changes made"
-msgstr "Nebyly provedeny žádné změny"
+msgstr "Neboli vykonané žiadne zmeny"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:23
 msgid "No changes to save"
-msgstr "Žádné změny k uložení"
+msgstr "Žiadne zmeny na uloženie"
 
 #: frontend/src/components/CourseOutline.vue:29
 msgid "No chapters yet"
-msgstr "Zatím žádné kapitoly"
+msgstr "Zatiaľ žiadne kapitoly"
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:117
 msgid "No coupons selected for deletion"
-msgstr "Nebyly vybrány žádné kupóny ke smazání"
+msgstr "Neboli vybrané žiadne kupóny na odstránenie"
 
 #: frontend/src/pages/Batches/components/BatchCourses.vue:65
 #: frontend/src/pages/Batches/components/BatchDashboard.vue:61
 msgid "No courses added to this batch"
-msgstr "K tomuto školicímu kolu nebyly přidány žádné kurzy"
+msgstr "K tomuto školiacemu kolu neboli pridané žiadne kurzy"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:98
 msgid "No courses added yet."
-msgstr "Zatím nebyly přidány žádné kurzy."
+msgstr "Zatiaľ neboli pridané žiadne kurzy."
 
 #: frontend/src/pages/Home/AdminHome.vue:172
 #: lms/templates/courses_created.html:14
 msgid "No courses created"
-msgstr "Nebyly vytvořeny žádné kurzy"
+msgstr "Neboli vytvorené žiadne kurzy"
 
 #: lms/templates/courses_under_review.html:14
 msgid "No courses under review"
-msgstr "Žádné kurzy čekající na kontrolu"
+msgstr "Žiadne kurzy čakajúce na kontrolu"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:73
 msgid "No feedback received yet."
-msgstr "Zatím nebyla přijata žádná zpětná vazba."
+msgstr "Zatiaľ nebola prijatá žiadna spätná väzba."
 
 #: frontend/src/pages/ProfileAbout.vue:29
 msgid "No introduction"
@@ -5646,115 +5734,115 @@ msgstr "Bez úvodu"
 
 #: frontend/src/pages/Batches/components/LiveClass.vue:105
 msgid "No live classes scheduled"
-msgstr "Nejsou naplánovány žádné živé lekce"
+msgstr "Nie sú naplánované žiadne živé lekcie"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:162
 msgid "No members added yet."
-msgstr "Zatím nebyli přidáni žádní členové."
+msgstr "Zatiaľ neboli pridaní žiadni členovia."
 
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:62
 msgid "No members found."
-msgstr "Nebyli nalezeni žádní členové."
+msgstr "Nenašli sa žiadni členovia."
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:38
 msgid "No other published courses available"
-msgstr "Nejsou k dispozici žádné další zveřejněné kurzy"
+msgstr "Nie sú k dispozícii žiadne ďalšie zverejnené kurzy"
 
 #: frontend/src/pages/Programs/StudentPrograms.vue:56
 msgid "No programs found in this category."
-msgstr "V této kategorii nebyly nalezeny žádné programy."
+msgstr "V tejto kategórii sa nenašli žiadne programy."
 
 #: frontend/src/pages/QuizForm.vue:128
 msgid "No questions added yet"
-msgstr "Zatím nebyly přidány žádné otázky"
+msgstr "Zatiaľ neboli pridané žiadne otázky"
 
 #: frontend/src/components/Modals/QuizInVideo.vue:87
 msgid "No quizzes added yet."
-msgstr "Zatím nebyly přidány žádné kvízy."
+msgstr "Zatiaľ neboli pridané žiadne kvízy."
 
 #: frontend/src/components/Notifications/NotificationPanel.vue:127
 msgid "No read notifications"
-msgstr "Žádná přečtená oznámení"
+msgstr "Žiadne prečítané oznámenia"
 
 #: frontend/src/components/Controls/MultiSelect.vue:74
 msgid "No results found"
-msgstr "Nebyly nalezeny žádné výsledky"
+msgstr "Nenašli sa žiadne výsledky"
 
 #: frontend/src/components/Modals/EvaluationModal.vue:60
 msgid "No slots available for the selected course."
-msgstr "Pro vybraný kurz nejsou k dispozici žádné termíny."
+msgstr "Pre vybraný kurz nie sú k dispozícii žiadne termíny."
 
 #: frontend/src/components/Modals/VideoStatistics.vue:86
 msgid "No statistics available for this video."
-msgstr "Pro toto video nejsou k dispozici žádné statistiky."
+msgstr "Pre toto video nie sú k dispozícii žiadne štatistiky."
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:32
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:127
 #: frontend/src/pages/Courses/CourseDashboard.vue:29
 msgid "No students enrolled yet"
-msgstr "Zatím nejsou zapsáni žádní studenti"
+msgstr "Zatiaľ nie sú zapísaní žiadni študenti"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:93
 msgid "No students in this batch"
-msgstr "V tomto školicím kole nejsou žádní studenti"
+msgstr "V tomto školiacom kole nie sú žiadni študenti"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:126
 #: frontend/src/pages/Courses/CourseDashboard.vue:130
 msgid "No students match your search"
-msgstr "Vašemu hledání neodpovídají žádní studenti"
+msgstr "Vášmu vyhľadávaniu nezodpovedajú žiadni študenti"
 
 #: frontend/src/pages/AssignmentSubmissionList.vue:67
 msgid "No submissions"
-msgstr "Žádná odevzdání"
+msgstr "Žiadne odovzdania"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:34
 msgid "No thumbnail"
-msgstr "Bez miniatury"
+msgstr "Bez miniatúry"
 
 #: frontend/src/components/Notifications/NotificationPanel.vue:126
 msgid "No unread notifications"
-msgstr "Žádná nepřečtená oznámení"
+msgstr "Žiadne neprečítané oznámenia"
 
 #: lms/templates/course_list.html:13
 msgid "No {0}"
-msgstr "Žádné {0}"
+msgstr "Žiadne {0}"
 
 #: frontend/src/components/Layouts/EmptyStateLayout.vue:37
 msgid "No {0} Found"
-msgstr "Nenalezeno: {0}"
+msgstr "Nenašlo sa: {0}"
 
 #: frontend/src/pages/PersonaForm.vue:126
 msgid "Non-profit or Government"
-msgstr "Nezisková nebo vládní organizace"
+msgstr "Nezisková alebo vládna organizácia"
 
 #: lms/lms/user.py:29
 msgid "Not Allowed"
-msgstr "Nepovoleno"
+msgstr "Nepovolené"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Assignment
 #. Submission'
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Not Applicable"
-msgstr "Nevztahuje se"
+msgstr "Nevzťahuje sa"
 
 #: lms/templates/assessments.html:48
 msgid "Not Attempted"
-msgstr "Nezahájeno"
+msgstr "Nezahájené"
 
 #: lms/lms/widgets/NoPreviewModal.html:6
 msgid "Not Available for Preview"
-msgstr "Není k dispozici náhled"
+msgstr "Náhľad nie je k dispozícii"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Assignment
 #. Submission'
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 msgid "Not Graded"
-msgstr "Nehodnoceno"
+msgstr "Neohodnotené"
 
 #: frontend/src/components/NoPermission.vue:5
 #: frontend/src/components/NoPermission.vue:46
 msgid "Not Permitted"
-msgstr "Nepovoleno"
+msgstr "Nepovolené"
 
 #: frontend/src/components/Assignment.vue:36
 #: frontend/src/components/Modals/EditProfile.vue:10
@@ -5766,11 +5854,11 @@ msgstr "Nepovoleno"
 #: frontend/src/pages/Programs/ProgramForm.vue:11
 #: frontend/src/pages/QuizForm.vue:8 frontend/src/pages/QuizSubmission.vue:9
 msgid "Not Saved"
-msgstr "Neuloženo"
+msgstr "Neuložené"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:9
 msgid "Not yet open for enrollment."
-msgstr "Zápis zatím není otevřen."
+msgstr "Zápis zatiaľ nie je otvorený."
 
 #. Label of the note (Text Editor) field in DocType 'LMS Lesson Note'
 #: lms/lms/doctype/lms_lesson_note/lms_lesson_note.json
@@ -5786,7 +5874,7 @@ msgstr "Poznámky"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Notification Sent"
-msgstr "Oznámení odesláno"
+msgstr "Oznámenie odoslané"
 
 #. Label of the notifications (Check) field in DocType 'LMS Settings'
 #. Label of the notifications_section (Section Break) field in DocType 'LMS
@@ -5794,15 +5882,15 @@ msgstr "Oznámení odesláno"
 #: frontend/src/components/Notifications/NotificationPanel.vue:22
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Notifications"
-msgstr "Oznámení"
+msgstr "Oznámenia"
 
 #: frontend/src/components/Notifications/NotificationPanel.vue:133
 msgid "Notifications you have read will appear here."
-msgstr "Zde se zobrazí přečtená oznámení."
+msgstr "Tu sa zobrazia prečítané oznámenia."
 
 #: lms/lms/widgets/NoPreviewModal.html:30
 msgid "Notify me when available"
-msgstr "Upozornit mě, až bude k dispozici"
+msgstr "Upozorniť ma, keď bude k dispozícii"
 
 #: frontend/src/pages/PersonaForm.vue:164
 msgid "Notion"
@@ -5810,11 +5898,11 @@ msgstr "Notion"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:161
 msgid "Number of Students"
-msgstr "Počet studentů"
+msgstr "Počet študentov"
 
 #: frontend/src/pages/Batches/BatchForm.vue:76
 msgid "Number of seats available"
-msgstr "Počet dostupných míst"
+msgstr "Počet dostupných miest"
 
 #. Label of the sb_00 (Section Break) field in DocType 'Zoom Settings'
 #: lms/lms/doctype/zoom_settings/zoom_settings.json
@@ -5824,40 +5912,40 @@ msgstr "ID klienta OAuth"
 #. Option for the 'Location Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Office close to Home"
-msgstr "Kancelář blízko domova"
+msgstr "Kancelária blízko domova"
 
 #. Option for the 'Medium' (Select) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:621
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:301
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Offline"
-msgstr "Prezenčně"
+msgstr "Prezenčne"
 
 #: frontend/src/components/CourseCardOverlay.vue:108
 msgid "On demand course video"
-msgstr "Video kurzu na vyžádání"
+msgstr "Video kurzu na požiadanie"
 
 #: frontend/src/pages/JobForm.vue:293
 msgid "On site"
-msgstr "Na pracovišti"
+msgstr "Na pracovisku"
 
 #. Option for the 'Work Mode' (Select) field in DocType 'Job Opportunity'
 #: frontend/src/pages/Jobs.vue:340
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "On-site"
-msgstr "Na pracovišti"
+msgstr "Na pracovisku"
 
 #: frontend/src/pages/PersonaForm.vue:141
 msgid "Onboard my existing learners"
-msgstr "Zapojit své stávající studenty"
+msgstr "Zapojiť svojich súčasných študentov"
 
 #: lms/templates/emails/certification.html:16
 msgid "Once again, congratulations on this significant accomplishment."
-msgstr "Ještě jednou vám blahopřejeme k tomuto významnému úspěchu."
+msgstr "Ešte raz vám blahoželáme k tomuto významnému úspechu."
 
 #: frontend/src/components/Assignment.vue:66
 msgid "Once the moderator grades your submission, you'll find the details here."
-msgstr "Podrobnosti se zde zobrazí, jakmile moderátor oznámkuje vaši práci."
+msgstr "Podrobnosti sa tu zobrazia, keď moderátor oznámkuje vašu prácu."
 
 #. Option for the 'Medium' (Select) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:617
@@ -5868,43 +5956,43 @@ msgstr "Online"
 
 #: frontend/src/utils/index.js:699
 msgid "Only PDF files are allowed."
-msgstr "Jsou povoleny pouze soubory PDF."
+msgstr "Povolené sú iba súbory PDF."
 
 #: frontend/src/utils/index.js:705
 msgid "Only ZIP files are allowed."
-msgstr "Jsou povoleny pouze soubory ZIP."
+msgstr "Povolené sú iba súbory ZIP."
 
 #: frontend/src/utils/index.js:702
 msgid "Only document file of type .doc or .docx are allowed."
-msgstr "Jsou povoleny pouze dokumenty typu .doc nebo .docx."
+msgstr "Povolené sú iba dokumenty typu .doc alebo .docx."
 
 #: lms/templates/assignment.html:6
 msgid "Only files of type {0} will be accepted."
-msgstr "Budou přijaty pouze soubory typu {0}."
+msgstr "Prijaté budú iba súbory typu {0}."
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:229
 msgid "Only image data is allowed in quiz answers."
-msgstr "V odpovědích kvízu jsou povolena pouze obrazová data."
+msgstr "V odpovediach na kvíz sú povolené iba obrazové údaje."
 
 #: frontend/src/components/AssessmentPlugin.vue:53
 msgid "Only show assignments from the current course"
-msgstr "Zobrazovat pouze úkoly z aktuálního kurzu"
+msgstr "Zobrazovať iba úlohy z aktuálneho kurzu"
 
 #: frontend/src/pages/Batches/Batches.vue:85
 msgid "Only show batches that offer a certificate"
-msgstr "Zobrazovat pouze školicí kola s certifikátem"
+msgstr "Zobrazovať iba školiace kolá s certifikátom"
 
 #: frontend/src/pages/Courses/Courses.vue:65
 msgid "Only show courses that offer a certificate"
-msgstr "Zobrazovat pouze kurzy s certifikátem"
+msgstr "Zobrazovať iba kurzy s certifikátom"
 
 #: frontend/src/components/Modals/ChapterModal.vue:204
 msgid "Only zip files are allowed"
-msgstr "Jsou povoleny pouze soubory ZIP"
+msgstr "Povolené sú iba súbory ZIP"
 
 #: frontend/src/utils/index.js:710
 msgid "Only {0} file is allowed."
-msgstr "Je povolen pouze soubor typu {0}."
+msgstr "Povolený je iba súbor typu {0}."
 
 #. Option for the 'Status' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -5912,94 +6000,94 @@ msgstr "Je povolen pouze soubor typu {0}."
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Open"
-msgstr "Otevřeno"
+msgstr "Otvorené"
 
 #: lms/templates/emails/assignment_submission.html:8
 msgid "Open Assignment"
-msgstr "Otevřít úkol"
+msgstr "Otvoriť úlohu"
 
 #: lms/templates/emails/lms_message.html:13
 msgid "Open Course"
-msgstr "Otevřít kurz"
+msgstr "Otvoriť kurz"
 
 #. Option for the 'Type' (Select) field in DocType 'LMS Question'
 #. Option for the 'Type' (Select) field in DocType 'LMS Quiz Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 #: lms/lms/doctype/lms_quiz_question/lms_quiz_question.json
 msgid "Open Ended"
-msgstr "Otevřená odpověď"
+msgstr "Otvorená odpoveď"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:16
 msgid "Open the "
-msgstr "Otevřít "
+msgstr "Otvoriť "
 
 #. Label of the open_to (Select) field in DocType 'User'
 #: frontend/src/components/Modals/EditProfile.vue:60
 #: lms/fixtures/custom_field.json
 msgid "Open to"
-msgstr "Mám zájem o"
+msgstr "Mám záujem o"
 
 #: frontend/src/components/UserAvatar.vue:11
 #: frontend/src/pages/CertifiedParticipants.vue:48
 #: frontend/src/pages/Profile.vue:69
 msgid "Open to Work"
-msgstr "Otevřený/á pracovním nabídkám"
+msgstr "Otvorený/-á pracovným ponukám"
 
 #. Label of the option (Data) field in DocType 'LMS Option'
 #: frontend/src/components/Modals/Question.vue:67
 #: lms/lms/doctype/lms_option/lms_option.json
 msgid "Option"
-msgstr "Možnost"
+msgstr "Možnosť"
 
 #. Label of the option_1 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 1"
-msgstr "Možnost 1"
+msgstr "Možnosť 1"
 
 #. Label of the option_10 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 10"
-msgstr "Možnost 10"
+msgstr "Možnosť 10"
 
 #. Label of the option_2 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 2"
-msgstr "Možnost 2"
+msgstr "Možnosť 2"
 
 #. Label of the option_3 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 3"
-msgstr "Možnost 3"
+msgstr "Možnosť 3"
 
 #. Label of the option_4 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 4"
-msgstr "Možnost 4"
+msgstr "Možnosť 4"
 
 #. Label of the option_5 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 5"
-msgstr "Možnost 5"
+msgstr "Možnosť 5"
 
 #. Label of the option_6 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 6"
-msgstr "Možnost 6"
+msgstr "Možnosť 6"
 
 #. Label of the option_7 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 7"
-msgstr "Možnost 7"
+msgstr "Možnosť 7"
 
 #. Label of the option_8 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 8"
-msgstr "Možnost 8"
+msgstr "Možnosť 8"
 
 #. Label of the option_9 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Option 9"
-msgstr "Možnost 9"
+msgstr "Možnosť 9"
 
 #: frontend/src/components/Modals/Question.vue:48
 msgid "Options"
@@ -6019,32 +6107,32 @@ msgstr "ID objednávky"
 #. Label of the organization (Data) field in DocType 'Certification'
 #: lms/lms/doctype/certification/certification.json
 msgid "Organization"
-msgstr "Organizace"
+msgstr "Organizácia"
 
 #. Label of the original_amount (Currency) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:129
 #: frontend/src/pages/Billing.vue:34
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Original Amount"
-msgstr "Původní částka"
+msgstr "Pôvodná suma"
 
 #: frontend/src/pages/PersonaForm.vue:129
 #: frontend/src/pages/PersonaForm.vue:167
 msgid "Other"
-msgstr "Jiné"
+msgstr "Iné"
 
 #. Option for the 'User Category' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:28
 msgid "Others"
-msgstr "Ostatní"
+msgstr "Ostatné"
 
 #: frontend/src/pages/Home/StudentHome.vue:81
 msgid "Our Popular Courses"
-msgstr "Naše oblíbené kurzy"
+msgstr "Naše obľúbené kurzy"
 
 #: frontend/src/pages/Home/StudentHome.vue:113
 msgid "Our Upcoming Batches"
-msgstr "Naše nadcházející školicí kola"
+msgstr "Naše nadchádzajúce školiace kolá"
 
 #. Label of the output (Data) field in DocType 'LMS Test Case Submission'
 #: lms/lms/doctype/lms_test_case_submission/lms_test_case_submission.json
@@ -6053,11 +6141,11 @@ msgstr "Výstup"
 
 #: frontend/src/pages/ProfileRoles.vue:42
 msgid "Oversee all users, content, and system settings"
-msgstr "Spravujte všechny uživatele, obsah a nastavení systému"
+msgstr "Spravujte všetkých používateľov, obsah a nastavenia systému"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:307
 msgid "Overview"
-msgstr "Přehled"
+msgstr "Prehľad"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:239
 #: lms/lms/doctype/lms_badge/lms_badge.js:37
@@ -6085,31 +6173,31 @@ msgstr "PDF"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:414
 msgid "Page deleted successfully"
-msgstr "Stránka byla úspěšně smazána"
+msgstr "Stránka bola úspešne odstránená"
 
 #. Label of the paid_batch (Check) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:104
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Paid Batch"
-msgstr "Placené školicí kolo"
+msgstr "Platené školiace kolo"
 
 #. Label of the paid_certificate (Check) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Paid Certificate"
-msgstr "Placený certifikát"
+msgstr "Platený certifikát"
 
 #. Label of the paid_course (Check) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Paid Course"
-msgstr "Placený kurz"
+msgstr "Platený kurz"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:84
 msgid "Paid certificate"
-msgstr "Placený certifikát"
+msgstr "Platený certifikát"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:33
 msgid "Paid course"
-msgstr "Placený kurz"
+msgstr "Platený kurz"
 
 #. Option for the 'Type' (Select) field in DocType 'Job Opportunity'
 #. Option in a Select field in the job-opportunity Web Form
@@ -6117,12 +6205,12 @@ msgstr "Placený kurz"
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Part Time"
-msgstr "Částečný úvazek"
+msgstr "Čiastočný úväzok"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Course Progress'
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.json
 msgid "Partially Complete"
-msgstr "Částečně dokončeno"
+msgstr "Čiastočne dokončené"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Assignment
 #. Submission'
@@ -6132,7 +6220,7 @@ msgstr "Částečně dokončeno"
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.json
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Pass"
-msgstr "Úspěšné"
+msgstr "Úspešné"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Programming Exercise
 #. Submission'
@@ -6141,7 +6229,7 @@ msgstr "Úspěšné"
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 #: lms/lms/doctype/lms_test_case_submission/lms_test_case_submission.json
 msgid "Passed"
-msgstr "Úspěšné"
+msgstr "Úspešné"
 
 #. Label of the passing_percentage (Int) field in DocType 'LMS Quiz'
 #. Label of the passing_percentage (Int) field in DocType 'LMS Quiz Submission'
@@ -6149,7 +6237,7 @@ msgstr "Úspěšné"
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
 msgid "Passing Percentage"
-msgstr "Procento potřebné k úspěchu"
+msgstr "Percento potrebné na úspech"
 
 #. Label of the password (Password) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
@@ -6162,11 +6250,11 @@ msgstr "Vložte odkaz na YouTube"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:107
 msgid ""
-"Paste a YouTube link, or upload a video file (MP4, WebM, or OGG) to show a preview on the course "
-"page."
+"Paste a YouTube link, or upload a video file (MP4, WebM, or OGG) to show a "
+"preview on the course page."
 msgstr ""
-"Vložte odkaz na YouTube nebo nahrajte soubor videa (MP4, WebM či OGG), který se zobrazí jako "
-"náhled na stránce kurzu."
+"Vložte odkaz na YouTube alebo nahrajte súbor videa (MP4, WebM či OGG), ktorý"
+" sa zobrazí ako náhľad na stránke kurzu."
 
 #. Label of the payment (Link) field in DocType 'LMS Batch Enrollment'
 #. Label of the payment (Link) field in DocType 'LMS Enrollment'
@@ -6180,7 +6268,7 @@ msgstr "Platba"
 #. Name of a DocType
 #: lms/lms/doctype/payment_country/payment_country.json
 msgid "Payment Country"
-msgstr "Země platby"
+msgstr "Krajina platby"
 
 #. Label of the payment_details_section (Section Break) field in DocType 'LMS
 #. Payment'
@@ -6199,12 +6287,12 @@ msgstr "Platba za dokument"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:67
 msgid "Payment For Document Type"
-msgstr "Typ dokumentu, za který se platí"
+msgstr "Typ dokumentu, za ktorý sa platí"
 
 #. Label of the payment_gateway (Data) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Payment Gateway"
-msgstr "Platební brána"
+msgstr "Platobná brána"
 
 #. Label of the payment_id (Data) field in DocType 'LMS Payment'
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:157
@@ -6218,19 +6306,19 @@ msgstr "ID platby"
 #: frontend/src/components/Settings/Transactions/TransactionList.vue:195
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Payment Received"
-msgstr "Platba přijata"
+msgstr "Platba prijatá"
 
 #. Label of the payment_reminder_template (Link) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Payment Reminder Template"
-msgstr "Šablona připomenutí platby"
+msgstr "Šablóna pripomenutia platby"
 
 #. Label of the payment_settings_tab (Tab Break) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Payment Settings"
-msgstr "Nastavení plateb"
+msgstr "Nastavenia platieb"
 
 #: frontend/src/pages/Billing.vue:20
 msgid "Payment for "
@@ -6253,25 +6341,25 @@ msgstr "Platba za dokument"
 #. Payment'
 #: lms/lms/doctype/lms_payment/lms_payment.json
 msgid "Payment for Document Type"
-msgstr "Typ dokumentu, za který se platí"
+msgstr "Typ dokumentu, za ktorý sa platí"
 
 #: frontend/src/components/Settings/PaymentGateways.vue:144
 msgid "Payment gateways deleted successfully"
-msgstr "Platební brány byly úspěšně smazány"
+msgstr "Platobné brány boli úspešne odstránené"
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:46
 msgid "Payment is required to enroll in this batch."
-msgstr "Pro zápis do tohoto školicího kola je vyžadována platba."
+msgstr "Na zápis do tohto školiaceho kola sa vyžaduje platba."
 
 #. Label of the payments_app_is_not_installed (HTML) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Payments app is not installed"
-msgstr "Aplikace Payments není nainstalována"
+msgstr "Aplikácia Payments nie je nainštalovaná"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:165
 msgid "Payments app required"
-msgstr "Je vyžadována aplikace Payments"
+msgstr "Vyžaduje sa aplikácia Payments"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Certificate
 #. Evaluation'
@@ -6280,11 +6368,11 @@ msgstr "Je vyžadována aplikace Payments"
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:192
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Pending"
-msgstr "Čeká na vyřízení"
+msgstr "Čaká na vybavenie"
 
 #: frontend/src/pages/Profile.vue:296
 msgid "People"
-msgstr "Lidé"
+msgstr "Ľudia"
 
 #. Option for the 'Discount Type' (Select) field in DocType 'LMS Coupon'
 #. Label of the percentage (Int) field in DocType 'LMS Quiz Submission'
@@ -6294,196 +6382,204 @@ msgstr "Lidé"
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
 msgid "Percentage"
-msgstr "Procento"
+msgstr "Percento"
 
 #. Option for the 'Grade Type' (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Percentage (e.g. 70%)"
-msgstr "Procento (např. 70 %)"
+msgstr "Percento (napr. 70 %)"
 
 #. Label of the percentage_discount (Int) field in DocType 'LMS Coupon'
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Percentage Discount"
-msgstr "Procentní sleva"
+msgstr "Percentuálna zľava"
 
 #. Label of the persona_captured (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Persona Captured"
-msgstr "Persona byla zaznamenána"
+msgstr "Persona bola zaznamenaná"
 
 #: frontend/src/pages/PersonaForm.vue:124
 msgid "Personal Business"
-msgstr "Osobní podnikání"
+msgstr "Vlastné podnikanie"
 
 #: frontend/src/pages/Billing.vue:154
 msgid "Phone Number"
-msgstr "Telefonní číslo"
+msgstr "Telefónne číslo"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Pink"
-msgstr "Růžová"
+msgstr "Ružová"
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:40
 msgid ""
-"Please add <a href='{0}'>{1}</a> for <a href='{2}'>{3}</a> to send calendar invites for "
-"evaluations."
+"Please add <a href='{0}'>{1}</a> for <a href='{2}'>{3}</a> to send calendar "
+"invites for evaluations."
 msgstr ""
-"Přidejte prosím <a href='{0}'>{1}</a> pro <a href='{2}'>{3}</a>, aby bylo možné odesílat pozvánky"
-" do kalendáře k hodnocením."
+"Pridajte, prosím, <a href='{0}'>{1}</a> pre <a href='{2}'>{3}</a>, aby bolo "
+"možné odosielať pozvánky do kalendára na hodnotenia."
 
 #: lms/lms/user.py:77
 msgid "Please ask your administrator to verify your sign-up"
-msgstr "Požádejte administrátora o ověření vaší registrace"
+msgstr "Požiadajte administrátora o overenie vašej registrácie"
 
 #: lms/lms/api.py:1129
 msgid "Please attach a SCORM package before saving this chapter."
-msgstr "Před uložením této kapitoly přiložte balíček SCORM."
+msgstr "Pred uložením tejto kapitoly priložte balík SCORM."
 
 #: lms/lms/user.py:75
 msgid "Please check your email for verification"
-msgstr "Ověřovací zprávu najdete ve svém e-mailu"
+msgstr "Overovaciu správu nájdete vo svojom e-maile"
 
 #: lms/templates/emails/community_course_membership.html:7
 msgid "Please click on the following button to set your new password"
-msgstr "Kliknutím na následující tlačítko nastavíte nové heslo"
+msgstr "Kliknutím na nasledujúce tlačidlo nastavíte nové heslo"
 
 #: frontend/src/pages/Programs/ProgramDetail.vue:54
 msgid "Please complete the previous course to unlock this one."
-msgstr "Dokončete předchozí kurz, abyste tento kurz odemkli."
+msgstr "Dokončite predchádzajúci kurz, aby ste odomkli tento."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:309
 msgid "Please enable the Google Meet account to use this feature."
-msgstr "Chcete-li tuto funkci používat, povolte účet Google Meet."
+msgstr "Ak chcete túto funkciu používať, povoľte účet Google Meet."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:340
 msgid "Please enable the zoom account to use this feature."
-msgstr "Chcete-li tuto funkci používat, povolte účet Zoom."
+msgstr "Ak chcete túto funkciu používať, povoľte účet Zoom."
 
 #: frontend/src/components/ChapterRow.vue:295
 msgid "Please enroll for this course to view this lesson"
-msgstr "Pro zobrazení této lekce se zapište do kurzu"
+msgstr "Ak chcete zobraziť túto lekciu, zapíšte sa do kurzu"
 
 #: frontend/src/pages/Billing.vue:99
-msgid "Please ensure that the billing name you enter is correct, as it will be used on your invoice."
-msgstr "Zkontrolujte, že je zadané fakturační jméno správné, protože bude uvedeno na faktuře."
+msgid ""
+"Please ensure that the billing name you enter is correct, as it will be used"
+" on your invoice."
+msgstr ""
+"Skontrolujte, či je zadané fakturačné meno správne, pretože bude uvedené na "
+"faktúre."
 
 #: frontend/src/components/Quiz.vue:37
 msgid "Please ensure that you complete all the questions in {0} minutes."
-msgstr "Odpovězte na všechny otázky během {0} minut."
+msgstr "Odpovedzte na všetky otázky do {0} minút."
 
 #: frontend/src/pages/Billing.vue:371
 msgid "Please enter a coupon code"
-msgstr "Zadejte kód kupónu"
+msgstr "Zadajte kód kupónu"
 
 #: frontend/src/components/Modals/LiveClassModal.vue:200
 msgid "Please enter a title."
-msgstr "Zadejte název."
+msgstr "Zadajte názov."
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:56
 msgid "Please enter a valid Contact Us Email."
-msgstr "Zadejte platnou e-mailovou adresu pro kontakt."
+msgstr "Zadajte platnú kontaktnú e-mailovú adresu."
 
 #: lms/lms/doctype/lms_settings/lms_settings.py:58
 msgid "Please enter a valid Contact Us URL."
-msgstr "Zadejte platnou kontaktní adresu URL."
+msgstr "Zadajte platnú URL kontaktnej stránky."
 
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py:47
 msgid "Please enter a valid URL."
-msgstr "Zadejte platnou adresu URL."
+msgstr "Zadajte platnú URL."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:212
 msgid "Please enter a valid time in the format HH:mm."
-msgstr "Zadejte platný čas ve formátu HH:mm."
+msgstr "Zadajte platný čas vo formáte HH:mm."
 
 #: frontend/src/components/Modals/QuizInVideo.vue:174
 msgid "Please enter a valid timestamp"
-msgstr "Zadejte platné časové razítko"
+msgstr "Zadajte platnú časovú značku"
 
 #: frontend/src/components/Modals/EditProfile.vue:148
 msgid "Please fill the mandatory fields: {0}"
-msgstr "Vyplňte povinná pole: {0}"
+msgstr "Vyplňte povinné polia: {0}"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:72
 msgid ""
-"Please install the Payments App to create a paid batch. Refer to the documentation for more "
-"details. {0}"
+"Please install the Payments App to create a paid batch. Refer to the "
+"documentation for more details. {0}"
 msgstr ""
-"Chcete-li vytvořit placené školicí kolo, nainstalujte aplikaci Payments. Podrobnosti naleznete v "
-"dokumentaci. {0}"
+"Ak chcete vytvoriť platené školiace kolo, nainštalujte aplikáciu "
+"Payments. Podrobnosti nájdete v dokumentácii. {0}"
 
 
 
 #: lms/lms/doctype/lms_course/lms_course.py:71
 msgid ""
-"Please install the Payments App to create a paid course. Refer to the documentation for more "
-"details. {0}"
+"Please install the Payments App to create a paid course. Refer to the "
+"documentation for more details. {0}"
 msgstr ""
-"Chcete-li vytvořit placený kurz, nainstalujte aplikaci Payments. Podrobnosti naleznete v "
-"dokumentaci. {0}"
+"Ak chcete vytvoriť platený kurz, nainštalujte aplikáciu Payments. "
+"Podrobnosti nájdete v dokumentácii. {0}"
 
 #: frontend/src/pages/Billing.vue:350
 msgid "Please let us know where you heard about us from."
-msgstr "Sdělte nám, odkud jste se o nás dozvěděli."
+msgstr "Povedzte nám, odkiaľ ste sa o nás dozvedeli."
 
 #: frontend/src/components/QuizBlock.vue:5
 msgid "Please login to access the quiz."
-msgstr "Pro přístup ke kvízu se přihlaste."
+msgstr "Ak chcete získať prístup ku kvízu, prihláste sa."
 
 #: lms/lms/api.py:167
 msgid "Please login to continue with payment."
-msgstr "Pro pokračování k platbě se přihlaste."
+msgstr "Ak chcete pokračovať k platbe, prihláste sa."
 
 #: lms/lms/utils.py:2307
 msgid "Please login to view program details."
-msgstr "Pro zobrazení podrobností programu se přihlaste."
+msgstr "Ak chcete zobraziť podrobnosti programu, prihláste sa."
 
 #: lms/lms/utils.py:2272
 msgid "Please login to view programs."
-msgstr "Pro zobrazení programů se přihlaste."
+msgstr "Ak chcete zobraziť programy, prihláste sa."
 
 #: frontend/src/components/UpcomingEvaluations.vue:19
 msgid "Please make sure to schedule your evaluation before this date."
-msgstr "Nezapomeňte si naplánovat hodnocení před tímto datem."
+msgstr "Nezabudnite si naplánovať hodnotenie pred týmto dátumom."
 
 #: lms/lms/notification/certificate_request_reminder/certificate_request_reminder.html:7
 #: lms/templates/emails/certificate_request_notification.html:7
 msgid "Please prepare well and be on time for the evaluations."
-msgstr "Na hodnocení se dobře připravte a přijďte včas."
+msgstr "Na hodnotenia sa dobre pripravte a príďte včas."
 
 #: frontend/src/components/Assignment.vue:318
 msgid "Please provide an answer or upload a file before submitting."
-msgstr "Před odesláním zadejte odpověď nebo nahrajte soubor."
+msgstr "Pred odoslaním zadajte odpoveď alebo nahrajte súbor."
 
 #: frontend/src/pages/Billing.vue:198
 msgid "Please provide your consent to proceed with the payment"
-msgstr "Pro pokračování v platbě udělte svůj souhlas"
+msgstr "Ak chcete pokračovať v platbe, udeľte svoj súhlas"
 
 #: frontend/src/pages/Billing.vue:354
 msgid "Please provide your consent to proceed with the payment."
-msgstr "Pro pokračování v platbě udělte svůj souhlas."
+msgstr "Ak chcete pokračovať v platbe, udeľte svoj súhlas."
 
 #: frontend/src/components/Quiz.vue:14
 msgid "Please read the following instructions carefully before starting the quiz"
-msgstr "Před zahájením kvízu si pečlivě přečtěte následující pokyny"
+msgstr "Pred začatím kvízu si pozorne prečítajte nasledujúce pokyny"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:142
 msgid "Please run the code to execute the test cases."
-msgstr "Spusťte kód, aby se provedly testovací případy."
+msgstr "Spustite kód, aby sa vykonali testovacie prípady."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:137
 msgid "Please select a Google Meet account for this batch."
-msgstr "Vyberte pro toto školicí kolo účet Google Meet."
+msgstr "Vyberte pre toto školiace kolo účet Google Meet."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:154
 msgid "Please select a Zoom account for this batch."
-msgstr "Vyberte pro toto školicí kolo účet Zoom."
+msgstr "Vyberte pre toto školiace kolo účet Zoom."
 
 #: frontend/src/pages/Batches/components/LiveClass.vue:10
-msgid "Please select a conferencing provider and add an account to the batch to create live classes."
+msgid ""
+"Please select a conferencing provider and add an account to the batch to "
+"create live classes."
 msgstr ""
-"Chcete-li vytvářet živé lekce, vyberte poskytovatele videokonferencí a přidejte ke školicímu kolu"
-" účet."
+"Ak chcete vytvárať živé lekcie, vyberte poskytovateľa videokonferencií a "
+"pridajte ku školiacemu kolu účet."
+
+
 
 #: frontend/src/pages/Programs/ProgramForm.vue:422
 msgid "Please select a course"
@@ -6491,19 +6587,19 @@ msgstr "Vyberte kurz"
 
 #: frontend/src/components/Modals/EvaluationModal.vue:57
 msgid "Please select a course to view available slots."
-msgstr "Vyberte kurz, abyste zobrazili dostupné termíny."
+msgstr "Vyberte kurz, aby ste zobrazili dostupné termíny."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:203
 msgid "Please select a date."
-msgstr "Vyberte datum."
+msgstr "Vyberte dátum."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:227
 msgid "Please select a duration."
-msgstr "Vyberte délku."
+msgstr "Vyberte trvanie."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:224
 msgid "Please select a future date and time."
-msgstr "Vyberte budoucí datum a čas."
+msgstr "Vyberte budúci dátum a čas."
 
 #: frontend/src/pages/Programs/ProgramForm.vue:446
 msgid "Please select a member"
@@ -6511,7 +6607,7 @@ msgstr "Vyberte člena"
 
 #: frontend/src/pages/Courses/CourseEnrollmentModal.vue:93
 msgid "Please select a payment for the purchased certificate."
-msgstr "Vyberte platbu za zakoupený certifikát."
+msgstr "Vyberte platbu za zakúpený certifikát."
 
 #: frontend/src/components/Modals/QuizInVideo.vue:179
 msgid "Please select a quiz"
@@ -6519,11 +6615,11 @@ msgstr "Vyberte kvíz"
 
 #: frontend/src/components/Modals/EvaluationModal.vue:103
 msgid "Please select a slot for your evaluation."
-msgstr "Vyberte termín hodnocení."
+msgstr "Vyberte termín hodnotenia."
 
 #: frontend/src/pages/Courses/CourseEnrollmentModal.vue:89
 msgid "Please select a student to enroll."
-msgstr "Vyberte studenta k zápisu."
+msgstr "Vyberte študenta na zápis."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:206
 msgid "Please select a time."
@@ -6535,87 +6631,91 @@ msgstr "Vyberte časové pásmo."
 
 #: frontend/src/components/Quiz.vue:791
 msgid "Please select an option"
-msgstr "Vyberte možnost"
+msgstr "Vyberte možnosť"
 
 #: lms/templates/emails/job_report.html:6
 msgid "Please take appropriate action at {0}"
-msgstr "Proveďte příslušnou akci na adrese {0}"
+msgstr "Vykonajte príslušnú akciu na adrese {0}"
 
 #: frontend/src/components/Modals/ChapterModal.vue:162
 msgid "Please upload a SCORM package"
-msgstr "Nahrajte balíček SCORM"
+msgstr "Nahrajte balík SCORM"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:156
-msgid "Please upload an MP4, WebM, or OGG video — formats like .MOV can't be played in the browser."
-msgstr "Nahrajte video ve formátu MP4, WebM nebo OGG — formáty jako .MOV nelze v prohlížeči přehrát."
+msgid ""
+"Please upload an MP4, WebM, or OGG video — formats like .MOV can't be played"
+" in the browser."
+msgstr ""
+"Nahrajte video vo formáte MP4, WebM alebo OGG — formáty ako .MOV nemožno "
+"prehrať v prehliadači."
 
 #. Option for the 'Grade Type' (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "Point of Score (e.g. 70)"
-msgstr "Bodové hodnocení (např. 70)"
+msgstr "Bodové hodnotenie (napr. 70)"
 
 #: frontend/src/components/Modals/Question.vue:54
 msgid "Possibilities"
-msgstr "Možné odpovědi"
+msgstr "Možné odpovede"
 
 #: frontend/src/components/Modals/Question.vue:114
 msgid "Possibility"
-msgstr "Možná odpověď"
+msgstr "Možná odpoveď"
 
 #. Label of the possibility_1 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 1"
-msgstr "Možná odpověď 1"
+msgstr "Možná odpoveď 1"
 
 #. Label of the possibility_10 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 10"
-msgstr "Možná odpověď 10"
+msgstr "Možná odpoveď 10"
 
 #. Label of the possibility_2 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 2"
-msgstr "Možná odpověď 2"
+msgstr "Možná odpoveď 2"
 
 #. Label of the possibility_3 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 3"
-msgstr "Možná odpověď 3"
+msgstr "Možná odpoveď 3"
 
 #. Label of the possibility_4 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 4"
-msgstr "Možná odpověď 4"
+msgstr "Možná odpoveď 4"
 
 #. Label of the possibility_5 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 5"
-msgstr "Možná odpověď 5"
+msgstr "Možná odpoveď 5"
 
 #. Label of the possibility_6 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 6"
-msgstr "Možná odpověď 6"
+msgstr "Možná odpoveď 6"
 
 #. Label of the possibility_7 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 7"
-msgstr "Možná odpověď 7"
+msgstr "Možná odpoveď 7"
 
 #. Label of the possibility_8 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 8"
-msgstr "Možná odpověď 8"
+msgstr "Možná odpoveď 8"
 
 #. Label of the possibility_9 (Small Text) field in DocType 'LMS Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 msgid "Possible Answer 9"
-msgstr "Možná odpověď 9"
+msgstr "Možná odpoveď 9"
 
 #: frontend/src/components/DiscussionReplies.vue:60
 #: frontend/src/components/DiscussionReplies.vue:95
 msgid "Post"
-msgstr "Odeslat"
+msgstr "Odoslať"
 
 #: frontend/src/pages/Billing.vue:149
 msgid "Postal Code"
@@ -6623,57 +6723,57 @@ msgstr "PSČ"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:204
 msgid "Powered by Frappe Learning"
-msgstr "Běží na platformě Frappe Learning"
+msgstr "Používa technológiu Frappe Learning"
 
 #. Name of a DocType
 #: lms/lms/doctype/preferred_function/preferred_function.json
 msgid "Preferred Function"
-msgstr "Preferovaná pracovní oblast"
+msgstr "Preferovaná pracovná oblasť"
 
 #. Label of the preferred_functions (Table MultiSelect) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Preferred Functions"
-msgstr "Preferované pracovní oblasti"
+msgstr "Preferované pracovné oblasti"
 
 #. Label of the preferred_industries (Table MultiSelect) field in DocType
 #. 'User'
 #: lms/fixtures/custom_field.json
 msgid "Preferred Industries"
-msgstr "Preferovaná odvětví"
+msgstr "Preferované odvetvia"
 
 #. Name of a DocType
 #: lms/lms/doctype/preferred_industry/preferred_industry.json
 msgid "Preferred Industry"
-msgstr "Preferované odvětví"
+msgstr "Preferované odvetvie"
 
 #. Label of the preferred_location (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Preferred Location"
-msgstr "Preferované místo"
+msgstr "Preferované miesto"
 
 #. Label of the prevent_skipping_videos (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Prevent Skipping Videos"
-msgstr "Zabránit přeskakování videí"
+msgstr "Zabrániť preskakovaniu videí"
 
 #. Label of the image (Attach Image) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Preview Image"
-msgstr "Náhledový obrázek"
+msgstr "Náhľadový obrázok"
 
 #. Label of the video_link (Attach) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:193
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Preview Video"
-msgstr "Náhledové video"
+msgstr "Náhľadové video"
 
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:81
 msgid "Preview video"
-msgstr "Náhledové video"
+msgstr "Náhľadové video"
 
 #: frontend/src/pages/Lesson.vue:139 frontend/src/pages/Lesson.vue:172
 msgid "Previous"
-msgstr "Předchozí"
+msgstr "Predchádzajúce"
 
 #. Label of the pricing_tab (Tab Break) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
@@ -6683,23 +6783,23 @@ msgstr "Ceny"
 #. Label of the pricing_tab (Tab Break) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Pricing and Certification"
-msgstr "Cena a certifikace"
+msgstr "Cena a certifikácia"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:28
 msgid "Pricing and certification"
-msgstr "Cena a certifikace"
+msgstr "Cena a certifikácia"
 
 #. Label of the exception_country (Table MultiSelect) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Primary Countries"
-msgstr "Primární země"
+msgstr "Primárne krajiny"
 
 #. Description of the 'Hide my Private Information from others' (Check) field
 #. in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Private Information includes your Grade and Work Environment Preferences"
-msgstr "Soukromé údaje zahrnují vaši známku a preference pracovního prostředí"
+msgstr "Súkromné údaje zahŕňajú vašu známku a preferencie pracovného prostredia"
 
 #. Label of the problem_statement (Text Editor) field in DocType 'LMS
 #. Programming Exercise'
@@ -6707,21 +6807,21 @@ msgstr "Soukromé údaje zahrnují vaši známku a preference pracovního prost�
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:25
 #: lms/lms/doctype/lms_programming_exercise/lms_programming_exercise.json
 msgid "Problem Statement"
-msgstr "Zadání úlohy"
+msgstr "Zadanie úlohy"
 
 #: frontend/src/pages/Billing.vue:209
 msgid "Proceed to Payment"
-msgstr "Pokračovat k platbě"
+msgstr "Pokračovať k platbe"
 
 #. Label of the profession (Data) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Profession"
-msgstr "Povolání"
+msgstr "Povolanie"
 
 #: frontend/src/components/Modals/EditProfile.vue:27
 #: frontend/src/components/Modals/EditProfile.vue:145
 msgid "Profile Image"
-msgstr "Profilový obrázek"
+msgstr "Profilový obrázok"
 
 #. Label of the program_courses (Table) field in DocType 'LMS Program'
 #: lms/lms/doctype/lms_program/lms_program.json
@@ -6735,50 +6835,50 @@ msgstr "Člen programu"
 #. Label of the program_members (Table) field in DocType 'LMS Program'
 #: lms/lms/doctype/lms_program/lms_program.json
 msgid "Program Members"
-msgstr "Členové programu"
+msgstr "Členovia programu"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:382
 msgid "Program created successfully"
-msgstr "Program byl úspěšně vytvořen"
+msgstr "Program bol úspešne vytvorený"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:567
 msgid "Program deleted successfully"
-msgstr "Program byl úspěšně smazán"
+msgstr "Program bol úspešne odstránený"
 
 #: frontend/src/pages/Programs/ProgramForm.vue:401
 msgid "Program updated successfully"
-msgstr "Program byl úspěšně aktualizován"
+msgstr "Program bol úspešne aktualizovaný"
 
 #: frontend/src/pages/Batches/components/Assessments.vue:245
 msgid "Programming Exercise"
-msgstr "Programovací cvičení"
+msgstr "Programovacie cvičenie"
 
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:129
 msgid "Programming Exercise Progress"
-msgstr "Průběh programovacího cvičení"
+msgstr "Priebeh programovacieho cvičenia"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:223
 #: frontend/src/components/Settings/Badges/Badges.vue:211
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:436
 msgid "Programming Exercise Submission"
-msgstr "Odevzdání programovacího cvičení"
+msgstr "Odovzdanie programovacieho cvičenia"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:427
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:307
 msgid "Programming Exercise Submissions"
-msgstr "Odevzdání programovacích cvičení"
+msgstr "Odovzdania programovacích cvičení"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:256
 msgid "Programming Exercise created successfully"
-msgstr "Programovací cvičení bylo úspěšně vytvořeno"
+msgstr "Programovacie cvičenie bolo úspešne vytvorené"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:293
 msgid "Programming Exercise deleted successfully"
-msgstr "Programovací cvičení bylo úspěšně smazáno"
+msgstr "Programovacie cvičenie bolo úspešne odstránené"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:276
 msgid "Programming Exercise updated successfully"
-msgstr "Programovací cvičení bylo úspěšně aktualizováno"
+msgstr "Programovacie cvičenie bolo úspešne aktualizované"
 
 #. Label of the programming_exercises (Check) field in DocType 'LMS Settings'
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:317
@@ -6786,7 +6886,7 @@ msgstr "Programovací cvičení bylo úspěšně aktualizováno"
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:354
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Programming Exercises"
-msgstr "Programovací cvičení"
+msgstr "Programovacie cvičenia"
 
 #: frontend/src/pages/Programs/ProgramDetail.vue:123
 #: frontend/src/pages/Programs/Programs.vue:223
@@ -6801,47 +6901,47 @@ msgstr "Programy"
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 #: lms/lms/doctype/lms_program_member/lms_program_member.json
 msgid "Progress"
-msgstr "Průběh"
+msgstr "Priebeh"
 
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:133
 #: lms/lms/report/course_progress_summary/course_progress_summary.py:77
 msgid "Progress (%)"
-msgstr "Průběh (%)"
+msgstr "Priebeh (%)"
 
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:28
 msgid "Progress Distribution"
-msgstr "Rozložení pokroku"
+msgstr "Rozloženie pokroku"
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:150
 #: frontend/src/pages/Programs/ProgramForm.vue:120
 msgid "Progress Summary"
-msgstr "Souhrn průběhu"
+msgstr "Súhrn priebehu"
 
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:4
 msgid "Progress Summary for {0}"
-msgstr "Souhrn průběhu pro {0}"
+msgstr "Súhrn priebehu pre {0}"
 
 #: lms/lms/doctype/lms_course_progress/lms_course_progress.py:19
 msgid "Progress is already recorded for this lesson."
-msgstr "Průběh této lekce již byl zaznamenán."
+msgstr "Priebeh tejto lekcie už bol zaznamenaný."
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:154
 msgid "Progress of students in courses and assessments"
-msgstr "Průběh studentů v kurzech a hodnoceních"
+msgstr "Priebeh študentov v kurzoch a hodnoteniach"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:78
 #: frontend/src/pages/Courses/CourseDetail.vue:91
 msgid "Publish"
-msgstr "Zveřejnit"
+msgstr "Zverejniť"
 
 #: frontend/src/pages/PersonaForm.vue:137
 msgid "Publish my first course"
-msgstr "Zveřejnit svůj první kurz"
+msgstr "Zverejniť svoj prvý kurz"
 
 #. Label of the published (Check) field in DocType 'LMS Certificate'
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
 msgid "Publish on Participant Page"
-msgstr "Zveřejnit na stránce účastníků"
+msgstr "Zverejniť na stránke účastníkov"
 
 #. Label of the published (Check) field in DocType 'LMS Batch'
 #. Label of the published (Check) field in DocType 'LMS Course'
@@ -6858,24 +6958,24 @@ msgstr "Zveřejnit na stránce účastníků"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_program/lms_program.json
 msgid "Published"
-msgstr "Zveřejněno"
+msgstr "Zverejnené"
 
 #: frontend/src/pages/Statistics.vue:16
 #: lms/lms/web_template/lms_statistics/lms_statistics.html:14
 #: lms/templates/statistics.html:4
 msgid "Published Courses"
-msgstr "Zveřejněné kurzy"
+msgstr "Zverejnené kurzy"
 
 #. Label of the published_on (Date) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Published On"
-msgstr "Zveřejněno dne"
+msgstr "Zverejnené dňa"
 
 #. Label of the purchased_certificate (Check) field in DocType 'LMS Enrollment'
 #: frontend/src/pages/Courses/CourseEnrollmentModal.vue:7
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Purchased Certificate"
-msgstr "Zakoupený certifikát"
+msgstr "Zakúpený certifikát"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #. Option for the 'Color' (Select) field in DocType 'LMS Lesson Note'
@@ -6917,19 +7017,19 @@ msgstr "Podrobnosti otázky"
 #. Label of the question_name (Link) field in DocType 'LMS Quiz Result'
 #: lms/lms/doctype/lms_quiz_result/lms_quiz_result.json
 msgid "Question Name"
-msgstr "Název otázky"
+msgstr "Názov otázky"
 
 #: frontend/src/components/Modals/Question.vue:373
 msgid "Question added successfully"
-msgstr "Otázka byla úspěšně přidána"
+msgstr "Otázka bola úspešne pridaná"
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:306
 msgid "Question not found in this quiz."
-msgstr "Otázka nebyla v tomto kvízu nalezena."
+msgstr "Otázka sa v tomto kvíze nenašla."
 
 #: frontend/src/components/Modals/Question.vue:423
 msgid "Question updated successfully"
-msgstr "Otázka byla úspěšně aktualizována"
+msgstr "Otázka bola úspešne aktualizovaná"
 
 #: frontend/src/components/Quiz.vue:143
 msgid "Question {0}"
@@ -6947,11 +7047,11 @@ msgstr "Otázky"
 
 #: frontend/src/pages/QuizForm.vue:483
 msgid "Questions deleted successfully"
-msgstr "Otázky byly úspěšně smazány"
+msgstr "Otázky boli úspešne odstránené"
 
 #: frontend/src/components/Quiz.vue:338
 msgid "Questions marked for review"
-msgstr "Otázky označené ke kontrole"
+msgstr "Otázky označené na kontrolu"
 
 #. Label of the quiz (Link) field in DocType 'LMS Quiz Submission'
 #. Label of a Link in the Learning Workspace
@@ -6971,36 +7071,36 @@ msgstr "ID kvízu"
 
 #: frontend/src/pages/Courses/StudentCourseProgress.vue:78
 msgid "Quiz Progress"
-msgstr "Průběh kvízu"
+msgstr "Priebeh kvízu"
 
 #. Label of a Link in the Learning Workspace
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:220
 #: frontend/src/components/Settings/Badges/Badges.vue:209
 #: lms/lms/workspace/learning/learning.json
 msgid "Quiz Submission"
-msgstr "Odevzdání kvízu"
+msgstr "Odovzdanie kvízu"
 
 #: frontend/src/pages/QuizSubmission.vue:133
 #: frontend/src/pages/QuizSubmissionList.vue:136
 msgid "Quiz Submissions"
-msgstr "Odevzdání kvízů"
+msgstr "Odovzdania kvízov"
 
 #: frontend/src/components/Quiz.vue:353
 msgid "Quiz Summary"
-msgstr "Souhrn kvízu"
+msgstr "Súhrn kvízu"
 
 #. Label of the quiz_title (Data) field in DocType 'LMS Quiz Submission'
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
 msgid "Quiz Title"
-msgstr "Název kvízu"
+msgstr "Názov kvízu"
 
 #: frontend/src/pages/QuizForm.vue:326
 msgid "Quiz deleted successfully"
-msgstr "Kvíz byl úspěšně smazán"
+msgstr "Kvíz bol úspešne odstránený"
 
 #: lms/plugins.py:97
 msgid "Quiz is not available to Guest users. Please login to continue."
-msgstr "Kvíz není dostupný hostům. Pro pokračování se přihlaste."
+msgstr "Kvíz nie je dostupný hosťom. Ak chcete pokračovať, prihláste sa."
 
 #: frontend/src/components/CourseCardOverlay.vue:129
 msgid "Quiz topic"
@@ -7008,16 +7108,16 @@ msgstr "Téma kvízu"
 
 #: frontend/src/components/CourseCardOverlay.vue:130
 msgid "Quiz topics"
-msgstr "Témata kvízu"
+msgstr "Témy kvízu"
 
 #: frontend/src/pages/QuizForm.vue:406
 msgid "Quiz updated successfully"
-msgstr "Kvíz byl úspěšně aktualizován"
+msgstr "Kvíz bol úspešne aktualizovaný"
 
 #. Description of the 'Quiz ID' (Data) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "Quiz will appear at the bottom of the lesson."
-msgstr "Kvíz se zobrazí na konci lekce."
+msgstr "Kvíz sa zobrazí na konci lekcie."
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:611
 #: frontend/src/pages/QuizForm.vue:494 frontend/src/pages/QuizPage.vue:59
@@ -7029,7 +7129,7 @@ msgstr "Kvízy"
 
 #: frontend/src/pages/Quizzes.vue:256
 msgid "Quizzes deleted successfully"
-msgstr "Kvízy byly úspěšně smazány"
+msgstr "Kvízy boli úspešne odstránené"
 
 #: frontend/src/components/Modals/QuizInVideo.vue:29
 msgid "Quizzes in this video"
@@ -7037,7 +7137,7 @@ msgstr "Kvízy v tomto videu"
 
 #: frontend/src/pages/QuizForm.vue:221
 msgid "Randomize the order of questions for each attempt."
-msgstr "Při každém pokusu náhodně změnit pořadí otázek."
+msgstr "Pri každom pokuse náhodne zmeniť poradie otázok."
 
 #. Label of the rating (Rating) field in DocType 'LMS Certificate Evaluation'
 #. Label of the rating (Data) field in DocType 'LMS Course'
@@ -7048,11 +7148,11 @@ msgstr "Při každém pokusu náhodně změnit pořadí otázek."
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_course_review/lms_course_review.json
 msgid "Rating"
-msgstr "Hodnocení"
+msgstr "Hodnotenie"
 
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.py:18
 msgid "Rating cannot be 0"
-msgstr "Hodnocení nesmí být 0"
+msgstr "Hodnotenie nesmie byť 0"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #. Option for the 'Color' (Select) field in DocType 'LMS Lesson Note'
@@ -7065,17 +7165,17 @@ msgstr "Červená"
 #: frontend/src/components/Settings/Coupons/CouponList.vue:183
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Redemption Count"
-msgstr "Počet uplatnění"
+msgstr "Počet uplatnení"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:72
 msgid "Redemptions Count"
-msgstr "Počet uplatnění"
+msgstr "Počet uplatnení"
 
 #. Label of the reference_docname (Dynamic Link) field in DocType 'LMS Batch
 #. Timetable'
 #: lms/lms/doctype/lms_batch_timetable/lms_batch_timetable.json
 msgid "Reference DocName"
-msgstr "Název referenčního dokumentu"
+msgstr "Názov referenčného dokumentu"
 
 #. Label of the reference_doctype (Link) field in DocType 'LMS Batch Timetable'
 #. Label of the reference_doctype (Select) field in DocType 'LMS Coupon Item'
@@ -7085,30 +7185,30 @@ msgstr "Název referenčního dokumentu"
 #: lms/lms/doctype/lms_coupon_item/lms_coupon_item.json
 #: lms/lms/doctype/lms_timetable_legend/lms_timetable_legend.json
 msgid "Reference DocType"
-msgstr "Typ referenčního dokumentu"
+msgstr "Typ referenčného dokumentu"
 
 #. Label of the reference_doctype (Link) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Reference Document Type"
-msgstr "Typ referenčního dokumentu"
+msgstr "Typ referenčného dokumentu"
 
 #. Label of the reference_name (Dynamic Link) field in DocType 'LMS Coupon
 #. Item'
 #: lms/lms/doctype/lms_coupon_item/lms_coupon_item.json
 msgid "Reference Name"
-msgstr "Referenční název"
+msgstr "Referenčný názov"
 
 #: lms/templates/emails/community_course_membership.html:17
 msgid "Regards"
-msgstr "S pozdravem"
+msgstr "S pozdravom"
 
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:84
 msgid "Register Now"
-msgstr "Registrovat se"
+msgstr "Zaregistrovať sa"
 
 #: lms/lms/user.py:36
 msgid "Registered but disabled"
-msgstr "Registrován, ale deaktivován"
+msgstr "Zaregistrovaný, ale deaktivovaný"
 
 #. Label of the related_courses (Table) field in DocType 'LMS Course'
 #. Name of a DocType
@@ -7117,66 +7217,66 @@ msgstr "Registrován, ale deaktivován"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/related_courses/related_courses.json
 msgid "Related Courses"
-msgstr "Související kurzy"
+msgstr "Súvisiace kurzy"
 
 #. Option for the 'Work Mode' (Select) field in DocType 'Job Opportunity'
 #: frontend/src/pages/JobForm.vue:295 frontend/src/pages/Jobs.vue:342
 #: lms/job/doctype/job_opportunity/job_opportunity.json
 msgid "Remote"
-msgstr "Na dálku"
+msgstr "Na diaľku"
 
 #: frontend/src/components/Controls/ImageUploader.vue:21
 #: frontend/src/components/Controls/Uploader.vue:51
 #: frontend/src/components/Controls/VideoPreviewField.vue:68
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:68
 msgid "Remove"
-msgstr "Odstranit"
+msgstr "Odstrániť"
 
 #: frontend/src/components/Notes/InlineLessonMenu.vue:49
 msgid "Remove Highlight"
-msgstr "Odstranit zvýraznění"
+msgstr "Odstrániť zvýraznenie"
 
 #: frontend/src/components/Settings/Coupons/CouponItems.vue:46
 msgid "Remove row"
-msgstr "Odstranit řádek"
+msgstr "Odstrániť riadok"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:18
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:72
 msgid "Remove the image to pick a color instead."
-msgstr "Chcete-li místo obrázku vybrat barvu, obrázek odstraňte."
+msgstr "Ak chcete namiesto obrázka vybrať farbu, obrázok odstráňte."
 
 #: frontend/src/components/Controls/Uploader.vue:41
 #: frontend/src/components/Controls/VideoPreviewField.vue:60
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:60
 msgid "Replace"
-msgstr "Nahradit"
+msgstr "Nahradiť"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:23
 #: frontend/src/pages/JobApplications.vue:143
 msgid "Reply To"
-msgstr "Adresa pro odpověď"
+msgstr "Adresa na odpoveď"
 
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:102
 msgid "Reply To is required"
-msgstr "Adresa pro odpověď je povinná"
+msgstr "Adresa na odpoveď je povinná"
 
 #: frontend/src/components/DiscussionReplies.vue:182
 #: frontend/src/components/DiscussionReplies.vue:205
 msgid "Reply cannot be empty."
-msgstr "Odpověď nesmí být prázdná."
+msgstr "Odpoveď nesmie byť prázdna."
 
 #: lms/lms/widgets/RequestInvite.html:7
 msgid "Request Invite"
-msgstr "Požádat o pozvánku"
+msgstr "Požiadať o pozvánku"
 
 #: lms/patches/create_mentor_request_email_templates.py:18
 msgid "Request for Mentorship"
-msgstr "Žádost o mentoring"
+msgstr "Žiadosť o mentoring"
 
 #. Label of the result (Table) field in DocType 'LMS Quiz Submission'
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
 msgid "Result"
-msgstr "Výsledek"
+msgstr "Výsledok"
 
 #. Label of the resume (Attach) field in DocType 'LMS Job Application'
 #: lms/job/doctype/lms_job_application/lms_job_application.json
@@ -7186,11 +7286,11 @@ msgstr "Životopis"
 #: frontend/src/components/Quiz.vue:108 frontend/src/components/Quiz.vue:129
 #: frontend/src/components/Quiz.vue:389
 msgid "Resume Video"
-msgstr "Pokračovat ve videu"
+msgstr "Pokračovať vo videu"
 
 #: frontend/src/pages/Home/Home.vue:166
 msgid "Resume where you left off"
-msgstr "Pokračovat tam, kde jste skončili"
+msgstr "Pokračovať tam, kde ste skončili"
 
 #. Label of the review (Small Text) field in DocType 'LMS Course Review'
 #. Label of a Link in the Learning Workspace
@@ -7198,31 +7298,31 @@ msgstr "Pokračovat tam, kde jste skončili"
 #: lms/lms/doctype/lms_course_review/lms_course_review.json
 #: lms/lms/workspace/learning/learning.json
 msgid "Review"
-msgstr "Recenze"
+msgstr "Recenzia"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:4
 msgid "Review and update the details of this payment."
-msgstr "Zkontrolujte a aktualizujte údaje této platby."
+msgstr "Skontrolujte a aktualizujte údaje tejto platby."
 
 #. Label of the role (Select) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Role"
-msgstr "Role"
+msgstr "Rola"
 
 #. Label of the role (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Role Preference"
-msgstr "Preferovaná role"
+msgstr "Preferovaná rola"
 
 #: frontend/src/pages/ProfileRoles.vue:110
 msgid "Role updated successfully"
-msgstr "Role byla úspěšně aktualizována"
+msgstr "Rola bola úspešne aktualizovaná"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:44
 #: frontend/src/components/Sidebar/AppSidebar.vue:639
 #: frontend/src/pages/Profile.vue:265
 msgid "Roles"
-msgstr "Role"
+msgstr "Roly"
 
 #. Label of the route (Data) field in DocType 'LMS Sidebar Item'
 #: lms/lms/doctype/lms_sidebar_item/lms_sidebar_item.json
@@ -7231,31 +7331,33 @@ msgstr "Trasa"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:129
 msgid "Row #{0} Date cannot be outside the batch duration."
-msgstr "Datum v řádku č. {0} nesmí být mimo dobu trvání školicího kola."
+msgstr "Dátum v riadku č. {0} nesmie byť mimo trvania školiaceho kola."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:125
 msgid "Row #{0} End time cannot be outside the batch duration."
-msgstr "Čas ukončení v řádku č. {0} nesmí být mimo dobu trvání školicího kola."
+msgstr "Čas ukončenia v riadku č. {0} nesmie byť mimo trvania školiaceho kola."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:109
 msgid "Row #{0} Start time cannot be greater than or equal to end time."
-msgstr "Čas zahájení v řádku č. {0} nesmí být pozdější než čas ukončení ani se mu rovnat."
+msgstr ""
+"Čas začiatku v riadku č. {0} nesmie byť neskorší ako čas ukončenia ani sa mu"
+" rovnať."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:118
 msgid "Row #{0} Start time cannot be outside the batch duration."
-msgstr "Čas zahájení v řádku č. {0} nesmí být mimo dobu trvání školicího kola."
+msgstr "Čas začiatku v riadku č. {0} nesmie byť mimo trvania školiaceho kola."
 
 #: lms/lms/doctype/lms_quiz/lms_quiz.py:46
 msgid "Rows {0} have the duplicate questions."
-msgstr "Řádky {0} obsahují duplicitní otázky."
+msgstr "Riadky {0} obsahujú duplicitné otázky."
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:59
 msgid "Run"
-msgstr "Spustit"
+msgstr "Spustiť"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:59
 msgid "Running"
-msgstr "Probíhá"
+msgstr "Prebieha"
 
 #. Option for the 'Language' (Select) field in DocType 'LMS Programming
 #. Exercise'
@@ -7278,12 +7380,12 @@ msgstr "Obsah SCORM"
 #: frontend/src/components/Modals/ChapterModal.vue:25
 #: lms/lms/doctype/course_chapter/course_chapter.json
 msgid "SCORM Package"
-msgstr "Balíček SCORM"
+msgstr "Balík SCORM"
 
 #. Label of the scorm_package_path (Code) field in DocType 'Course Chapter'
 #: lms/lms/doctype/course_chapter/course_chapter.json
 msgid "SCORM Package Path"
-msgstr "Cesta k balíčku SCORM"
+msgstr "Cesta k balíku SCORM"
 
 #. Label of the seo_tab (Tab Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
@@ -7292,7 +7394,7 @@ msgstr "SEO"
 
 #: frontend/src/utils/index.js:727
 msgid "SVG contains potentially unsafe content."
-msgstr "SVG obsahuje potenciálně nebezpečný obsah."
+msgstr "SVG obsahuje potenciálne nebezpečný obsah."
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
@@ -7337,26 +7439,26 @@ msgstr "Sobota"
 #: frontend/src/pages/QuizSubmission.vue:15
 #: lms/job/web_form/job_opportunity/job_opportunity.json
 msgid "Save"
-msgstr "Uložit"
+msgstr "Uložiť"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:29
 msgid "Saved — this format can't be previewed here."
-msgstr "Uloženo — náhled tohoto formátu zde nelze zobrazit."
+msgstr "Uložené — náhľad tohto formátu tu nemožno zobraziť."
 
 #. Label of the schedule (Table) field in DocType 'Course Evaluator'
 #: frontend/src/components/UpcomingEvaluations.vue:8
 #: frontend/src/pages/Profile.vue:270
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
 msgid "Schedule"
-msgstr "Naplánovat"
+msgstr "Naplánovať"
 
 #: frontend/src/components/UpcomingEvaluations.vue:101
 msgid "Schedule an evaluation to get certified."
-msgstr "Naplánujte si hodnocení a získejte certifikát."
+msgstr "Naplánujte si hodnotenie a získajte certifikát."
 
 #: frontend/src/components/Modals/EvaluationModal.vue:4
 msgid "Schedule your evaluation"
-msgstr "Naplánujte si hodnocení"
+msgstr "Naplánujte si hodnotenie"
 
 #. Name of a DocType
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
@@ -7391,71 +7493,71 @@ msgstr "Skóre z"
 #: frontend/src/pages/Programs/ProgramProgressSummary.vue:44
 #: frontend/src/pages/Programs/Programs.vue:34
 msgid "Search"
-msgstr "Hledat"
+msgstr "Hľadať"
 
 #: frontend/src/components/Modals/VideoStatistics.vue:14
 msgid "Search by Member"
-msgstr "Hledat podle člena"
+msgstr "Hľadať podľa člena"
 
 #: frontend/src/components/Controls/IconPicker.vue:34
 msgid "Search for an icon"
-msgstr "Vyhledat ikonu"
+msgstr "Vyhľadať ikonu"
 
 #: frontend/src/components/Controls/MultiSelect.vue:24
 msgid "Search..."
-msgstr "Hledat…"
+msgstr "Hľadať…"
 
 #. Label of the seat_count (Int) field in DocType 'LMS Batch'
 #: frontend/src/pages/Batches/BatchForm.vue:73
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:65
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Seat Count"
-msgstr "Počet míst"
+msgstr "Počet miest"
 
 #: frontend/src/pages/Batches/components/BatchCard.vue:18
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:21
 msgid "Seat Left"
-msgstr "Zbývá místo"
+msgstr "Zostáva miesto"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:96
 msgid "Seat count cannot be negative."
-msgstr "Počet míst nesmí být záporný."
+msgstr "Počet miest nesmie byť záporný."
 
 #: frontend/src/pages/Batches/components/BatchCard.vue:18
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:21
 msgid "Seats Left"
-msgstr "Zbývající místa"
+msgstr "Zostávajúce miesta"
 
 #: frontend/src/pages/Home/AdminHome.vue:122
 #: frontend/src/pages/Home/AdminHome.vue:150
 #: frontend/src/pages/Home/StudentHome.vue:91
 #: frontend/src/pages/Home/StudentHome.vue:123
 msgid "See all"
-msgstr "Zobrazit vše"
+msgstr "Zobraziť všetko"
 
 #: frontend/src/components/CourseReviews.vue:81
 msgid "See less"
-msgstr "Zobrazit méně"
+msgstr "Zobraziť menej"
 
 #: frontend/src/components/CourseReviews.vue:81
 msgid "See more"
-msgstr "Zobrazit více"
+msgstr "Zobraziť viac"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignmentForm.vue:41
 msgid "Select Date"
-msgstr "Vyberte datum"
+msgstr "Vyberte dátum"
 
 #: frontend/src/components/Settings/PaymentGatewayDetails.vue:24
 msgid "Select Payment Gateway"
-msgstr "Vyberte platební bránu"
+msgstr "Vyberte platobnú bránu"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseModal.vue:21
 msgid "Select a Programming Exercise"
-msgstr "Vyberte programovací cvičení"
+msgstr "Vyberte programovacie cvičenie"
 
 #: frontend/src/pages/Courses/CourseEditor.vue:15
 msgid "Select a lesson on the right to start editing."
-msgstr "Začněte upravovat výběrem lekce vpravo."
+msgstr "Začnite upravovať výberom lekcie vpravo."
 
 #: frontend/src/components/Modals/Question.vue:143
 msgid "Select a question"
@@ -7463,7 +7565,7 @@ msgstr "Vyberte otázku"
 
 #: frontend/src/components/Discussions.vue:72
 msgid "Select a question to view the thread"
-msgstr "Vyberte otázku, abyste zobrazili vlákno"
+msgstr "Vyberte otázku, aby ste zobrazili vlákno"
 
 #: frontend/src/components/AssessmentPlugin.vue:27
 msgid "Select a quiz"
@@ -7472,35 +7574,35 @@ msgstr "Vyberte kvíz"
 #: frontend/src/components/AssessmentPlugin.vue:40
 #: frontend/src/components/AssessmentPlugin.vue:48
 msgid "Select an Assignment"
-msgstr "Vyberte úkol"
+msgstr "Vyberte úlohu"
 
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:18
 msgid "Select category"
-msgstr "Vyberte kategorii"
+msgstr "Vyberte kategóriu"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:44
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:98
 msgid "Select currency"
-msgstr "Vyberte měnu"
+msgstr "Vyberte menu"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:117
 msgid "Select evaluator"
-msgstr "Vyberte hodnotitele"
+msgstr "Vyberte hodnotiteľa"
 
 #: frontend/src/components/Modals/Question.vue:12
 msgid "Select from questions you have already created"
-msgstr "Vyberte z již vytvořených otázek"
+msgstr "Vyberte z už vytvorených otázok"
 
 #: frontend/src/pages/Batches/BatchForm.vue:155
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:95
 #: frontend/src/pages/Courses/CourseInstructorsField.vue:11
 #: frontend/src/pages/Courses/NewCourseModal.vue:28
 msgid "Select instructors"
-msgstr "Vyberte lektory"
+msgstr "Vyberte lektorov"
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:37
 msgid "Select related courses"
-msgstr "Vyberte související kurzy"
+msgstr "Vyberte súvisiace kurzy"
 
 #: frontend/src/pages/Batches/BatchForm.vue:65
 #: frontend/src/pages/Batches/components/NewBatchModal.vue:51
@@ -7514,86 +7616,90 @@ msgstr "Samostatný zápis"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:86
 msgid "Sell an evaluator-graded certificate alongside this free course."
-msgstr "Nabízet k tomuto bezplatnému kurzu placený certifikát hodnocený hodnotitelem."
+msgstr "Ponúkať k tomuto bezplatnému kurzu platený certifikát hodnotený hodnotiteľom."
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:180
 msgid ""
-"Selling a paid course or certificate needs the Payments app. Install it from the Frappe "
-"Marketplace, then turn on pricing here."
+"Selling a paid course or certificate needs the Payments app. Install it from"
+" the Frappe Marketplace, then turn on pricing here."
 msgstr ""
-"Pro prodej placeného kurzu nebo certifikátu je potřeba aplikace Payments. Nainstalujte ji z "
-"Frappe Marketplace a poté zde zapněte ceny."
+"Na predaj plateného kurzu alebo certifikátu je potrebná aplikácia Payments. "
+"Nainštalujte ju z Frappe Marketplace a potom tu zapnite ceny."
 
 #: frontend/src/components/ContactUsEmail.vue:27
 #: frontend/src/pages/JobApplications.vue:126
 msgid "Send"
-msgstr "Odeslat"
+msgstr "Odoslať"
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.js:7
 msgid "Send Confirmation Email"
-msgstr "Odeslat potvrzovací e-mail"
+msgstr "Odoslať potvrdzovací e-mail"
 
 #: frontend/src/pages/JobApplications.vue:324
 msgid "Send Email"
-msgstr "Odeslat e-mail"
+msgstr "Odoslať e-mail"
 
 #: frontend/src/pages/JobApplications.vue:122
 msgid "Send Email to {0}"
-msgstr "Odeslat e-mail uživateli {0}"
+msgstr "Odoslať e-mail používateľovi {0}"
 
 #. Label of the send_notification_for_published_batches (Select) field in
 #. DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Send Notification for Published Batches"
-msgstr "Odesílat oznámení o zveřejněných školicích kolech"
+msgstr "Odosielať oznámenia o zverejnených školiacich kolách"
 
 #. Label of the send_notification_for_published_courses (Select) field in
 #. DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Send Notification for Published Courses"
-msgstr "Odesílat oznámení o zveřejněných kurzech"
+msgstr "Odosielať oznámenia o zverejnených kurzoch"
 
 #. Label of the send_payment_reminders_for_batch (Check) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Send Payment Reminders for Batch"
-msgstr "Odesílat připomenutí platby za školicí kolo"
+msgstr "Odosielať pripomenutia platby za školiace kolo"
 
 #. Label of the send_payment_reminders_for_course (Check) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Send Payment Reminders for Course"
-msgstr "Odesílat připomenutí platby za kurz"
+msgstr "Odosielať pripomenutia platby za kurz"
 
 #. Label of the send_calendar_invite_for_evaluations (Check) field in DocType
 #. 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Send calendar invite for evaluations"
-msgstr "Odesílat pozvánky do kalendáře k hodnocením"
+msgstr "Odosielať pozvánky do kalendára na hodnotenia"
 
 #: frontend/src/pages/Batches/BatchForm.vue:53
 msgid "Session End Time"
-msgstr "Čas ukončení lekce"
+msgstr "Čas ukončenia lekcie"
 
 #: frontend/src/pages/Batches/BatchForm.vue:45
 msgid "Session Start Time"
-msgstr "Čas zahájení lekce"
+msgstr "Čas začiatku lekcie"
 
 #: frontend/src/pages/Profile.vue:280
 msgid "Session refreshed successfully"
-msgstr "Relace byla úspěšně obnovena"
+msgstr "Relácia bola úspešne obnovená"
 
 #: frontend/src/components/Controls/ColorSwatches.vue:11
 msgid "Set Color"
-msgstr "Nastavit barvu"
+msgstr "Nastaviť farbu"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:5
-msgid "Set the discount, validity, and the courses or batches this coupon applies to."
-msgstr "Nastavte slevu, platnost a kurzy nebo školicí kola, na které se kupón vztahuje."
+msgid ""
+"Set the discount, validity, and the courses or batches this coupon applies "
+"to."
+msgstr ""
+"Nastavte zľavu, platnosť a kurzy alebo školiace kolá, na ktoré sa kupón "
+"vzťahuje."
 
 #: frontend/src/components/Settings/BrandSettings.vue:25
 msgid "Set the name of your brand. Appears in the left sidebar."
-msgstr "Nastavte název své značky. Zobrazí se v levém postranním panelu."
+msgstr "Nastavte názov svojej značky. Zobrazí sa v ľavom bočnom paneli."
 
 #: lms/templates/emails/community_course_membership.html:1
 msgid "Set your Password"
@@ -7601,11 +7707,11 @@ msgstr "Nastavte si heslo"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:582
 msgid "Setting up"
-msgstr "Nastavení"
+msgstr "Nastavenie"
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:632
 msgid "Setting up payment gateway"
-msgstr "Nastavení platební brány"
+msgstr "Nastavenie platobnej brány"
 
 #: frontend/src/components/Settings/Settings.vue:9
 #: frontend/src/components/Sidebar/AppSidebar.vue:637
@@ -7614,147 +7720,147 @@ msgstr "Nastavení platební brány"
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:19
 #: frontend/src/pages/QuizForm.vue:201
 msgid "Settings"
-msgstr "Nastavení"
+msgstr "Nastavenia"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAdd.vue:3
 msgid "Setup Email"
-msgstr "Nastavit e-mail"
+msgstr "Nastaviť e-mail"
 
 #: frontend/src/pages/ProfileAbout.vue:84
 msgid "Share on"
-msgstr "Sdílet na"
+msgstr "Zdieľať na"
 
 #: frontend/src/pages/Batches/BatchForm.vue:182
 msgid "Short Description"
-msgstr "Krátký popis"
+msgstr "Krátky popis"
 
 #. Label of the short_introduction (Small Text) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Short Introduction"
-msgstr "Krátké představení"
+msgstr "Krátke predstavenie"
 
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:69
 msgid "Short description"
-msgstr "Krátký popis"
+msgstr "Krátky popis"
 
 #: frontend/src/pages/Batches/BatchForm.vue:185
 msgid "Short description of the batch"
-msgstr "Krátký popis školicího kola"
+msgstr "Krátky popis školiaceho kola"
 
 #: frontend/src/pages/Courses/NewCourseModal.vue:72
 msgid "Short introduction"
-msgstr "Krátké představení"
+msgstr "Krátke predstavenie"
 
 #. Label of the show_answer (Check) field in DocType 'LMS Assignment'
 #: lms/lms/doctype/lms_assignment/lms_assignment.json
 msgid "Show Answer"
-msgstr "Zobrazit odpověď"
+msgstr "Zobraziť odpoveď"
 
 #. Label of the show_answers (Check) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:205 frontend/src/pages/Quizzes.vue:289
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Show Answers"
-msgstr "Zobrazit odpovědi"
+msgstr "Zobraziť odpovede"
 
 #. Label of the show_submission_history (Check) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:213 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Show Submission History"
-msgstr "Zobrazit historii odevzdání"
+msgstr "Zobraziť históriu odovzdaní"
 
 #. Label of the column_break_2 (Column Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Show Tab in Batch"
-msgstr "Zobrazit kartu v školicím kole"
+msgstr "Zobraziť kartu v školiacom kole"
 
 #. Label of the show_usd_equivalent (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Show USD Equivalent"
-msgstr "Zobrazit ekvivalent v USD"
+msgstr "Zobraziť ekvivalent v USD"
 
 #. Label of the show_day_view (Check) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Show day view in timetable"
-msgstr "Zobrazit v rozvrhu denní pohled"
+msgstr "Zobraziť v rozvrhu denný pohľad"
 
 #. Label of the show_live_class (Check) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Show live class"
-msgstr "Zobrazit živou lekci"
+msgstr "Zobraziť živú lekciu"
 
 #. Label of the shuffle_questions (Check) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:219 lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Shuffle Questions"
-msgstr "Promíchat otázky"
+msgstr "Zamiešať otázky"
 
 #. Label of the sidebar_tab (Tab Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Sidebar"
-msgstr "Postranní panel"
+msgstr "Bočný panel"
 
 #. Label of the sidebar_items (Table) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Sidebar Items"
-msgstr "Položky postranního panelu"
+msgstr "Položky bočného panela"
 
 #: lms/lms/user.py:29
 msgid "Sign Up is disabled"
-msgstr "Registrace je zakázána"
+msgstr "Registrácia je zakázaná"
 
 #: lms/templates/signup-form.html:53
 msgid "Sign up"
-msgstr "Zaregistrovat se"
+msgstr "Zaregistrovať sa"
 
 #. Label of the signup_settings_tab (Tab Break) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Signup Settings"
-msgstr "Nastavení registrace"
+msgstr "Nastavenia registrácie"
 
 #. Label of a chart in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Signups"
-msgstr "Registrace"
+msgstr "Registrácie"
 
 #. Label of the skill (Table MultiSelect) field in DocType 'User'
 #. Label of the skill (Data) field in DocType 'User Skill'
 #: lms/fixtures/custom_field.json lms/lms/doctype/user_skill/user_skill.json
 msgid "Skill"
-msgstr "Dovednost"
+msgstr "Zručnosť"
 
 #. Label of the skill_details (Section Break) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Skill Details"
-msgstr "Podrobnosti dovednosti"
+msgstr "Podrobnosti zručnosti"
 
 #. Label of the skill_name (Link) field in DocType 'Skills'
 #: lms/lms/doctype/skills/skills.json
 msgid "Skill Name"
-msgstr "Název dovednosti"
+msgstr "Názov zručnosti"
 
 #. Name of a DocType
 #: lms/lms/doctype/skills/skills.json
 msgid "Skills"
-msgstr "Dovednosti"
+msgstr "Zručnosti"
 
 #: lms/templates/onboarding_header.html:6
 msgid "Skip"
-msgstr "Přeskočit"
+msgstr "Preskočiť"
 
 #: frontend/src/components/Questionnaire.vue:147
 #: frontend/src/pages/PersonaForm.vue:39 frontend/src/pages/PersonaForm.vue:102
 msgid "Skip for now"
-msgstr "Prozatím přeskočit"
+msgstr "Zatiaľ preskočiť"
 
 #: lms/lms/doctype/course_evaluator/course_evaluator.py:62
 msgid "Slot Times are overlapping for some schedules."
-msgstr "Časy termínů se v některých rozvrzích překrývají."
+msgstr "Časy termínov sa v niektorých rozvrhoch prekrývajú."
 
 #: frontend/src/pages/ProfileEvaluator.vue:235
 msgid "Slot added successfully"
-msgstr "Termín byl úspěšně přidán"
+msgstr "Termín bol úspešne pridaný"
 
 #: frontend/src/pages/ProfileEvaluator.vue:274
 msgid "Slot deleted successfully"
-msgstr "Termín byl úspěšně smazán"
+msgstr "Termín bol úspešne odstránený"
 
 #: frontend/src/pages/Profile.vue:269
 msgid "Slots"
@@ -7763,11 +7869,11 @@ msgstr "Termíny"
 #: frontend/src/pages/Batches/components/BatchCard.vue:27
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:30
 msgid "Sold Out"
-msgstr "Vyprodáno"
+msgstr "Vypredané"
 
 #: frontend/src/pages/Courses/CourseDashboard.vue:238
 msgid "Sort by"
-msgstr "Seřadit podle"
+msgstr "Zoradiť podľa"
 
 #. Label of the source (Link) field in DocType 'LMS Batch Enrollment'
 #. Label of the source (Link) field in DocType 'LMS Payment'
@@ -7783,19 +7889,19 @@ msgstr "Zdroj"
 
 #: frontend/src/pages/PersonaForm.vue:165
 msgid "Spreadsheets"
-msgstr "Tabulky"
+msgstr "Tabuľky"
 
 #. Option for the 'Member Type' (Select) field in DocType 'LMS Enrollment'
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 msgid "Staff"
-msgstr "Zaměstnanec"
+msgstr "Zamestnanec"
 
 #: frontend/src/components/Quiz.vue:104
 #: frontend/src/pages/Batches/components/LiveClass.vue:78
 #: frontend/src/pages/Home/AdminHome.vue:81
 #: frontend/src/pages/Home/StudentHome.vue:46
 msgid "Start"
-msgstr "Zahájit"
+msgstr "Začať"
 
 #. Label of the start_date (Date) field in DocType 'Education Detail'
 #. Label of the start_date (Date) field in DocType 'LMS Batch'
@@ -7803,16 +7909,16 @@ msgstr "Zahájit"
 #: lms/lms/doctype/education_detail/education_detail.json
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Start Date"
-msgstr "Datum zahájení"
+msgstr "Dátum začiatku"
 
 #: lms/templates/emails/batch_start_reminder.html:13
 msgid "Start Date:"
-msgstr "Datum zahájení:"
+msgstr "Dátum začiatku:"
 
 #: frontend/src/pages/Lesson.vue:46 frontend/src/pages/SCORMChapter.vue:31
 #: lms/templates/emails/lms_course_interest.html:9
 msgid "Start Learning"
-msgstr "Začít se učit"
+msgstr "Začať sa učiť"
 
 #. Label of the start_time (Time) field in DocType 'Evaluator Schedule'
 #. Label of the start_time (Time) field in DocType 'LMS Batch'
@@ -7829,29 +7935,29 @@ msgstr "Začít se učit"
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/doctype/scheduled_flow/scheduled_flow.json
 msgid "Start Time"
-msgstr "Čas zahájení"
+msgstr "Čas začiatku"
 
 #: lms/lms/doctype/course_evaluator/course_evaluator.py:41
 msgid "Start Time cannot be greater than End Time"
-msgstr "Čas zahájení nesmí být pozdější než čas ukončení"
+msgstr "Čas začiatku nesmie byť neskorší ako čas ukončenia"
 
 #. Label of the start_url (Small Text) field in DocType 'LMS Live Class'
 #: lms/lms/doctype/lms_live_class/lms_live_class.json
 msgid "Start URL"
-msgstr "Adresa URL pro zahájení"
+msgstr "URL na začatie"
 
 #: frontend/src/components/Quiz.vue:104
 msgid "Start the Quiz"
-msgstr "Zahájit kvíz"
+msgstr "Začať kvíz"
 
 #. Option for the 'Company Type' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Startup Organization"
-msgstr "Startupová organizace"
+msgstr "Startupová organizácia"
 
 #: frontend/src/pages/Billing.vue:135
 msgid "State/Province"
-msgstr "Stát/provincie"
+msgstr "Štát/provincia"
 
 #. Label of the tab_4_tab (Tab Break) field in DocType 'LMS Course'
 #. Label of the statistics (Check) field in DocType 'LMS Settings'
@@ -7859,7 +7965,7 @@ msgstr "Stát/provincie"
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_settings/lms_settings.json lms/www/_lms.py:223
 msgid "Statistics"
-msgstr "Statistiky"
+msgstr "Štatistiky"
 
 #. Label of the status (Select) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -7893,7 +7999,7 @@ msgstr "Stav"
 
 #: frontend/src/pages/Batches/components/Assessments.vue:220
 msgid "Status/Percentage"
-msgstr "Stav/procento"
+msgstr "Stav/percento"
 
 #: lms/templates/assessments.html:17
 msgid "Status/Score"
@@ -7909,23 +8015,23 @@ msgstr "Stav/skóre"
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.json
 #: lms/templates/signup-form.html:26
 msgid "Student"
-msgstr "Student"
+msgstr "Študent"
 
 #: frontend/src/pages/Batches/components/BatchStudentProgress.vue:5
 msgid "Student Details"
-msgstr "Podrobnosti studenta"
+msgstr "Podrobnosti študenta"
 
 #: frontend/src/pages/Courses/CourseDetail.vue:70
 msgid "Student View"
-msgstr "Zobrazení studenta"
+msgstr "Zobrazenie študenta"
 
 #: frontend/src/pages/Courses/CourseEnrollmentModal.vue:78
 msgid "Student enrolled successfully"
-msgstr "Student byl úspěšně zapsán"
+msgstr "Študent bol úspešne zapísaný"
 
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.py:35
 msgid "Student is already enrolled in this course."
-msgstr "Student je již zapsán do tohoto kurzu."
+msgstr "Študent je už zapísaný do tohto kurzu."
 
 #. Label of the show_students (Check) field in DocType 'LMS Settings'
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:46
@@ -7933,12 +8039,12 @@ msgstr "Student je již zapsán do tohoto kurzu."
 #: frontend/src/pages/Courses/CourseOverview.vue:45
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Students"
-msgstr "Studenti"
+msgstr "Študenti"
 
 #. Description of the 'Paid Batch' (Check) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Students will be enrolled in a paid batch once they complete the payment"
-msgstr "Studenti budou zapsáni do placeného školicího kola po dokončení platby"
+msgstr "Študenti budú zapísaní do plateného školiaceho kola po dokončení platby"
 
 #: frontend/src/components/ContactUsEmail.vue:7
 #: frontend/src/components/Modals/EmailTemplateModal.vue:28
@@ -7948,40 +8054,40 @@ msgstr "Studenti budou zapsáni do placeného školicího kola po dokončení pl
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:17
 #: frontend/src/pages/JobApplications.vue:137
 msgid "Subject"
-msgstr "Předmět"
+msgstr "Predmet"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:123
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:123
 #: frontend/src/pages/Batches/components/AnnouncementModal.vue:96
 #: frontend/src/pages/JobApplications.vue:293
 msgid "Subject is required"
-msgstr "Předmět je povinný"
+msgstr "Predmet je povinný"
 
 #: frontend/src/components/Assignment.vue:32
 msgid "Submission"
-msgstr "Odevzdání"
+msgstr "Odovzdanie"
 
 #: frontend/src/components/Modals/AssignmentForm.vue:22
 msgid "Submission Type"
-msgstr "Typ odevzdání"
+msgstr "Typ odovzdania"
 
 #: frontend/src/components/Assignment.vue:13
 #: frontend/src/components/Assignment.vue:16
 msgid "Submission by"
-msgstr "Odevzdal(a)"
+msgstr "Odovzdal(a)"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:368
 msgid "Submission saved!"
-msgstr "Odevzdání bylo uloženo!"
+msgstr "Odovzdanie bolo uložené!"
 
 #: frontend/src/pages/AssignmentSubmission.vue:62
 #: frontend/src/pages/QuizSubmissionList.vue:130
 msgid "Submissions"
-msgstr "Odevzdání"
+msgstr "Odovzdania"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:263
 msgid "Submissions deleted successfully"
-msgstr "Odevzdání byla úspěšně smazána"
+msgstr "Odovzdania boli úspešne odstránené"
 
 #: frontend/src/components/Modals/AssessmentModal.vue:8
 #: frontend/src/components/Modals/BatchCourseModal.vue:8
@@ -7989,45 +8095,45 @@ msgstr "Odevzdání byla úspěšně smazána"
 #: frontend/src/components/Quiz.vue:330 frontend/src/components/Quiz.vue:420
 #: lms/templates/assignment.html:9 lms/www/new-sign-up.html:32
 msgid "Submit"
-msgstr "Odeslat"
+msgstr "Odoslať"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:56
 msgid "Submit Feedback"
-msgstr "Odeslat zpětnou vazbu"
+msgstr "Odoslať spätnú väzbu"
 
 #: frontend/src/components/Modals/JobApplicationModal.vue:21
 msgid ""
-"Submit your resume to proceed with your application for this position. Upon submission, it will "
-"be shared with the job poster."
+"Submit your resume to proceed with your application for this position. Upon "
+"submission, it will be shared with the job poster."
 msgstr ""
-"Chcete-li pokračovat v žádosti o tuto pozici, odešlete svůj životopis. Po odeslání bude sdílen se"
-" zadavatelem pracovní nabídky."
+"Ak chcete pokračovať v žiadosti o túto pozíciu, odošlite svoj životopis. Po "
+"odoslaní sa poskytne zadávateľovi pracovnej ponuky."
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:140
 msgid "Successfully enrolled in program"
-msgstr "Úspěšně jste se zapsali do programu"
+msgstr "Úspešne ste sa zapísali do programu"
 
 #. Label of the summary (Small Text) field in DocType 'LMS Certificate
 #. Evaluation'
 #: frontend/src/components/Modals/Event.vue:107
 #: lms/lms/doctype/lms_certificate_evaluation/lms_certificate_evaluation.json
 msgid "Summary"
-msgstr "Souhrn"
+msgstr "Súhrn"
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Sunday"
-msgstr "Neděle"
+msgstr "Nedeľa"
 
 #: lms/lms/api.py:1227
 msgid "Suspicious pattern found in {0}: {1}"
-msgstr "V položce {0} byl nalezen podezřelý vzor: {1}"
+msgstr "V položke {0} sa našiel podozrivý vzor: {1}"
 
 #: frontend/src/components/Controls/ColorSwatches.vue:50
 msgid "Swatches"
-msgstr "Vzorník barev"
+msgstr "Vzorkovníky"
 
 #. Name of a role
 #: lms/job/doctype/job_opportunity/job_opportunity.json
@@ -8074,7 +8180,7 @@ msgstr "Vzorník barev"
 #: lms/lms/doctype/user_skill/user_skill.json
 #: lms/lms/doctype/zoom_settings/zoom_settings.json
 msgid "System Manager"
-msgstr "Systémový správce"
+msgstr "Správca systému"
 
 #. Label of the tags (Data) field in DocType 'LMS Course'
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:28
@@ -8088,7 +8194,7 @@ msgstr "TalentLMS"
 
 #: frontend/src/components/InstallPrompt.vue:51
 msgid "Tap"
-msgstr "Klepněte"
+msgstr "Ťuknite"
 
 #: frontend/src/components/CourseCreatorCard.vue:139
 msgid "Taught by"
@@ -8096,7 +8202,7 @@ msgstr "Vyučuje"
 
 #: frontend/src/components/CourseCreatorCard.vue:140
 msgid "Taught by a team of {0}"
-msgstr "Vyučuje tým {0}"
+msgstr "Vyučuje tím {0}"
 
 #: frontend/src/pages/PersonaForm.vue:160
 msgid "Teachable"
@@ -8111,23 +8217,23 @@ msgstr "Modrozelená"
 #: lms/templates/emails/mentor_request_creation_email.html:8
 #: lms/templates/emails/mentor_request_status_update_email.html:7
 msgid "Team School"
-msgstr "Tým School"
+msgstr "Tím School"
 
 #. Option for the 'Collaboration Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Team Work"
-msgstr "Týmová práce"
+msgstr "Tímová práca"
 
 #. Label of the template (Link) field in DocType 'LMS Certificate'
 #: frontend/src/components/Modals/Event.vue:131
 #: frontend/src/pages/Batches/components/BulkCertificates.vue:41
 #: lms/lms/doctype/lms_certificate/lms_certificate.json
 msgid "Template"
-msgstr "Šablona"
+msgstr "Šablóna"
 
 #: lms/lms/user.py:42
 msgid "Temporarily Disabled"
-msgstr "Dočasně zakázáno"
+msgstr "Dočasne zakázané"
 
 #. Label of the test_cases (Table) field in DocType 'LMS Programming Exercise'
 #. Label of the test_cases (Table) field in DocType 'LMS Programming Exercise
@@ -8137,19 +8243,19 @@ msgstr "Dočasně zakázáno"
 #: lms/lms/doctype/lms_programming_exercise/lms_programming_exercise.json
 #: lms/lms/doctype/lms_programming_exercise_submission/lms_programming_exercise_submission.json
 msgid "Test Cases"
-msgstr "Testovací případy"
+msgstr "Testovacie prípady"
 
 #: frontend/src/pages/QuizForm.vue:23 frontend/src/pages/QuizPage.vue:66
 msgid "Test Quiz"
-msgstr "Vyzkoušet kvíz"
+msgstr "Vyskúšať kvíz"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseForm.vue:87
 msgid "Test this Exercise"
-msgstr "Otestovat toto cvičení"
+msgstr "Otestovať toto cvičenie"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:96
 msgid "Test {0}"
-msgstr "Otestovat {0}"
+msgstr "Otestovať {0}"
 
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment'
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment Submission'
@@ -8160,30 +8266,36 @@ msgstr "Text"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:27
 msgid "Thank you for providing your feedback."
-msgstr "Děkujeme za poskytnutí zpětné vazby."
+msgstr "Ďakujeme za poskytnutie spätnej väzby."
 
 #: lms/templates/emails/lms_course_interest.html:17
 #: lms/templates/emails/lms_invite_request_approved.html:15
 #: lms/templates/emails/mentor_request_creation_email.html:7
 #: lms/templates/emails/mentor_request_status_update_email.html:6
 msgid "Thanks and Regards"
-msgstr "Děkujeme a s pozdravem"
+msgstr "Ďakujeme a s pozdravom"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:313
 msgid ""
-"The Google Meet account does not have a Google Calendar configured. Please set up a Google "
-"Calendar first."
-msgstr "Účet Google Meet nemá nakonfigurovaný Kalendář Google. Nejprve nastavte Kalendář Google."
+"The Google Meet account does not have a Google Calendar configured. Please "
+"set up a Google Calendar first."
+msgstr ""
+"Účet Google Meet nemá nakonfigurovaný Kalendár Google. Najprv nastavte "
+"Kalendár Google."
 
 #: lms/lms/utils.py:2548
 msgid "The batch does not exist."
-msgstr "Školicí kolo neexistuje."
+msgstr "Školiace kolo neexistuje."
 
 #: lms/templates/emails/batch_start_reminder.html:6
 msgid ""
-"The batch you have enrolled for is starting tomorrow. Please be prepared and be on time for the "
-"session."
-msgstr "Školicí kolo, do kterého jste se zapsali, začíná zítra. Připravte se a přijďte na lekci včas."
+"The batch you have enrolled for is starting tomorrow. Please be prepared and"
+" be on time for the session."
+msgstr ""
+"Školiace kolo, do ktorého ste sa zapísali, sa začína zajtra. Pripravte sa"
+" a príďte na lekciu včas."
+
+
 
 #: lms/lms/utils.py:2022
 msgid "The coupon code '{0}' is invalid."
@@ -8191,90 +8303,106 @@ msgstr "Kód kupónu „{0}“ je neplatný."
 
 #: lms/templates/emails/lms_course_interest.html:5
 msgid "The course {0} is now available on {1}."
-msgstr "Kurz {0} je nyní dostupný na {1}."
+msgstr "Kurz {0} je teraz dostupný na {1}."
 
 #: frontend/src/components/UpcomingEvaluations.vue:26
-msgid "The deadline to schedule evaluations has passed. Please contact the Instructor for assistance."
-msgstr "Termín pro naplánování hodnocení již uplynul. Požádejte o pomoc lektora."
+msgid ""
+"The deadline to schedule evaluations has passed. Please contact the "
+"Instructor for assistance."
+msgstr "Termín na naplánovanie hodnotenia už uplynul. Požiadajte o pomoc lektora."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:70
-msgid "The evaluator of this course is unavailable from {0} to {1}. Please select a date after {1}"
-msgstr "Hodnotitel tohoto kurzu není dostupný od {0} do {1}. Vyberte datum po {1}."
+msgid ""
+"The evaluator of this course is unavailable from {0} to {1}. Please select a"
+" date after {1}"
+msgstr "Hodnotiteľ tohto kurzu nie je dostupný od {0} do {1}. Vyberte dátum po {1}."
 
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py:82
 msgid "The instructor has left a comment on your assignment {0}"
-msgstr "Lektor přidal komentář k vašemu úkolu {0}"
+msgstr "Lektor pridal komentár k vašej úlohe {0}"
 
 #: lms/templates/emails/batch_start_reminder_recorded.html:13
 msgid "The last day to schedule your evaluation is {0}."
-msgstr "Poslední den pro naplánování hodnocení je {0}."
+msgstr "Posledný deň na naplánovanie hodnotenia je {0}."
 
 #: frontend/src/components/UpcomingEvaluations.vue:15
 msgid "The last day to schedule your evaluations is "
-msgstr "Poslední den pro naplánování hodnocení je "
+msgstr "Posledný deň na naplánovanie hodnotení je "
 
 #: lms/lms/utils.py:2532
 msgid "The lesson does not exist."
-msgstr "Lekce neexistuje."
+msgstr "Lekcia neexistuje."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:149
 msgid "The selected Google Meet account does not have a Google Calendar configured."
-msgstr "Vybraný účet Google Meet nemá nakonfigurovaný Kalendář Google."
+msgstr "Vybraný účet Google Meet nemá nakonfigurovaný Kalendár Google."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:142
-msgid "The selected Google Meet account is disabled. Please enable it or select another account."
-msgstr "Vybraný účet Google Meet je zakázán. Povolte jej nebo vyberte jiný účet."
+msgid ""
+"The selected Google Meet account is disabled. Please enable it or select "
+"another account."
+msgstr "Vybraný účet Google Meet je zakázaný. Povoľte ho alebo vyberte iný účet."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:89
 msgid "The slot is already booked by another participant."
-msgstr "Tento termín již rezervoval jiný účastník."
+msgstr "Tento termín už rezervoval iný účastník."
 
 #: lms/lms/utils.py:1707 lms/lms/utils.py:2224
 msgid "The specified batch does not exist."
-msgstr "Zadané školicí kolo neexistuje."
+msgstr "Zadané školiace kolo neexistuje."
 
 #: lms/patches/create_mentor_request_email_templates.py:36
 msgid "The status of your application has changed."
-msgstr "Stav vaší žádosti se změnil."
+msgstr "Stav vašej žiadosti sa zmenil."
 
 #: frontend/src/components/CreateOutline.vue:12
 msgid "There are no chapters in this course. Create and manage chapters from here."
-msgstr "Tento kurz nemá žádné kapitoly. Zde můžete kapitoly vytvářet a spravovat."
+msgstr "Tento kurz nemá žiadne kapitoly. Tu môžete vytvárať a spravovať kapitoly."
 
 #: frontend/src/pages/Home/AdminHome.vue:178
 msgid "There are no courses currently. Create your first course to get started!"
-msgstr "Momentálně nejsou k dispozici žádné kurzy. Začněte vytvořením svého prvního kurzu!"
+msgstr ""
+"Momentálne nie sú k dispozícii žiadne kurzy. Začnite vytvorením svojho "
+"prvého kurzu!"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:100
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:74
 msgid "There are no seats available in this batch."
-msgstr "V tomto školicím kole nejsou k dispozici žádná místa."
+msgstr "V tomto školiacom kole nie sú k dispozícii žiadne miesta."
 
 #: frontend/src/pages/AssignmentSubmissionList.vue:70
 msgid "There are no submissions for this assignment."
-msgstr "K tomuto úkolu nejsou žádná odevzdání."
+msgstr "K tejto úlohe nie sú žiadne odovzdania."
 
 #: frontend/src/components/Layouts/EmptyStateLayout.vue:43
-msgid "There are no {0} currently. Keep an eye out, fresh learning experiences are on the way!"
-msgstr "Momentálně není k dispozici žádný obsah typu {0}. Brzy přibudou nové možnosti vzdělávání!"
+msgid ""
+"There are no {0} currently. Keep an eye out, fresh learning experiences are "
+"on the way!"
+msgstr ""
+"Momentálne nie je k dispozícii žiadny obsah typu {0}. Čoskoro pribudnú nové "
+"možnosti vzdelávania!"
 
 #: lms/templates/course_list.html:14
 msgid "There are no {0} on this site."
-msgstr "Na tomto webu nejsou žádné položky typu {0}."
+msgstr "Na tejto stránke nie sú žiadne položky typu {0}."
 
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py:59
-msgid "There has been an update on your submission. You have got a score of {0} for the quiz {1}"
-msgstr "Vaše odevzdání bylo aktualizováno. Za kvíz {1} jste získali skóre {0}."
+msgid ""
+"There has been an update on your submission. You have got a score of {0} for"
+" the quiz {1}"
+msgstr "Vaše odovzdanie bolo aktualizované. Za kvíz {1} ste získali skóre {0}."
 
 #. Description of the 'section_break_ubxi' (Section Break) field in DocType
 #. 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "These customisations will work on the main batch page."
-msgstr "Tato přizpůsobení se projeví na hlavní stránce školicího kola."
+msgstr "Tieto prispôsobenia sa prejavia na hlavnej stránke školiaceho kola."
 
 #: frontend/src/pages/Courses/CourseOverviewSection.vue:51
 msgid "These tags help search engines describe and rank your course in results."
-msgstr "Tyto štítky pomáhají vyhledávačům popsat váš kurz a určit jeho pořadí ve výsledcích."
+msgstr ""
+"Tieto štítky pomáhajú vyhľadávačom opísať váš kurz a určiť jeho poradie vo "
+"výsledkoch."
 
 #: frontend/src/pages/PersonaForm.vue:159
 msgid "Thinkific"
@@ -8282,34 +8410,34 @@ msgstr "Thinkific"
 
 #: frontend/src/components/Settings/Badges/BadgeAssignments.vue:83
 msgid "This badge has not been assigned to any students yet"
-msgstr "Tento odznak zatím nebyl přidělen žádnému studentovi"
+msgstr "Tento odznak zatiaľ nebol pridelený žiadnemu študentovi"
 
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.py:56
 msgid "This batch is not associated with this course."
-msgstr "Toto školicí kolo není spojeno s tímto kurzem."
+msgstr "Toto školiace kolo nie je prepojené s týmto kurzom."
 
 #. Label of the expire (Check) field in DocType 'Certification'
 #: lms/lms/doctype/certification/certification.json
 msgid "This certificate does no expire"
-msgstr "Platnost tohoto certifikátu nevyprší"
+msgstr "Platnosť tohto certifikátu nevyprší"
 
 #: frontend/src/pages/Batches/components/LiveClass.vue:91
 #: frontend/src/pages/Home/AdminHome.vue:94
 #: frontend/src/pages/Home/StudentHome.vue:59
 msgid "This class has ended"
-msgstr "Tato lekce skončila"
+msgstr "Táto lekcia sa skončila"
 
 #: lms/lms/utils.py:2051
 msgid "This coupon has expired."
-msgstr "Platnost tohoto kupónu vypršela."
+msgstr "Platnosť tohto kupónu vypršala."
 
 #: lms/lms/utils.py:2054
 msgid "This coupon has reached its maximum usage limit."
-msgstr "Tento kupón dosáhl maximálního počtu použití."
+msgstr "Tento kupón dosiahol maximálny počet použití."
 
 #: lms/lms/utils.py:2063
 msgid "This coupon is not applicable to this {0}."
-msgstr "Tento kupón nelze použít na položku {0}."
+msgstr "Tento kupón nemožno použiť na položku {0}."
 
 #: frontend/src/components/CourseCardOverlay.vue:94
 msgid "This course includes:"
@@ -8317,68 +8445,80 @@ msgstr "Tento kurz obsahuje:"
 
 #: lms/lms/utils.py:1982
 msgid "This course is free."
-msgstr "Tento kurz je zdarma."
+msgstr "Tento kurz je bezplatný."
 
 #. Description of the 'Meta Description' (Small Text) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "This description will be shown on lists and pages without meta description"
-msgstr "Tento popis se zobrazí v seznamech a na stránkách, které nemají vlastní meta popis"
+msgstr ""
+"Tento opis sa zobrazí v zoznamoch a na stránkach, ktoré nemajú vlastný "
+"metaopis"
 
 #. Description of the 'Meta Image' (Attach Image) field in DocType 'LMS
 #. Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
-msgid "This image will be shown on lists and pages that don't have an image by default"
+msgid ""
+"This image will be shown on lists and pages that don't have an image by "
+"default"
 msgstr ""
-"Tento obrázek se ve výchozím nastavení zobrazí v seznamech a na stránkách, které nemají vlastní "
-"obrázek"
+"Tento obrázok sa predvolene zobrazí v zoznamoch a na stránkach, ktoré nemajú"
+" vlastný obrázok"
 
 #: frontend/src/pages/Lesson.vue:31
 msgid "This lesson is locked"
-msgstr "Tato lekce je uzamčena"
+msgstr "Táto lekcia je uzamknutá"
 
 #: frontend/src/pages/Lesson.vue:36
-msgid "This lesson is not available for preview. Please enroll in the course to access it."
-msgstr "Pro tuto lekci není k dispozici náhled. Přístup získáte zápisem do kurzu."
+msgid ""
+"This lesson is not available for preview. Please enroll in the course to "
+"access it."
+msgstr "Pre túto lekciu nie je k dispozícii ukážka. Prístup získate zápisom do kurzu."
 
 #: lms/lms/widgets/NoPreviewModal.html:16
-msgid "This lesson is not available for preview. Please join the course to access it."
-msgstr "Pro tuto lekci není k dispozici náhled. Přístup získáte připojením ke kurzu."
+msgid ""
+"This lesson is not available for preview. Please join the course to access "
+"it."
+msgstr ""
+"Pre túto lekciu nie je k dispozícii ukážka. Prístup získate pripojením ku "
+"kurzu."
 
 #: frontend/src/components/Settings/EmailAccount/EmailAccountList.vue:103
 msgid "This permanently deletes the email account and cannot be undone."
-msgstr "Tímto trvale smažete e-mailový účet. Tuto akci nelze vrátit zpět."
+msgstr "Týmto natrvalo odstránite e-mailový účet. Túto akciu nemožno vrátiť späť."
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateList.vue:85
 msgid "This permanently deletes the email template and cannot be undone."
-msgstr "Tímto trvale smažete e-mailovou šablonu. Tuto akci nelze vrátit zpět."
+msgstr "Týmto natrvalo odstránite e-mailovú šablónu. Túto akciu nemožno vrátiť späť."
 
 #: frontend/src/components/Settings/Members.vue:117
 msgid "This permanently deletes the user account and cannot be undone."
-msgstr "Tímto trvale smažete uživatelský účet. Tuto akci nelze vrátit zpět."
+msgstr "Týmto natrvalo odstránite používateľský účet. Túto akciu nemožno vrátiť späť."
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:13
 msgid "This program consists of {0} courses"
-msgstr "Tento program se skládá z {0} kurzů"
+msgstr "Tento program pozostáva z {0} kurzov"
 
 #: frontend/src/components/Quiz.vue:32
 msgid "This quiz consists of {0} questions."
-msgstr "Tento kvíz obsahuje {0} otázek."
+msgstr "Tento kvíz obsahuje {0} otázok."
 
 #: frontend/src/components/Quiz.vue:126
 msgid "This quiz has no questions available yet."
-msgstr "Tento kvíz zatím neobsahuje žádné otázky."
+msgstr "Tento kvíz zatiaľ neobsahuje žiadne otázky."
 
 #: frontend/src/components/Sidebar/AppSidebar.vue:91
 #: frontend/src/components/Sidebar/AppSidebar.vue:177
 msgid ""
-"This site is being updated. You will not be able to make any changes. Full access will be "
-"restored shortly."
-msgstr "Tento web se aktualizuje. Nebude možné provádět žádné změny. Plný přístup bude brzy obnoven."
+"This site is being updated. You will not be able to make any changes. Full "
+"access will be restored shortly."
+msgstr ""
+"Táto stránka sa aktualizuje. Nebude možné vykonávať žiadne zmeny. Plný "
+"prístup bude čoskoro obnovený."
 
 #: lms/lms/api.py:1652
 msgid "This user cannot be deleted."
-msgstr "Tohoto uživatele nelze smazat."
+msgstr "Tohto používateľa nemožno odstrániť."
 
 #: frontend/src/components/VideoBlock.vue:5
 msgid "This video contains {0} {1}:"
@@ -8386,22 +8526,22 @@ msgstr "Toto video obsahuje {0} {1}:"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:161
 msgid ""
-"This video's codec can't be played in browsers (e.g. HEVC/H.265). Please upload an H.264 MP4 or a"
-" WebM."
+"This video's codec can't be played in browsers (e.g. HEVC/H.265). Please "
+"upload an H.264 MP4 or a WebM."
 msgstr ""
-"Kodek tohoto videa nelze přehrát v prohlížečích (např. HEVC/H.265). Nahrajte video MP4 s kodekem "
-"H.264 nebo video WebM."
+"Kodek tohto videa nemožno prehrávať v prehliadačoch (napr. HEVC/H.265). "
+"Nahrajte video MP4 s kodekom H.264 alebo video WebM."
 
 #: frontend/src/components/Settings/Coupons/CouponList.vue:122
 msgid "This will permanently delete the coupon and the code will no longer be valid."
-msgstr "Tímto kupón trvale smažete a jeho kód již nebude platný."
+msgstr "Týmto kupón natrvalo odstránite a jeho kód už nebude platný."
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Thursday"
-msgstr "Čtvrtek"
+msgstr "Štvrtok"
 
 #. Label of the time (Time) field in DocType 'LMS Live Class'
 #: frontend/src/components/Modals/Event.vue:49
@@ -8422,19 +8562,19 @@ msgstr "Čas na kvíz"
 
 #: frontend/src/components/Modals/QuizInVideo.vue:7
 msgid "Time in Video"
-msgstr "Čas ve videu"
+msgstr "Čas vo videu"
 
 #: frontend/src/components/Modals/QuizInVideo.vue:213
 msgid "Time in Video (minutes)"
-msgstr "Čas ve videu (minuty)"
+msgstr "Čas vo videu (minúty)"
 
 #: frontend/src/components/Modals/QuizInVideo.vue:166
 msgid "Time in video exceeds the total duration of the video."
-msgstr "Čas ve videu přesahuje celkovou délku videa."
+msgstr "Čas vo videu presahuje celkovú dĺžku videa."
 
 #: frontend/src/components/Modals/LiveClassModal.vue:40
 msgid "Time must be in 24 hour format (HH:mm). Example 11:30 or 22:00"
-msgstr "Čas musí být ve 24hodinovém formátu (HH:mm), například 11:30 nebo 22:00."
+msgstr "Čas musí byť v 24-hodinovom formáte (HH:mm), napríklad 11:30 alebo 22:00."
 
 #: lms/templates/emails/published_batch_notification.html:29
 msgid "Time: "
@@ -8454,12 +8594,12 @@ msgstr "Rozvrh"
 #: lms/lms/doctype/lms_batch/lms_batch.json
 #: lms/lms/doctype/lms_timetable_template/lms_timetable_template.json
 msgid "Timetable Legends"
-msgstr "Legendy rozvrhu"
+msgstr "Legenda rozvrhu"
 
 #. Label of the timetable_template (Link) field in DocType 'LMS Batch'
 #: lms/lms/doctype/lms_batch/lms_batch.json
 msgid "Timetable Template"
-msgstr "Šablona rozvrhu"
+msgstr "Šablóna rozvrhu"
 
 #. Label of the timezone (Data) field in DocType 'LMS Batch'
 #. Label of the timezone (Data) field in DocType 'LMS Certificate Request'
@@ -8478,7 +8618,7 @@ msgstr "Časové pásmo"
 
 #: lms/lms/doctype/lms_course/lms_course.py:84
 msgid "Timezone is required for paid certificates."
-msgstr "U placených certifikátů je vyžadováno časové pásmo."
+msgstr "Pri platených certifikátoch sa vyžaduje časové pásmo."
 
 #: lms/templates/emails/batch_confirmation.html:21
 #: lms/templates/emails/batch_start_reminder.html:16
@@ -8528,16 +8668,16 @@ msgstr "Časy:"
 #: lms/lms/doctype/lms_timetable_template/lms_timetable_template.json
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "Title"
-msgstr "Název"
+msgstr "Názov"
 
 #: frontend/src/components/Modals/DiscussionModal.vue:66
 msgid "Title cannot be empty."
-msgstr "Název nesmí být prázdný."
+msgstr "Názov nesmie byť prázdny."
 
 #: frontend/src/components/Modals/ChapterModal.vue:159
 #: frontend/src/components/Modals/LessonModal.vue:131
 msgid "Title is required"
-msgstr "Název je povinný"
+msgstr "Názov je povinný"
 
 #. Label of the unavailable_to (Date) field in DocType 'Course Evaluator'
 #: frontend/src/pages/ProfileEvaluator.vue:120
@@ -8548,77 +8688,79 @@ msgstr "Do"
 #. Label of the to_date (Date) field in DocType 'Work Experience'
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "To Date"
-msgstr "Datum do"
+msgstr "Dátum do"
 
 #: lms/lms/utils.py:1996
 msgid "To join this batch, please contact the Administrator."
-msgstr "Chcete-li se připojit k tomuto školicímu kolu, obraťte se na správce."
+msgstr "Ak sa chcete pripojiť k tomuto školiacemu kolu, obráťte sa na správcu."
 
 #: frontend/src/components/CourseReviews.vue:189
 msgid "Today"
 msgstr "Dnes"
 
 #: lms/lms/user.py:43
-msgid "Too many users signed up recently, so the registration is disabled. Please try back in an hour"
+msgid ""
+"Too many users signed up recently, so the registration is disabled. Please "
+"try back in an hour"
 msgstr ""
-"Nedávno se zaregistrovalo příliš mnoho uživatelů, takže je registrace zakázána. Zkuste to znovu "
-"za hodinu"
+"Nedávno sa zaregistrovalo príliš veľa používateľov, preto je registrácia "
+"zakázaná. Skúste to znova o hodinu"
 
 #: frontend/src/pages/Billing.vue:54
 msgid "Total"
-msgstr "Celkem"
+msgstr "Celkom"
 
 #. Label of the total_marks (Int) field in DocType 'LMS Quiz'
 #: frontend/src/pages/QuizForm.vue:180 frontend/src/pages/Quizzes.vue:268
 #: lms/lms/doctype/lms_quiz/lms_quiz.json
 msgid "Total Marks"
-msgstr "Celkem bodů"
+msgstr "Celkový počet bodov"
 
 #: frontend/src/components/Quiz.vue:434
 msgid "Total Questions"
-msgstr "Celkem otázek"
+msgstr "Celkový počet otázok"
 
 #: lms/lms/web_template/lms_statistics/lms_statistics.html:14
 #: lms/templates/statistics.html:12
 msgid "Total Signups"
-msgstr "Celkový počet registrací"
+msgstr "Celkový počet registrácií"
 
 #: frontend/src/components/Modals/FeedbackModal.vue:6
 msgid "Training Feedback"
-msgstr "Zpětná vazba ke školení"
+msgstr "Spätná väzba k školeniu"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:3
 msgid "Transaction Details"
-msgstr "Podrobnosti transakce"
+msgstr "Podrobnosti transakcie"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:207
 msgid "Transaction created successfully"
-msgstr "Transakce byla úspěšně vytvořena"
+msgstr "Transakcia bola úspešne vytvorená"
 
 #: frontend/src/components/Settings/Transactions/TransactionDetails.vue:221
 msgid "Transaction updated successfully"
-msgstr "Transakce byla úspěšně aktualizována"
+msgstr "Transakcia bola úspešne aktualizovaná"
 
 #. Option for the 'Location Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Travel"
-msgstr "Cestování"
+msgstr "Cestovanie"
 
 #: frontend/src/components/Quiz.vue:385
 msgid "Try Again"
-msgstr "Zkusit znovu"
+msgstr "Skúsiť znova"
 
 #: frontend/src/pages/Batches/components/AdminBatchDashboard.vue:131
 #: frontend/src/pages/Courses/CourseDashboard.vue:131
 msgid "Try a different name."
-msgstr "Zkuste jiný název."
+msgstr "Skúste iný názov."
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Tuesday"
-msgstr "Úterý"
+msgstr "Utorok"
 
 #: frontend/src/pages/ProfileAbout.vue:108
 msgid "Twitter"
@@ -8628,7 +8770,7 @@ msgstr "Twitter"
 #: frontend/src/components/Modals/EditProfile.vue:51
 #: lms/fixtures/custom_field.json
 msgid "Twitter ID"
-msgstr "ID na Twitteru"
+msgstr "ID na Twitteri"
 
 #. Label of the type (Select) field in DocType 'Job Opportunity'
 #. Label of a field in the job-opportunity Web Form
@@ -8654,20 +8796,20 @@ msgstr "Typ"
 
 #: frontend/src/utils/markdownParser.js:45
 msgid "Type '/' for commands or select text to format"
-msgstr "Zadejte „/“ pro příkazy nebo vyberte text, který chcete formátovat"
+msgstr "Zadajte „/“ na príkazy alebo označte text, ktorý chcete formátovať"
 
 #: frontend/src/pages/Courses/CourseDetailsSection.vue:70
 msgid "Type something"
-msgstr "Něco napište"
+msgstr "Niečo napíšte"
 
 #: frontend/src/components/Quiz.vue:924
 msgid "Type your answer"
-msgstr "Napište svou odpověď"
+msgstr "Napíšte svoju odpoveď"
 
 #. Option for the 'Grade Type' (Select) field in DocType 'Education Detail'
 #: lms/lms/doctype/education_detail/education_detail.json
 msgid "UK Grading  (e.g. 1st, 2:2)"
-msgstr "Britské známkování (např. 1st, 2:2)"
+msgstr "Britské známkovanie (napr. 1st, 2:2)"
 
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment'
 #. Option for the 'Type' (Select) field in DocType 'LMS Assignment Submission'
@@ -8683,53 +8825,53 @@ msgstr "UUID"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:190
 msgid "Unable to add member"
-msgstr "Člena se nepodařilo přidat"
+msgstr "Člena sa nepodarilo pridať"
 
 #: frontend/src/utils/index.js:827
 msgid "Unable to create category"
-msgstr "Kategorii se nepodařilo vytvořit"
+msgstr "Kategóriu sa nepodarilo vytvoriť"
 
 #: frontend/src/components/Modals/NewMemberModal.vue:215
 msgid "Unable to update member"
-msgstr "Člena se nepodařilo aktualizovat"
+msgstr "Člena sa nepodarilo aktualizovať"
 
 #: frontend/src/components/Quiz.vue:450
 msgid "Unattempted Questions"
-msgstr "Nezodpovězené otázky"
+msgstr "Nezodpovedané otázky"
 
 #. Label of the unavailability_section (Section Break) field in DocType 'Course
 #. Evaluator'
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
 msgid "Unavailability"
-msgstr "Nedostupnost"
+msgstr "Nedostupnosť"
 
 #: frontend/src/pages/ProfileEvaluator.vue:293
 msgid "Unavailability updated successfully"
-msgstr "Nedostupnost byla úspěšně aktualizována"
+msgstr "Nedostupnosť bola úspešne aktualizovaná"
 
 #: lms/lms/doctype/course_evaluator/course_evaluator.py:36
 msgid "Unavailable From Date cannot be greater than Unavailable To Date"
-msgstr "Datum „Nedostupný od“ nesmí být pozdější než datum „Nedostupný do“"
+msgstr "Dátum „Nedostupný od“ nesmie byť neskorší ako dátum „Nedostupný do“"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Under Review"
-msgstr "Probíhá kontrola"
+msgstr "Posudzuje sa"
 
 #: frontend/src/pages/Batches/BatchDetail.vue:78
 #: frontend/src/pages/Courses/CourseDetail.vue:91
 msgid "Unpublish"
-msgstr "Zrušit zveřejnění"
+msgstr "Zrušiť zverejnenie"
 
 #: frontend/src/pages/Batches/Batches.vue:338
 #: frontend/src/pages/Courses/Courses.vue:321
 #: frontend/src/pages/Programs/Programs.vue:196
 msgid "Unpublished"
-msgstr "Nezveřejněno"
+msgstr "Nezverejnené"
 
 #: lms/lms/course_import_export.py:774
 msgid "Unsafe file path detected"
-msgstr "Byla zjištěna nebezpečná cesta k souboru"
+msgstr "Zistila sa nebezpečná cesta k súboru"
 
 #: frontend/src/components/Modals/EditCoverImage.vue:60
 #: frontend/src/components/UnsplashImageBrowser.vue:54
@@ -8739,12 +8881,12 @@ msgstr "Unsplash"
 #. Label of the unsplash_access_key (Data) field in DocType 'LMS Settings'
 #: lms/lms/doctype/lms_settings/lms_settings.json
 msgid "Unsplash Access Key"
-msgstr "Přístupový klíč Unsplash"
+msgstr "Prístupový kľúč Unsplash"
 
 #. Option for the 'Role Preference' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Unstructured Role"
-msgstr "Nestrukturovaná role"
+msgstr "Neštruktúrovaná rola"
 
 #: frontend/src/pages/Quizzes.vue:232
 msgid "Untitled Quiz"
@@ -8752,7 +8894,7 @@ msgstr "Kvíz bez názvu"
 
 #: lms/lms/api.py:634
 msgid "Untitled lesson"
-msgstr "Lekce bez názvu"
+msgstr "Lekcia bez názvu"
 
 #. Option for the 'Status' (Select) field in DocType 'LMS Certificate Request'
 #. Label of the upcoming (Check) field in DocType 'LMS Course'
@@ -8762,119 +8904,123 @@ msgstr "Lekce bez názvu"
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Upcoming"
-msgstr "Nadcházející"
+msgstr "Nadchádzajúce"
 
 #: frontend/src/pages/Home/AdminHome.vue:141
 msgid "Upcoming Batches"
-msgstr "Nadcházející školicí kola"
+msgstr "Nadchádzajúce školiace kolá"
 
 #: frontend/src/components/UpcomingEvaluations.vue:5
 #: frontend/src/pages/Home/AdminHome.vue:6 lms/templates/upcoming_evals.html:3
 msgid "Upcoming Evaluations"
-msgstr "Nadcházející hodnocení"
+msgstr "Nadchádzajúce hodnotenia"
 
 #: frontend/src/pages/Home/AdminHome.vue:42
 #: frontend/src/pages/Home/StudentHome.vue:7
 msgid "Upcoming Live Classes"
-msgstr "Nadcházející živé lekce"
+msgstr "Nadchádzajúce živé lekcie"
 
 #: frontend/src/components/Settings/BrandSettings.vue:13
 #: frontend/src/components/Settings/SettingDetails.vue:13
 msgid "Update"
-msgstr "Aktualizovat"
+msgstr "Aktualizovať"
 
 #: frontend/src/components/Settings/EmailAccount/EmailEdit.vue:10
 msgid "Update Account"
-msgstr "Aktualizovat účet"
+msgstr "Aktualizovať účet"
 
 #: lms/templates/emails/community_course_membership.html:11
 msgid "Update Password"
-msgstr "Změnit heslo"
+msgstr "Zmeniť heslo"
 
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:10
 msgid "Update Template"
-msgstr "Aktualizovat šablonu"
+msgstr "Aktualizovať šablónu"
 
 #: frontend/src/pages/Assignments.vue:286
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:335
 #: frontend/src/pages/Quizzes.vue:296
 msgid "Updated On"
-msgstr "Aktualizováno dne"
+msgstr "Aktualizované"
 
 #: frontend/src/components/Controls/ImageUploader.vue:15
 #: frontend/src/components/Controls/Uploader.vue:42
 msgid "Upload"
-msgstr "Nahrát"
+msgstr "Nahrať"
 
 #: frontend/src/components/Assignment.vue:74
 msgid "Upload Assignment"
-msgstr "Nahrát vypracovaný úkol"
+msgstr "Nahrať vypracovanú úlohu"
 
 #: frontend/src/components/Assignment.vue:98
 msgid "Upload File"
-msgstr "Nahrát soubor"
+msgstr "Nahrať súbor"
 
 #: frontend/src/pages/Courses/NewCourseModal.vue:189
-msgid "Upload a 750×422 image (.jpg, .jpeg, .gif, or .png) — shown on the catalog card and lesson hero."
+msgid ""
+"Upload a 750×422 image (.jpg, .jpeg, .gif, or .png) — shown on the catalog "
+"card and lesson hero."
 msgstr ""
-"Nahrajte obrázek o rozměrech 750 × 422 (.jpg, .jpeg, .gif nebo .png) — zobrazí se na kartě v "
-"katalogu a v záhlaví lekce."
+"Nahrajte obrázok s rozmermi 750 × 422 (.jpg, .jpeg, .gif alebo .png) — "
+"zobrazí sa na karte v katalógu a v záhlaví lekcie."
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:115
 msgid "Upload an image to replace the color."
-msgstr "Nahrajte obrázek, který nahradí barvu."
+msgstr "Nahrajte obrázok, ktorý nahradí farbu."
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:172
 msgid "Upload failed"
-msgstr "Nahrávání selhalo"
+msgstr "Nahrávanie zlyhalo"
 
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:110
 msgid "Upload image instead"
-msgstr "Nahrát raději obrázek"
+msgstr "Namiesto toho nahrať obrázok"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:97
 msgid "Upload video"
-msgstr "Nahrát video"
+msgstr "Nahrať video"
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:73
-msgid "Uploaded video — students see it on the course page. Remove it to use a YouTube link instead."
+msgid ""
+"Uploaded video — students see it on the course page. Remove it to use a "
+"YouTube link instead."
 msgstr ""
-"Video nahráno — studenti ho uvidí na stránce kurzu. Chcete-li místo něj použít odkaz na YouTube, "
-"video odeberte."
+"Video je nahrané — študenti ho uvidia na stránke kurzu. Ak chcete namiesto "
+"neho použiť odkaz na YouTube, video odstráňte."
 
 #: frontend/src/components/Controls/Uploader.vue:39
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:60
 #: frontend/src/pages/Courses/CourseThumbnailField.vue:110
 msgid "Uploading"
-msgstr "Nahrávání"
+msgstr "Nahráva sa"
 
 #: frontend/src/components/Assignment.vue:97
 #: frontend/src/components/Controls/ImageUploader.vue:12
 msgid "Uploading {0}%"
-msgstr "Nahrávání {0} %"
+msgstr "Nahráva sa {0} %"
 
 #. Label of the usage_limit (Int) field in DocType 'LMS Coupon'
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:66
 #: frontend/src/components/Settings/Coupons/CouponList.vue:176
 #: lms/lms/doctype/lms_coupon/lms_coupon.json
 msgid "Usage Limit"
-msgstr "Limit použití"
+msgstr "Limit použitia"
 
 #: lms/lms/doctype/lms_coupon/lms_coupon.py:34
 msgid "Usage limit cannot be negative"
-msgstr "Limit použití nesmí být záporný"
+msgstr "Limit použitia nesmie byť záporný"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:37
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:36
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:34
 msgid "Use HTML"
-msgstr "Použít HTML"
+msgstr "Použiť HTML"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:36
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:37
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:35
 msgid "Use HTML content for the email response"
-msgstr "Pro e-mailovou odpověď použít obsah HTML"
+msgstr "Použiť obsah HTML v e-mailovej odpovedi"
 
 #. Label of the user (Link) field in DocType 'LMS Job Application'
 #. Label of the user (Link) field in DocType 'LMS Course Interest'
@@ -8882,69 +9028,71 @@ msgstr "Pro e-mailovou odpověď použít obsah HTML"
 #: lms/job/doctype/lms_job_application/lms_job_application.json
 #: lms/lms/doctype/lms_course_interest/lms_course_interest.json
 msgid "User"
-msgstr "Uživatel"
+msgstr "Používateľ"
 
 #. Label of the user_category (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json lms/templates/signup-form.html:17
 msgid "User Category"
-msgstr "Kategorie uživatele"
+msgstr "Kategória používateľa"
 
 #. Label of the user_field (Select) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "User Field"
-msgstr "Pole uživatele"
+msgstr "Pole používateľa"
 
 #. Label of the user_image (Attach Image) field in DocType 'Course Evaluator'
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
 msgid "User Image"
-msgstr "Obrázek uživatele"
+msgstr "Obrázok používateľa"
 
 #. Option for the 'Type' (Select) field in DocType 'LMS Question'
 #. Option for the 'Type' (Select) field in DocType 'LMS Quiz Question'
 #: lms/lms/doctype/lms_question/lms_question.json
 #: lms/lms/doctype/lms_quiz_question/lms_quiz_question.json
 msgid "User Input"
-msgstr "Vstup uživatele"
+msgstr "Vstup používateľa"
 
 #. Name of a DocType
 #: lms/lms/doctype/user_skill/user_skill.json
 msgid "User Skill"
-msgstr "Dovednost uživatele"
+msgstr "Zručnosť používateľa"
 
 #: frontend/src/components/Settings/Members.vue:280
 msgid "User deleted"
-msgstr "Uživatel byl smazán"
+msgstr "Používateľ bol odstránený"
 
 #: lms/lms/api.py:1974
 msgid "User does not have permission to access this user's profile details."
-msgstr "Nemáte oprávnění k údajům profilu tohoto uživatele."
+msgstr ""
+"Používateľ nemá oprávnenie na prístup k podrobnostiam profilu tohto "
+"používateľa."
 
 #: lms/lms/api.py:1654
 msgid "User {0} does not exist."
-msgstr "Uživatel {0} neexistuje."
+msgstr "Používateľ {0} neexistuje."
 
 #: lms/job/doctype/job_opportunity/job_opportunity.py:41
 msgid "User {0} has reported the job post {1}"
-msgstr "Uživatel {0} nahlásil pracovní nabídku {1}"
+msgstr "Používateľ {0} nahlásil pracovnú ponuku {1}"
 
 #. Label of the username (Data) field in DocType 'Course Evaluator'
 #: lms/lms/doctype/course_evaluator/course_evaluator.json
 msgid "Username"
-msgstr "Uživatelské jméno"
+msgstr "Používateľské meno"
 
 #. Label of a shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "Users"
-msgstr "Uživatelé"
+msgstr "Používatelia"
 
 #. Label of the answer (Small Text) field in DocType 'LMS Quiz Result'
 #: lms/lms/doctype/lms_quiz_result/lms_quiz_result.json
 msgid "Users Response"
-msgstr "Odpověď uživatele"
+msgstr "Odpoveď používateľa"
 
 #: lms/templates/signup-form.html:83
 msgid "Valid email and name required"
-msgstr "Je vyžadován platný e-mail a jméno"
+msgstr "Vyžaduje sa platný e-mail a meno"
 
 #. Label of the value (Rating) field in DocType 'LMS Batch Feedback'
 #: lms/lms/doctype/lms_batch_feedback/lms_batch_feedback.json
@@ -8954,93 +9102,101 @@ msgstr "Hodnota"
 #. Option for the 'Event' (Select) field in DocType 'LMS Badge'
 #: lms/lms/doctype/lms_badge/lms_badge.json
 msgid "Value Change"
-msgstr "Změna hodnoty"
+msgstr "Zmena hodnoty"
 
 #. Label of the video_link (Data) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Video Embed Link"
-msgstr "Odkaz pro vložení videa"
+msgstr "Odkaz na vloženie videa"
 
 #: frontend/src/components/Modals/VideoStatistics.vue:2
 #: frontend/src/pages/Courses/CourseDetail.vue:41
 msgid "Video Statistics"
-msgstr "Statistiky videa"
+msgstr "Štatistiky videa"
 
 #: frontend/src/pages/Lesson.vue:902
-msgid "Video failed to load — this lesson will still be marked complete after you spend some time on it."
-msgstr "Video se nepodařilo načíst — po určité době strávené v lekci bude přesto označena jako dokončená."
+msgid ""
+"Video failed to load — this lesson will still be marked complete after you "
+"spend some time on it."
+msgstr ""
+"Video sa nepodarilo načítať — po určitom čase strávenom v lekcii bude "
+"napriek tomu označená ako dokončená."
 
 #: frontend/src/pages/JobDetail.vue:31
 msgid "View Applications"
-msgstr "Zobrazit žádosti"
+msgstr "Zobraziť žiadosti"
 
 #: frontend/src/components/CertificationLinks.vue:10
 #: frontend/src/components/Modals/Event.vue:68
 msgid "View Certificate"
-msgstr "Zobrazit certifikát"
+msgstr "Zobraziť certifikát"
 
 #: frontend/src/pages/JobApplications.vue:318
 msgid "View Resume"
-msgstr "Zobrazit životopis"
+msgstr "Zobraziť životopis"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:20
 msgid "View all feedback"
-msgstr "Zobrazit veškerou zpětnou vazbu"
+msgstr "Zobraziť všetku spätnú väzbu"
 
 #: frontend/src/components/CourseReviews.vue:89
 msgid "View all reviews"
-msgstr "Zobrazit všechny recenze"
+msgstr "Zobraziť všetky recenzie"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #: lms/lms/doctype/lms_course/lms_course.json
 msgid "Violet"
-msgstr "Fialková"
+msgstr "Fialová"
 
 #: frontend/src/pages/Courses/CoursePublishSettings.vue:3
 msgid "Visibility"
-msgstr "Viditelnost"
+msgstr "Viditeľnosť"
 
 #: frontend/src/pages/JobDetail.vue:52
 msgid "Visit Website"
-msgstr "Navštívit web"
+msgstr "Navštíviť webovú stránku"
 
 #: lms/templates/emails/batch_confirmation.html:25
 msgid "Visit the following link to view your "
-msgstr "Podrobnosti najdete na následujícím odkazu: "
+msgstr "Navštívte nasledujúci odkaz a zobrazte si "
 
 #: lms/templates/emails/batch_start_reminder.html:23
 #: lms/templates/emails/batch_start_reminder_recorded.html:26
 #: lms/templates/emails/live_class_reminder.html:20
 msgid "Visit your batch"
-msgstr "Navštívit své školicí kolo"
+msgstr "Navštíviť svoje školiace kolo"
 
 #. Label of the internship (Table) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Volunteering or Internship"
-msgstr "Dobrovolnictví nebo stáž"
+msgstr "Dobrovoľníctvo alebo stáž"
 
 #. Label of the watch_time (Data) field in DocType 'LMS Video Watch Duration'
 #: lms/lms/doctype/lms_video_watch_duration/lms_video_watch_duration.json
 msgid "Watch Time"
-msgstr "Doba sledování"
+msgstr "Čas sledovania"
 
 #: frontend/src/components/Modals/VideoStatistics.vue:33
 msgid "Watch Time (mins)"
-msgstr "Doba sledování (min)"
+msgstr "Čas sledovania (min)"
 
 #: lms/templates/emails/batch_confirmation.html:6
-msgid "We are pleased to inform you that you have been enrolled in our upcoming batch. Congratulations!"
+msgid ""
+"We are pleased to inform you that you have been enrolled in our upcoming "
+"batch. Congratulations!"
 msgstr ""
-"S potěšením vám oznamujeme, že jste byli zapsáni do našeho nadcházejícího školicího kola. "
-"Blahopřejeme!"
+"S potešením vám oznamujeme, že ste boli zapísaní do nášho nadchádzajúceho"
+" školiaceho kola. Blahoželáme!"
+
+
 
 #: lms/templates/emails/payment_reminder.html:7
 msgid "We have a limited number of seats, and they won't be available for long!"
-msgstr "Počet míst je omezený a dlouho nebudou k dispozici!"
+msgstr "Počet miest je obmedzený a dlho nebudú k dispozícii!"
 
 #: lms/templates/emails/payment_reminder.html:4
 msgid "We noticed that you started enrolling in the"
-msgstr "Všimli jsme si, že jste zahájili zápis do"
+msgstr "Všimli sme si, že ste sa začali zapisovať do"
 
 #. Label of the web_page (Link) field in DocType 'LMS Sidebar Item'
 #: frontend/src/components/Modals/PageModal.vue:21
@@ -9050,86 +9206,87 @@ msgstr "Webová stránka"
 
 #: frontend/src/components/Modals/PageModal.vue:79
 msgid "Web page added to sidebar"
-msgstr "Webová stránka byla přidána do postranního panelu"
+msgstr "Webová stránka bola pridaná na bočný panel"
 
 #. Option for the 'Day' (Select) field in DocType 'Evaluator Schedule'
 #. Option for the 'Day' (Select) field in DocType 'LMS Certificate Request'
 #: lms/lms/doctype/evaluator_schedule/evaluator_schedule.json
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.json
 msgid "Wednesday"
-msgstr "Středa"
+msgstr "Streda"
 
 #: lms/templates/emails/lms_invite_request_approved.html:4
 msgid "Welcome to {0}!"
-msgstr "Vítejte v {0}!"
+msgstr "Vitajte v {0}!"
 
 #: frontend/src/pages/PersonaForm.vue:154
 msgid "What are you using today to manage learning?"
-msgstr "Co dnes používáte ke správě vzdělávání?"
+msgstr "Čo dnes používate na správu vzdelávania?"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:43
 msgid "What is this badge awarded for?"
-msgstr "Za co se tento odznak uděluje?"
+msgstr "Za čo sa tento odznak udeľuje?"
 
 #: frontend/src/pages/PersonaForm.vue:134
 msgid "What's the first milestone you'd like to achieve?"
-msgstr "Jakého prvního milníku chcete dosáhnout?"
+msgstr "Aký prvý míľnik chcete dosiahnuť?"
 
 #: lms/templates/courses_under_review.html:15
 msgid "When a course gets submitted for review, it will be listed here."
-msgstr "Kurzy odeslané ke kontrole se zobrazí zde."
+msgstr "Kurzy odoslané na posúdenie sa zobrazia tu."
 
 #: frontend/src/pages/LessonForm.vue:13
 msgid ""
-"When on, anyone can preview this lesson without enrolling. Otherwise it is visible only to "
-"enrolled students."
+"When on, anyone can preview this lesson without enrolling. Otherwise it is "
+"visible only to enrolled students."
 msgstr ""
-"Je-li tato možnost zapnutá, může si lekci zobrazit kdokoli bez zápisu. Jinak je dostupná pouze "
-"zapsaným studentům."
+"Keď je táto možnosť zapnutá, ktokoľvek si môže zobraziť ukážku tejto lekcie "
+"bez zápisu. Inak je viditeľná iba pre zapísaných študentov."
 
 #: lms/templates/emails/batch_start_reminder_recorded.html:11
 msgid "When you feel ready, you can schedule an evaluation to get certified."
-msgstr "Až budete připraveni, můžete si naplánovat hodnocení a získat certifikát."
+msgstr "Keď budete pripravení, môžete si naplánovať hodnotenie a získať certifikát."
 
 #: frontend/src/pages/Billing.vue:162
 msgid "Where did you hear about us?"
-msgstr "Odkud jste se o nás dozvěděli?"
+msgstr "Odkiaľ ste sa o nás dozvedeli?"
 
 #: frontend/src/pages/PersonaForm.vue:108
 msgid "Where will you be using Frappe Learning?"
-msgstr "Kde budete Frappe Learning používat?"
+msgstr "Kde budete používať Frappe Learning?"
 
 #: lms/templates/emails/certification.html:10
 msgid ""
-"With this certification, you can now showcase your updated skills and share your achievement with"
-" your colleagues and on LinkedIn. To access your certificate, please click on the link provided "
-"below. Make sure you are logged in to the portal."
+"With this certification, you can now showcase your updated skills and share "
+"your achievement with your colleagues and on LinkedIn. To access your "
+"certificate, please click on the link provided below. Make sure you are "
+"logged in to the portal."
 msgstr ""
-"Díky této certifikaci nyní můžete prezentovat své nové dovednosti a sdílet svůj úspěch s kolegy i"
-" na LinkedInu. Certifikát otevřete kliknutím na níže uvedený odkaz. Ujistěte se, že jste "
-"přihlášeni k portálu."
+"Vďaka tejto certifikácii teraz môžete prezentovať svoje nové zručnosti a "
+"podeliť sa o svoj úspech s kolegami aj na LinkedIne. Certifikát otvoríte "
+"kliknutím na odkaz uvedený nižšie. Uistite sa, že ste prihlásení do portálu."
 
 #. Option for the 'Open to' (Select) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Work"
-msgstr "Práce"
+msgstr "Práca"
 
 #. Label of the work_environment (Section Break) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Work Environment"
-msgstr "Pracovní prostředí"
+msgstr "Pracovné prostredie"
 
 #. Label of the work_experience (Table) field in DocType 'User'
 #. Name of a DocType
 #: lms/fixtures/custom_field.json
 #: lms/lms/doctype/work_experience/work_experience.json
 msgid "Work Experience"
-msgstr "Pracovní zkušenosti"
+msgstr "Pracovné skúsenosti"
 
 #. Label of the work_experience_details (Section Break) field in DocType 'User'
 #: lms/fixtures/custom_field.json
 msgid "Work Experience Details"
-msgstr "Podrobnosti pracovních zkušeností"
+msgstr "Podrobnosti pracovných skúseností"
 
 #. Label of the work_mode (Select) field in DocType 'Job Opportunity'
 #: frontend/src/pages/JobForm.vue:39 frontend/src/pages/Jobs.vue:89
@@ -9140,388 +9297,404 @@ msgstr "Režim práce"
 #: frontend/src/components/CourseReviews.vue:20
 #: frontend/src/components/Modals/ReviewModal.vue:4
 msgid "Write a Review"
-msgstr "Napsat recenzi"
+msgstr "Napísať recenziu"
 
 #: frontend/src/components/Assignment.vue:139
 msgid "Write your answer here"
-msgstr "Napište svou odpověď sem"
+msgstr "Sem napíšte svoju odpoveď"
 
 #. Option for the 'Color' (Select) field in DocType 'LMS Course'
 #. Option for the 'Color' (Select) field in DocType 'LMS Lesson Note'
 #: lms/lms/doctype/lms_course/lms_course.json
 #: lms/lms/doctype/lms_lesson_note/lms_lesson_note.json
 msgid "Yellow"
-msgstr "Žlutá"
+msgstr "Žltá"
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:111
 msgid "You already have an evaluation on {0} at {1} for the course {2}."
-msgstr "Pro kurz {2} již máte naplánované hodnocení dne {0} v {1}."
+msgstr "Pre kurz {2} už máte naplánované hodnotenie na {0} o {1}."
 
 #: frontend/src/pages/Courses/CourseCertification.vue:14
-msgid "You are already certified for this course. Click on the card below to open your certificate."
-msgstr "Pro tento kurz již máte certifikát. Kliknutím na kartu níže ho otevřete."
+msgid ""
+"You are already certified for this course. Click on the card below to open "
+"your certificate."
+msgstr "Pre tento kurz už máte certifikát. Kliknutím na kartu nižšie ho otvoríte."
 
 #: lms/lms/api.py:187
 msgid "You are already enrolled for this batch."
-msgstr "Do tohoto školicího kola jste již zapsáni."
+msgstr "Do tohto školiaceho kola ste už zapísaní."
 
 #: lms/lms/api.py:181
 msgid "You are already enrolled for this course."
-msgstr "Do tohoto kurzu jste již zapsáni."
+msgstr "Do tohto kurzu ste už zapísaní."
 
 #: lms/lms/utils.py:1503
 msgid "You are not authorized to view the assessments of this batch."
-msgstr "Nemáte oprávnění zobrazit hodnocení tohoto školicího kola."
+msgstr "Nemáte oprávnenie zobraziť hodnotenia tohto školiaceho kola."
 
 #: lms/lms/utils.py:1705
 msgid "You are not authorized to view the chart data of this batch."
-msgstr "Nemáte oprávnění zobrazit data grafu tohoto školicího kola."
+msgstr "Nemáte oprávnenie zobraziť údaje grafu tohto školiaceho kola."
 
 #: lms/lms/utils.py:2314
 msgid "You are not authorized to view the details of this program."
-msgstr "Nemáte oprávnění zobrazit podrobnosti tohoto programu."
+msgstr "Nemáte oprávnenie zobraziť podrobnosti tohto programu."
 
 #: lms/lms/utils.py:1928
 msgid "You are not authorized to view the discussion replies for this topic."
-msgstr "Nemáte oprávnění zobrazit odpovědi v diskusi k tomuto tématu."
+msgstr "Nemáte oprávnenie zobraziť odpovede v diskusii k tejto téme."
 
 #: lms/lms/utils.py:1868
 msgid "You are not authorized to view the discussion topics for this item."
-msgstr "Nemáte oprávnění zobrazit témata diskuse k této položce."
+msgstr "Nemáte oprávnenie zobraziť témy diskusie k tejto položke."
 
 #: lms/lms/utils.py:1614
 msgid "You are not authorized to view the students of this batch."
-msgstr "Nemáte oprávnění zobrazit studenty tohoto školicího kola."
+msgstr "Nemáte oprávnenie zobraziť študentov tohto školiaceho kola."
 
 #: lms/lms/utils.py:1454
 msgid "You are not authorized to view this quiz."
-msgstr "Nemáte oprávnění zobrazit tento kvíz."
+msgstr "Nemáte oprávnenie zobraziť tento kvíz."
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:211
 msgid "You are not enrolled in this course."
-msgstr "Nejste zapsáni do tohoto kurzu."
+msgstr "Nie ste zapísaní do tohto kurzu."
 
 #: frontend/src/pages/SCORMChapter.vue:25
 msgid "You are not enrolled in this course. Please enroll to access this lesson."
-msgstr "Nejste zapsáni do tohoto kurzu. Pro přístup k lekci se zapište."
+msgstr ""
+"Nie ste zapísaní do tohto kurzu. Ak chcete získať prístup k lekcii, zapíšte "
+"sa."
 
 #: frontend/src/components/NoPermission.vue:23
 msgid "You are not permitted to access this page."
-msgstr "Nemáte oprávnění přistupovat k této stránce."
+msgstr "Nemáte oprávnenie na prístup k tejto stránke."
 
 #: lms/lms/api.py:798 lms/lms/api.py:849
 msgid "You are not the assigned evaluator for this course and batch."
-msgstr "Nejste hodnotitelem přiřazeným k tomuto kurzu a školicímu kolu."
+msgstr "Nie ste hodnotiteľom priradeným k tomuto kurzu a školiacemu kolu."
 
 #: lms/templates/emails/lms_course_interest.html:13
 #: lms/templates/emails/lms_invite_request_approved.html:11
 msgid "You can also copy-paste following link in your browser"
-msgstr "Můžete také zkopírovat a vložit následující odkaz do svého prohlížeče"
+msgstr "Nasledujúci odkaz môžete tiež skopírovať a vložiť do prehliadača"
 
 #: frontend/src/components/Quiz.vue:58
 msgid "You can attempt this quiz {0}."
-msgstr "Tento kvíz můžete absolvovat {0}."
+msgstr "Tento kvíz môžete absolvovať {0}."
 
 #: frontend/src/pages/Home/Streak.vue:11
 msgid "You can do better,"
-msgstr "Můžete to zvládnout lépe,"
+msgstr "Môžete to zvládnuť lepšie,"
 
 #: lms/templates/emails/job_application.html:6
 msgid "You can find their resume attached to this email."
-msgstr "Jejich životopis najdete v příloze tohoto e-mailu."
+msgstr "Ich životopis nájdete v prílohe tohto e-mailu."
 
 #: lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py:27
 msgid "You can only submit assignments for your own account."
-msgstr "Úkoly můžete odevzdávat pouze za svůj vlastní účet."
+msgstr "Úlohy môžete odovzdávať iba zo svojho vlastného účtu."
 
 #: frontend/src/components/Assignment.vue:78
 msgid "You can only upload {0} files"
-msgstr "Můžete nahrát pouze {0} souborů"
+msgstr "Môžete nahrať iba {0} súborov"
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:42
 msgid "You cannot book an evaluation for another user."
-msgstr "Nemůžete rezervovat hodnocení pro jiného uživatele."
+msgstr "Nemôžete rezervovať hodnotenie pre iného používateľa."
 
 #: frontend/src/pages/ProfileEvaluator.vue:14
 msgid "You cannot change the availability when the site is being updated."
-msgstr "Během aktualizace webu nelze měnit dostupnost."
+msgstr "Počas aktualizácie stránky nemožno meniť dostupnosť."
 
 #: frontend/src/pages/ProfileRoles.vue:12
 msgid "You cannot change the roles in read-only mode."
-msgstr "V režimu jen pro čtení nelze měnit role."
+msgstr "V režime iba na čítanie nemožno meniť roly."
 
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.py:64
 msgid "You cannot enroll in an unpublished course."
-msgstr "Do nezveřejněného kurzu se nelze zapsat."
+msgstr "Do nezverejneného kurzu sa nemožno zapísať."
 
 #: lms/lms/utils.py:2375
 msgid "You cannot enroll in an unpublished program."
-msgstr "Do nezveřejněného programu se nelze zapsat."
+msgstr "Do nezverejneného programu sa nemožno zapísať."
 
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.py:47
-msgid "You cannot enroll in this course as self-learning is disabled. Please contact the Administrator."
-msgstr "Do tohoto kurzu se nemůžete zapsat, protože je samostudium zakázáno. Obraťte se na správce."
+msgid ""
+"You cannot enroll in this course as self-learning is disabled. Please "
+"contact the Administrator."
+msgstr ""
+"Do tohto kurzu sa nemôžete zapísať, pretože samostatné štúdium je zakázané. "
+"Obráťte sa na správcu."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:127
 msgid "You cannot schedule evaluations after {0}."
-msgstr "Hodnocení nelze plánovat po {0}."
+msgstr "Hodnotenia nemožno plánovať po {0}."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:118
 msgid "You cannot schedule evaluations for past slots."
-msgstr "Hodnocení nelze plánovat na termíny v minulosti."
+msgstr "Hodnotenia nemožno plánovať na termíny v minulosti."
 
 #: lms/lms/utils.py:2560
 msgid "You do not have access to this batch."
-msgstr "K tomuto školicímu kolu nemáte přístup."
+msgstr "K tomuto školiacemu kolu nemáte prístup."
 
 #: lms/lms/utils.py:2543
 msgid "You do not have access to this course."
-msgstr "K tomuto kurzu nemáte přístup."
+msgstr "K tomuto kurzu nemáte prístup."
 
 #: lms/lms/api.py:985 lms/lms/doctype/lms_batch/lms_batch.py:368
 msgid "You do not have permission to access announcements for this batch."
-msgstr "Nemáte oprávnění k oznámením tohoto školicího kola."
+msgstr "Nemáte oprávnenie na prístup k oznámeniam tohto školiaceho kola."
 
 #: lms/lms/api.py:2473
 msgid "You do not have permission to access badges."
-msgstr "Nemáte oprávnění k odznakům."
+msgstr "Nemáte oprávnenie na prístup k odznakom."
 
 #: lms/lms/api.py:1357
 msgid "You do not have permission to access heatmap data."
-msgstr "Nemáte oprávnění k datům teplotní mapy."
+msgstr "Nemáte oprávnenie na prístup k údajom teplotnej mapy."
 
 #: lms/lms/api.py:2312
 msgid "You do not have permission to access lesson completion stats."
-msgstr "Nemáte oprávnění ke statistikám dokončení lekcí."
+msgstr "Nemáte oprávnenie na prístup k štatistikám dokončenia lekcií."
 
 #: lms/lms/api.py:2352
 msgid "You do not have permission to access this course's assessment data."
-msgstr "Nemáte oprávnění k údajům o hodnoceních tohoto kurzu."
+msgstr "Nemáte oprávnenie na prístup k údajom o hodnoteniach tohto kurzu."
 
 #: lms/lms/api.py:1875
 msgid "You do not have permission to access this course's progress data."
-msgstr "Nemáte oprávnění k údajům o průběhu tohoto kurzu."
+msgstr "Nemáte oprávnenie na prístup k údajom o priebehu tohto kurzu."
 
 #: frontend/src/components/NoPermission.vue:9
 msgid "You do not have permission to access this page."
-msgstr "Nemáte oprávnění přistupovat k této stránce."
+msgstr "Nemáte oprávnenie na prístup k tejto stránke."
 
 #: lms/lms/api.py:631
 msgid "You do not have permission to add a lesson."
-msgstr "Nemáte oprávnění přidat lekci."
+msgstr "Nemáte oprávnenie pridať lekciu."
 
 #: lms/lms/api.py:1531 lms/lms/api.py:1540
 msgid "You do not have permission to cancel this evaluation."
-msgstr "Nemáte oprávnění zrušit toto hodnocení."
+msgstr "Nemáte oprávnenie zrušiť toto hodnotenie."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:246
 msgid "You do not have permission to create a live class."
-msgstr "Nemáte oprávnění vytvořit živou lekci."
+msgstr "Nemáte oprávnenie vytvoriť živú lekciu."
 
 #: lms/lms/api.py:1067
 msgid "You do not have permission to delete this batch."
-msgstr "Nemáte oprávnění smazat toto školicí kolo."
+msgstr "Nemáte oprávnenie odstrániť toto školiace kolo."
 
 #: lms/lms/api.py:1295
 msgid "You do not have permission to delete this chapter."
-msgstr "Nemáte oprávnění smazat tuto kapitolu."
+msgstr "Nemáte oprávnenie odstrániť túto kapitolu."
 
 #: lms/lms/api.py:1015
 msgid "You do not have permission to delete this course."
-msgstr "Nemáte oprávnění smazat tento kurz."
+msgstr "Nemáte oprávnenie odstrániť tento kurz."
 
 #: lms/lms/api.py:596
 msgid "You do not have permission to delete this lesson."
-msgstr "Nemáte oprávnění smazat tuto lekci."
+msgstr "Nemáte oprávnenie odstrániť túto lekciu."
 
 #: lms/lms/api.py:2575
 msgid "You do not have permission to export this course."
-msgstr "Nemáte oprávnění exportovat tento kurz."
+msgstr "Nemáte oprávnenie exportovať tento kurz."
 
 #: lms/lms/api.py:704 lms/lms/api.py:1122
 msgid "You do not have permission to modify this chapter."
-msgstr "Nemáte oprávnění upravit tuto kapitolu."
+msgstr "Nemáte oprávnenie upraviť túto kapitolu."
 
 #: lms/lms/api.py:641
 msgid "You do not have permission to modify this lesson."
-msgstr "Nemáte oprávnění upravit tuto lekci."
+msgstr "Nemáte oprávnenie upraviť túto lekciu."
 
 #: lms/lms/api.py:1600
 msgid "You do not have permission to modify this role."
-msgstr "Nemáte oprávnění upravit tuto roli."
+msgstr "Nemáte oprávnenie upraviť túto rolu."
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:119
 msgid "You do not have permission to send confirmation emails for this enrollment."
-msgstr "Nemáte oprávnění odesílat potvrzovací e-maily k tomuto zápisu."
+msgstr "Nemáte oprávnenie odosielať potvrdzovacie e-maily k tomuto zápisu."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:196
 msgid "You do not have permission to set up calendar events for this evaluation."
-msgstr "Nemáte oprávnění nastavit události v kalendáři pro toto hodnocení."
+msgstr "Nemáte oprávnenie nastaviť udalosti v kalendári pre toto hodnotenie."
 
 #: lms/lms/api.py:1758 lms/lms/api.py:1762
 msgid "You do not have permission to update meta tags."
-msgstr "Nemáte oprávnění aktualizovat meta tagy."
+msgstr "Nemáte oprávnenie aktualizovať metaznačky."
 
 #: lms/lms/api.py:1799
 msgid "You do not have permission to update this submission."
-msgstr "Nemáte oprávnění aktualizovat toto odevzdání."
+msgstr "Nemáte oprávnenie aktualizovať toto odovzdanie."
 
 #: lms/templates/notifications.html:27
 msgid "You don't have any notifications."
-msgstr "Nemáte žádná oznámení."
+msgstr "Nemáte žiadne oznámenia."
 
 #: frontend/src/components/Quiz.vue:367
 msgid "You got {0}% correct answers with a score of {1} out of {2}"
-msgstr "Dosáhli jste {0}% celkové úspěšnosti se skóre {1} z {2}"
+msgstr "Dosiahli ste {0} % celkovej úspešnosti so skóre {1} z {2}"
 
 #: lms/templates/emails/live_class_reminder.html:6
-msgid "You have a live class scheduled tomorrow. Please be prepared and be on time for the session."
-msgstr "Na zítřek máte naplánovanou živou lekci. Připravte se a přijďte včas."
+msgid ""
+"You have a live class scheduled tomorrow. Please be prepared and be on time "
+"for the session."
+msgstr "Na zajtra máte naplánovanú živú lekciu. Pripravte sa a príďte na lekciu včas."
 
 #: lms/job/doctype/lms_job_application/lms_job_application.py:26
 msgid "You have already applied for this job."
-msgstr "O tuto pracovní nabídku jste již požádali."
+msgstr "O túto pracovnú pozíciu ste sa už uchádzali."
 
 #: frontend/src/components/Quiz.vue:119
-msgid "You have already exceeded the maximum number of attempts allowed for this quiz."
-msgstr "Již jste překročili maximální počet pokusů povolený pro tento kvíz."
+msgid ""
+"You have already exceeded the maximum number of attempts allowed for this "
+"quiz."
+msgstr "Už ste prekročili maximálny počet pokusov povolený pre tento kvíz."
 
 #: lms/lms/api.py:211
 msgid "You have already purchased the certificate for this course."
-msgstr "Certifikát k tomuto kurzu jste již zakoupili."
+msgstr "Certifikát k tomuto kurzu ste si už zakúpili."
 
 #: lms/lms/doctype/lms_course_review/lms_course_review.py:22
 msgid "You have already reviewed this course"
-msgstr "Tento kurz jste již ohodnotili"
+msgstr "Tento kurz ste už ohodnotili"
 
 #: frontend/src/pages/JobDetail.vue:68
 msgid "You have applied"
-msgstr "Žádost byla odeslána"
+msgstr "Podali ste žiadosť"
 
 #: frontend/src/pages/Batches/components/BatchOverlay.vue:143
 msgid "You have been enrolled in this batch"
-msgstr "Byli jste zapsáni do tohoto školicího kola"
+msgstr "Boli ste zapísaní do tohto školiaceho kola"
 
 #: frontend/src/components/CourseCardOverlay.vue:191
 msgid "You have been enrolled in this course"
-msgstr "Byli jste zapsáni do tohoto kurzu"
+msgstr "Boli ste zapísaní do tohto kurzu"
 
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py:30
 msgid "You have exceeded the maximum number of attempts ({0}) for this quiz"
-msgstr "Překročili jste maximální počet pokusů ({0}) pro tento kvíz"
+msgstr "Prekročili ste maximálny počet pokusov ({0}) pre tento kvíz"
 
 #: lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.py:56
 msgid "You have got a score of {0} for the quiz {1}"
-msgstr "Za kvíz {1} jste získali skóre {0}"
+msgstr "Za kvíz {1} ste získali skóre {0}"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:220
 msgid "You have not completed the course yet."
-msgstr "Kurz jste ještě nedokončili."
+msgstr "Kurz ste ešte nedokončili."
 
 #: frontend/src/pages/ProfileCertificates.vue:26
 msgid "You have not received any certificates yet."
-msgstr "Zatím jste nezískali žádné certifikáty."
+msgstr "Zatiaľ ste nezískali žiadne certifikáty."
 
 #: lms/lms/widgets/NoPreviewModal.html:12
 msgid ""
-"You have opted to be notified for this course. You will receive an email when the course becomes "
-"available."
+"You have opted to be notified for this course. You will receive an email "
+"when the course becomes available."
 msgstr ""
-"Požádali jste o upozornění na dostupnost tohoto kurzu. Jakmile bude kurz dostupný, obdržíte "
-"e-mail."
+"Požiadali ste o upozornenie na dostupnosť tohto kurzu. Keď bude kurz "
+"dostupný, dostanete e-mail."
 
 #: frontend/src/pages/Home/Home.vue:126 frontend/src/pages/Home/Home.vue:149
 msgid "You have {0} upcoming {1} and {2} {3} scheduled."
-msgstr "Nadcházející: {0}× {1}; naplánováno: {2}× {3}."
+msgstr "Nadchádzajúce: {0}× {1}; naplánované: {2}× {3}."
 
 #: frontend/src/pages/Home/Home.vue:133 frontend/src/pages/Home/Home.vue:156
 msgid "You have {0} upcoming {1}."
-msgstr "Nadcházející: {0}× {1}."
+msgstr "Nadchádzajúce: {0}× {1}."
 
 #: frontend/src/pages/Home/Home.vue:138 frontend/src/pages/Home/Home.vue:161
 msgid "You have {0} {1} scheduled."
-msgstr "Naplánováno: {0}× {1}."
+msgstr "Naplánované: {0}× {1}."
 
 #: lms/lms/doctype/lms_batch_enrollment/lms_batch_enrollment.py:31
 msgid "You must be a Moderator or Batch Evaluator to enroll users in a batch."
 msgstr ""
-"Chcete-li zapisovat uživatele do školicího kola, musíte být moderátor nebo hodnotitel školicího "
-"kola."
+"Ak chcete zapisovať používateľov do školiaceho kola, musíte byť "
+"moderátorom alebo hodnotiteľom školiaceho kola."
+
+
 
 #: lms/lms/doctype/lms_badge_assignment/lms_badge_assignment.py:23
 msgid "You must be an Admin to assign badges to users."
-msgstr "Odznaky může uživatelům přidělovat pouze správce."
+msgstr "Odznaky môže používateľom prideľovať iba správca."
 
 #: lms/lms/doctype/lms_course_review/lms_course_review.py:18
 msgid "You must be enrolled in the course to submit a review"
-msgstr "Pro odeslání recenze musíte být zapsáni do kurzu"
+msgstr "Na odoslanie recenzie musíte byť zapísaní do kurzu"
 
 #: lms/lms/doctype/lms_enrollment/lms_enrollment.py:78
 msgid "You need to complete the payment for this course before enrolling."
-msgstr "Před zápisem do tohoto kurzu musíte dokončit platbu."
+msgstr "Pred zápisom do tohto kurzu musíte dokončiť platbu."
 
 #: frontend/src/components/CourseCardOverlay.vue:174
 msgid "You need to login first to enroll for this course"
-msgstr "Před zápisem do tohoto kurzu se musíte přihlásit"
+msgstr "Pred zápisom do tohto kurzu sa musíte prihlásiť"
 
 #: frontend/src/pages/Home/Streak.vue:14
 msgid "You rock,"
-msgstr "Jste skvělí,"
+msgstr "Ste skvelí,"
 
 #: frontend/src/components/Quiz.vue:21
 msgid "You will have to complete the quiz to continue the video"
-msgstr "Abyste mohli pokračovat ve videu, musíte dokončit kvíz"
+msgstr "Ak chcete pokračovať vo videu, musíte dokončiť kvíz"
 
 #: frontend/src/components/Quiz.vue:51
 msgid "You will have to get {0}% correct answers in order to pass the quiz."
-msgstr "Pro úspěšné absolvování kvízu musíte dosáhnout alespoň {0}% celkové úspěšnosti."
+msgstr "Na úspešné absolvovanie kvízu musíte dosiahnuť aspoň {0} % celkovej úspešnosti."
 
 #: frontend/src/components/Notifications/NotificationPanel.vue:132
 msgid "You're all caught up! Check back later for updates."
-msgstr "Všechno máte přečtené! Novinky se mohou objevit později."
+msgstr "Všetko máte vybavené! Neskôr sa sem vráťte a skontrolujte novinky."
 
 #: lms/templates/emails/batch_start_reminder_recorded.html:6
 msgid ""
-"You're enrolled and all set! The course content is ready, so you can start learning right away "
-"and go at your own pace."
+"You're enrolled and all set! The course content is ready, so you can start "
+"learning right away and go at your own pace."
 msgstr ""
-"Jste zapsáni a vše je připraveno! Obsah kurzu je dostupný, takže můžete začít ihned a postupovat "
-"vlastním tempem."
+"Ste zapísaní a všetko je pripravené! Obsah kurzu je dostupný, takže sa "
+"môžete začať učiť ihneď a postupovať vlastným tempom."
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:475
 msgid "You're enrolled in {0} – start whenever you're ready"
-msgstr "Jste zapsáni do {0} – začněte, až budete připraveni"
+msgstr "Ste zapísaní do {0} – začnite, keď budete pripravení"
 
 #: lms/templates/emails/mentor_request_creation_email.html:4
-msgid "You've applied to become a mentor for this course. Your request is currently under review."
-msgstr "Požádali jste o roli mentora tohoto kurzu. Vaše žádost se právě kontroluje."
+msgid ""
+"You've applied to become a mentor for this course. Your request is currently"
+" under review."
+msgstr "Požiadali ste o rolu mentora tohto kurzu. Vaša žiadosť sa práve posudzuje."
 
 #: frontend/src/components/Assignment.vue:64
 msgid "You've successfully submitted the assignment."
-msgstr "Úkol jste úspěšně odevzdali."
+msgstr "Úlohu ste úspešne odovzdali."
 
 #. Label of the youtube (Data) field in DocType 'Course Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "YouTube Video URL"
-msgstr "Adresa URL videa na YouTube"
+msgstr "URL videa na YouTube"
 
 #. Description of the 'YouTube Video URL' (Data) field in DocType 'Course
 #. Lesson'
 #: lms/lms/doctype/course_lesson/course_lesson.json
 msgid "YouTube Video will appear at the top of the lesson."
-msgstr "Video z YouTube se zobrazí v horní části lekce."
+msgstr "Video z YouTube sa zobrazí v hornej časti lekcie."
 
 #: frontend/src/components/Controls/VideoPreviewField.vue:104
 msgid ""
-"YouTube link added — students see it embedded on the course page. Clear the field to upload a "
-"file instead."
+"YouTube link added — students see it embedded on the course page. Clear the "
+"field to upload a file instead."
 msgstr ""
-"Odkaz na YouTube byl přidán — studenti uvidí video vložené na stránce kurzu. Chcete-li místo něj "
-"nahrát soubor, pole vymažte."
+"Odkaz na YouTube bol pridaný — študenti uvidia video vložené na stránke "
+"kurzu. Ak chcete namiesto neho nahrať súbor, pole vymažte."
 
 #: lms/www/new-sign-up.html:56
 msgid "Your Account has been successfully created!"
-msgstr "Váš účet byl úspěšně vytvořen!"
+msgstr "Váš účet bol úspešne vytvorený!"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue:124
 msgid "Your Output"
@@ -9529,65 +9702,71 @@ msgstr "Váš výstup"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:472
 msgid "Your batch {0} is starting tomorrow"
-msgstr "Vaše školicí kolo {0} začíná zítra"
+msgstr "Vaše školiace kolo {0} sa začína zajtra"
 
 #: frontend/src/components/Controls/Uploader.vue:26
 msgid "Your browser does not support the video tag."
-msgstr "Váš prohlížeč nepodporuje přehrávání tohoto videa."
+msgstr "Váš prehliadač nepodporuje prehrávanie tohto videa."
 
 #: frontend/src/pages/ProfileEvaluator.vue:143
 msgid "Your calendar is set."
-msgstr "Váš kalendář je nastaven."
+msgstr "Váš kalendár je nastavený."
 
 #: lms/lms/doctype/lms_live_class/lms_live_class.py:173
 msgid "Your class on {0} is today"
-msgstr "Vaše lekce {0} je dnes"
+msgstr "Vaša lekcia {0} je dnes"
 
 #: frontend/src/components/Modals/EmailTemplateModal.vue:32
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateAdd.vue:30
 #: frontend/src/components/Settings/EmailTemplate/EmailTemplateEdit.vue:28
 msgid "Your enrollment in {{ batch_name }} is confirmed"
-msgstr "Váš zápis do školicího kola {{ batch_name }} je potvrzen"
+msgstr "Váš zápis do školiaceho kola {{ batch_name }} je potvrdený"
 
 #: lms/templates/emails/certificate_request_notification.html:3
-msgid "Your evaluation for the course {0} has been scheduled on {1} at {2} ({3} time)."
-msgstr "Vaše hodnocení pro kurz {0} bylo naplánováno na {1} v {2} (časové pásmo {3})."
+msgid ""
+"Your evaluation for the course {0} has been scheduled on {1} at {2} ({3} "
+"time)."
+msgstr ""
+"Vaše hodnotenie pre kurz {0} bolo naplánované na {1} o {2} (časové pásmo "
+"{3})."
 
 #: lms/lms/notification/certificate_request_reminder/certificate_request_reminder.html:3
 msgid "Your evaluation for the course {0} has been scheduled on {1} at {2} {3}."
-msgstr "Vaše hodnocení pro kurz {0} bylo naplánováno na {1} v {2} {3}."
+msgstr "Vaše hodnotenie pre kurz {0} bolo naplánované na {1} o {2} {3}."
 
 #: lms/lms/doctype/lms_certificate_request/lms_certificate_request.py:142
 msgid "Your evaluation slot has been booked"
-msgstr "Termín vašeho hodnocení byl rezervován"
+msgstr "Termín vášho hodnotenia bol rezervovaný"
 
 #: lms/templates/emails/certificate_request_notification.html:5
 msgid "Your evaluator is {0}"
-msgstr "Vaším hodnotitelem je {0}"
+msgstr "Vaším hodnotiteľom je {0}"
 
 #: frontend/src/pages/Home/Streak.vue:49
 msgid ""
-"Your learning streak counts the number of days in a row you’ve kept up your learning, whether "
-"it’s a lesson, quiz, or assignment. Don’t worry, weekends don’t break your streak."
+"Your learning streak counts the number of days in a row you’ve kept up your "
+"learning, whether it’s a lesson, quiz, or assignment. Don’t worry, weekends "
+"don’t break your streak."
 msgstr ""
-"Vaše studijní série počítá počet po sobě jdoucích dnů, během kterých jste se věnovali studiu – ať"
-" už lekci, kvízu nebo úkolu. Nemusíte se bát, víkendy sérii nepřeruší."
+"Vaša študijná séria vyjadruje počet po sebe nasledujúcich dní, počas ktorých"
+" ste sa učili — či už ste absolvovali lekciu, kvíz alebo úlohu. Nemusíte sa "
+"obávať, víkendy vašu sériu neprerušia."
 
 #: lms/templates/emails/mentor_request_status_update_email.html:4
 msgid "Your request to join us as a mentor for the course"
-msgstr "Vaše žádost o roli mentora v kurzu"
+msgstr "Vaša žiadosť stať sa mentorom kurzu"
 
 #: frontend/src/components/Quiz.vue:360
 msgid ""
-"Your submission has been successfully saved. The instructor will review and grade it shortly, and"
-" you'll be notified of your final result."
+"Your submission has been successfully saved. The instructor will review and "
+"grade it shortly, and you'll be notified of your final result."
 msgstr ""
-"Vaše odevzdání bylo úspěšně uloženo. Lektor ho brzy zkontroluje a oznámkuje a o konečném výsledku"
-" budete informováni."
+"Vaše odovzdanie bolo úspešne uložené. Lektor ho čoskoro skontroluje a "
+"ohodnotí a o konečnom výsledku dostanete oznámenie."
 
 #: frontend/src/pages/Lesson.vue:9 frontend/src/pages/Lesson.vue:128
 msgid "Zen Mode"
-msgstr "Režim soustředění"
+msgstr "Režim sústredenia"
 
 #. Option for the 'Conferencing Provider' (Select) field in DocType 'LMS Batch'
 #. Option for the 'Conferencing Provider' (Select) field in DocType 'LMS Live
@@ -9608,24 +9787,24 @@ msgstr "Účet Zoom"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:163
 msgid "Zoom Account created successfully"
-msgstr "Účet Zoom byl úspěšně vytvořen"
+msgstr "Účet Zoom bol úspešne vytvorený"
 
 #: frontend/src/components/Settings/ZoomAccountForm.vue:201
 msgid "Zoom Account updated successfully"
-msgstr "Účet Zoom byl úspěšně aktualizován"
+msgstr "Účet Zoom bol úspešne aktualizovaný"
 
 #. Name of a DocType
 #: lms/lms/doctype/zoom_settings/zoom_settings.json
 msgid "Zoom Settings"
-msgstr "Nastavení Zoomu"
+msgstr "Nastavenia Zoomu"
 
 #: frontend/src/components/Settings/ZoomSettings.vue:161
 msgid "Zoom account deleted successfully"
-msgstr "Účet Zoom byl úspěšně smazán"
+msgstr "Účet Zoom bol úspešne odstránený"
 
 #: frontend/src/components/StudentHeatmap.vue:6
 msgid "activities"
-msgstr "aktivit"
+msgstr "aktivít"
 
 #: frontend/src/components/StudentHeatmap.vue:6
 msgid "activity"
@@ -9638,15 +9817,15 @@ msgstr "a"
 
 #: frontend/src/components/InstallPrompt.vue:53
 msgid "and then 'Add to Home Screen'"
-msgstr "a poté „Přidat na plochu“"
+msgstr "a potom „Pridať na plochu“"
 
 #: frontend/src/components/JobCard.vue:26 frontend/src/pages/JobDetail.vue:127
 msgid "applicant"
-msgstr "uchazeč"
+msgstr "uchádzač"
 
 #: frontend/src/components/JobCard.vue:26 frontend/src/pages/JobDetail.vue:127
 msgid "applicants"
-msgstr "uchazeči"
+msgstr "uchádzači"
 
 #: frontend/src/components/VideoBlock.vue:15
 msgid "at {0} minutes"
@@ -9654,11 +9833,11 @@ msgstr "v čase {0} min"
 
 #: lms/templates/emails/payment_reminder.html:4
 msgid "but didn’t complete your payment"
-msgstr "ale nedokončili jste platbu"
+msgstr "ale nedokončili ste platbu"
 
 #: lms/templates/emails/mentor_request_creation_email.html:5
 msgid "cancel your application"
-msgstr "zrušit svou žádost"
+msgstr "zrušiť svoju žiadosť"
 
 #: frontend/src/pages/CertifiedParticipants.vue:102
 msgid "certificate"
@@ -9674,7 +9853,7 @@ msgstr "certifikáty"
 #: frontend/src/pages/Programs/ProgramDetail.vue:14
 #: frontend/src/pages/Programs/StudentPrograms.vue:44
 msgid "completed"
-msgstr "dokončeno"
+msgstr "dokončené"
 
 #: frontend/src/pages/Programs/StudentPrograms.vue:29
 msgid "course"
@@ -9682,11 +9861,11 @@ msgstr "kurz"
 
 #: lms/lms/api.py:1117
 msgid "course must be a string"
-msgstr "Hodnota „course“ musí být řetězec"
+msgstr "Hodnota „course“ musí byť reťazec"
 
 #: frontend/src/components/CourseReviews.vue:10
 msgid "course rating"
-msgstr "hodnocení kurzu"
+msgstr "hodnotenie kurzu"
 
 #: frontend/src/pages/Programs/StudentPrograms.vue:29
 msgid "courses"
@@ -9694,11 +9873,11 @@ msgstr "kurzy"
 
 #: lms/lms/email_account.py:60
 msgid "data must be an object"
-msgstr "Hodnota „data“ musí být objekt"
+msgstr "Hodnota „data“ musí byť objekt"
 
 #: frontend/src/components/CourseReviews.vue:187
 msgid "day ago"
-msgstr "den zpět"
+msgstr "deň dozadu"
 
 #: frontend/src/pages/Home/Streak.vue:19
 msgid "day streak"
@@ -9710,31 +9889,31 @@ msgstr "dní"
 
 #: frontend/src/components/CourseReviews.vue:187
 msgid "days ago"
-msgstr "dní zpět"
+msgstr "dní dozadu"
 
 #: frontend/src/components/Settings/Badges/BadgeForm.vue:28
 msgid "e.g. Course Champion"
-msgstr "např. Hvězda kurzu"
+msgstr "napr. Hviezda kurzu"
 
 #: frontend/src/components/Settings/Coupons/CouponDetails.vue:32
 msgid "e.g. WELCOME10"
-msgstr "např. VITEJTE10"
+msgstr "napr. VITAJTE10"
 
 #: frontend/src/components/CourseCardOverlay.vue:101
 msgid "enrolled"
-msgstr "zapsaných"
+msgstr "zapísaných"
 
 #: frontend/src/pages/Home/Home.vue:124 frontend/src/pages/Home/Home.vue:147
 msgid "evaluation"
-msgstr "hodnocení"
+msgstr "hodnotenie"
 
 #: frontend/src/pages/Home/Home.vue:124 frontend/src/pages/Home/Home.vue:147
 msgid "evaluations"
-msgstr "hodnocení"
+msgstr "hodnotenia"
 
 #: lms/lms/doctype/course_lesson/course_lesson.py:169
 msgid "file_url must be a string"
-msgstr "Hodnota „file_url“ musí být řetězec"
+msgstr "Hodnota „file_url“ musí byť reťazec"
 
 #: lms/templates/emails/mentor_request_status_update_email.html:4
 msgid "has been"
@@ -9742,11 +9921,11 @@ msgstr "má stav"
 
 #: frontend/src/components/Settings/EmailAccount/EmailAdd.vue:43
 msgid "here"
-msgstr "zde"
+msgstr "tu"
 
 #: frontend/src/components/StudentHeatmap.vue:8
 msgid "in the last"
-msgstr "za posledních"
+msgstr "za posledných"
 
 #: lms/templates/signup-form.html:12
 msgid "jane@example.com"
@@ -9754,20 +9933,20 @@ msgstr "jane@example.com"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:208
 msgid "lesson"
-msgstr "lekce"
+msgstr "lekcia"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:208
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:60
 msgid "lessons"
-msgstr "lekce"
+msgstr "lekcie"
 
 #: frontend/src/pages/Home/Home.vue:122 frontend/src/pages/Home/Home.vue:146
 msgid "live class"
-msgstr "živá lekce"
+msgstr "živá lekcia"
 
 #: frontend/src/pages/Home/Home.vue:122 frontend/src/pages/Home/Home.vue:146
 msgid "live classes"
-msgstr "živé lekce"
+msgstr "živé lekcie"
 
 #: frontend/src/pages/Programs/Programs.vue:73
 #: frontend/src/pages/Programs/StudentPrograms.vue:36
@@ -9777,23 +9956,23 @@ msgstr "člen"
 #: frontend/src/pages/Programs/Programs.vue:73
 #: frontend/src/pages/Programs/StudentPrograms.vue:36
 msgid "members"
-msgstr "členové"
+msgstr "členovia"
 
 #: frontend/src/components/Modals/LiveClassAttendance.vue:55
 msgid "minutes"
-msgstr "minut"
+msgstr "minút"
 
 #: frontend/src/components/CourseReviews.vue:183
 msgid "month ago"
-msgstr "měsíc zpět"
+msgstr "mesiac dozadu"
 
 #: frontend/src/components/CourseReviews.vue:183
 msgid "months ago"
-msgstr "měsíců zpět"
+msgstr "mesiacov dozadu"
 
 #: lms/lms/api.py:1119
 msgid "name must be a string"
-msgstr "Hodnota „name“ musí být řetězec"
+msgstr "Hodnota „name“ musí byť reťazec"
 
 #: frontend/src/pages/Assignments.vue:136
 #: frontend/src/pages/CertifiedParticipants.vue:138
@@ -9809,7 +9988,7 @@ msgstr "ostatní"
 
 #: frontend/src/pages/LessonForm.vue:50
 msgid "private"
-msgstr "soukromá"
+msgstr "súkromná"
 
 #: frontend/src/pages/QuizForm.vue:442
 msgid "question_detail"
@@ -9817,80 +9996,80 @@ msgstr "podrobnosti otázky"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:75
 msgid "rating"
-msgstr "hodnocení"
+msgstr "hodnotenie"
 
 #: frontend/src/components/Settings/Categories.vue:9
 msgid "saving..."
-msgstr "ukládání…"
+msgstr "ukladá sa…"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:202
 msgid "section"
-msgstr "sekce"
+msgstr "sekcia"
 
 #: frontend/src/pages/Courses/CourseOverview.vue:202
 msgid "sections"
-msgstr "sekce"
+msgstr "sekcie"
 
 #: lms/lms/email_account.py:63
 msgid "service must be a string"
-msgstr "Hodnota „service“ musí být řetězec"
+msgstr "Hodnota „service“ musí byť reťazec"
 
 #: frontend/src/pages/Programs/ProgramEnrollment.vue:67
 msgid "students"
-msgstr "studenti"
+msgstr "študenti"
 
 #: lms/templates/emails/published_batch_notification.html:7
 #: lms/templates/emails/published_course_notification.html:7
 msgid "that might interest you!"
-msgstr "– možná vás zaujme!"
+msgstr "– možno vás zaujme!"
 
 #: lms/lms/api.py:1115
 msgid "title must be a string"
-msgstr "Hodnota „title“ musí být řetězec"
+msgstr "Hodnota „title“ musí byť reťazec"
 
 #: frontend/src/components/CommandPalette/CommandPalette.vue:59
 msgid "to close"
-msgstr "pro zavření"
+msgstr "na zatvorenie"
 
 #: frontend/src/components/CommandPalette/CommandPalette.vue:45
 msgid "to navigate"
-msgstr "pro pohyb"
+msgstr "na navigáciu"
 
 #: frontend/src/components/CommandPalette/CommandPalette.vue:53
 msgid "to select"
-msgstr "pro výběr"
+msgstr "na výber"
 
 #: frontend/src/pages/Batches/components/BatchFeedback.vue:33
 msgid "to view your feedback."
-msgstr "a zobrazte svou zpětnou vazbu."
+msgstr "a zobrazte si svoju spätnú väzbu."
 
 #: lms/lms/api.py:1650
 msgid "user must be a string"
-msgstr "Hodnota „user“ musí být řetězec"
+msgstr "Hodnota „user“ musí byť reťazec"
 
 #: frontend/src/components/CourseReviews.vue:14
 msgid "user rating"
-msgstr "uživatelské hodnocení"
+msgstr "používateľské hodnotenie"
 
 #: frontend/src/components/CourseReviews.vue:15
 msgid "user ratings"
-msgstr "uživatelská hodnocení"
+msgstr "používateľské hodnotenia"
 
 #: frontend/src/components/StudentHeatmap.vue:10
 msgid "weeks"
-msgstr "týdnů"
+msgstr "týždňov"
 
 #: lms/templates/emails/mentor_request_creation_email.html:5
 msgid "you can"
-msgstr "můžete"
+msgstr "môžete"
 
 #: frontend/src/pages/Assignments.vue:30
 msgid "{0} Assignments"
-msgstr "Úkoly: {0}"
+msgstr "Úlohy: {0}"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExercises.vue:43
 msgid "{0} Exercises"
-msgstr "Cvičení: {0}"
+msgstr "Cvičenia: {0}"
 
 #: frontend/src/pages/Quizzes.vue:21
 msgid "{0} Quizzes"
@@ -9898,111 +10077,111 @@ msgstr "Kvízy: {0}"
 
 #: lms/lms/api.py:906 lms/lms/api.py:914
 msgid "{0} Settings not found"
-msgstr "Nastavení {0} nebylo nalezeno"
+msgstr "Nastavenia {0} sa nenašli"
 
 #: frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmissions.vue:12
 msgid "{0} Submissions"
-msgstr "Odevzdání: {0}"
+msgstr "Odovzdania: {0}"
 
 #: lms/templates/emails/job_application.html:2
 msgid "{0} has applied for the job position {1}"
-msgstr "{0} se uchází o pracovní pozici {1}"
+msgstr "{0} sa uchádza o pracovnú pozíciu {1}"
 
 #: lms/lms/doctype/lms_batch/lms_batch.py:215
 msgid "{0} has published a new batch {1}"
-msgstr "{0} zveřejnil(a) nové školicí kolo {1}"
+msgstr "{0} zverejnil(a) nové školiace kolo {1}"
 
 #: lms/lms/doctype/lms_course/lms_course.py:209
 msgid "{0} has published a new course {1}"
-msgstr "{0} zveřejnil(a) nový kurz {1}"
+msgstr "{0} zverejnil(a) nový kurz {1}"
 
 #: lms/templates/emails/job_report.html:4
 msgid "{0} has reported a job post for the following reason."
-msgstr "{0} nahlásil(a) pracovní nabídku z následujícího důvodu."
+msgstr "{0} nahlásil(a) pracovnú ponuku z nasledujúceho dôvodu."
 
 #: lms/templates/emails/assignment_submission.html:2
 msgid "{0} has submitted the assignment {1}"
-msgstr "{0} odevzdal(a) úkol {1}"
+msgstr "{0} odovzdal(a) úlohu {1}"
 
 #: lms/lms/doctype/lms_course_mentor_mapping/lms_course_mentor_mapping.py:15
 msgid "{0} is already a mentor for course {1}"
-msgstr "{0} již je mentorem kurzu {1}"
+msgstr "{0} už je mentorom kurzu {1}"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:134
 msgid "{0} is already certified for the batch {1}"
-msgstr "{0} již má certifikát pro školicí kolo {1}"
+msgstr "{0} už má certifikát pre školiace kolo {1}"
 
 #: lms/lms/doctype/lms_certificate/lms_certificate.py:115
 msgid "{0} is already certified for the course {1}"
-msgstr "{0} již má certifikát pro kurz {1}"
+msgstr "{0} už má certifikát pre kurz {1}"
 
 #: lms/lms/notification/certificate_request_reminder/certificate_request_reminder.html:5
 msgid "{0} is your evaluator"
-msgstr "{0} je váš hodnotitel"
+msgstr "{0} je váš hodnotiteľ"
 
 #: lms/lms/utils.py:562
 msgid "{0} mentioned you in a comment"
-msgstr "{0} vás zmínil(a) v komentáři"
+msgstr "{0} vás spomenul(a) v komentári"
 
 #: lms/templates/emails/mention_template.html:2
 msgid "{0} mentioned you in a comment in your batch."
-msgstr "{0} vás zmínil(a) v komentáři ve vašem školicím kole."
+msgstr "{0} vás spomenul(a) v komentári vo vašom školiacom kole."
 
 #: lms/lms/utils.py:515 lms/lms/utils.py:521
 msgid "{0} mentioned you in a comment in {1}"
-msgstr "{0} vás zmínil(a) v komentáři v položce {1}"
+msgstr "{0} vás spomenul(a) v komentári k položke {1}"
 
 #: lms/lms/email_account.py:69
 msgid "{0} must be a string"
-msgstr "Hodnota {0} musí být řetězec"
+msgstr "Hodnota {0} musí byť reťazec"
 
 #: lms/lms/api.py:968
 msgid "{0} not found"
-msgstr "{0} nebylo nalezeno"
+msgstr "{0} sa nenašlo"
 
 #: frontend/src/components/Discussions.vue:52
 msgid "{0} replies"
-msgstr "Odpovědi: {0}"
+msgstr "{0} odpovedí"
 
 #: frontend/src/components/Discussions.vue:51
 msgid "{0} reply"
-msgstr "Odpovědi: {0}"
+msgstr "{0} odpoveď"
 
 #: frontend/src/pages/Jobs.vue:36
 msgid "{0} {1} Jobs"
-msgstr "Pracovní nabídky ({1}): {0}"
+msgstr "Pracovné ponuky ({1}): {0}"
 
 #: frontend/src/components/Questionnaire.vue:144
 #: frontend/src/pages/PersonaForm.vue:100
 msgid "{0}% complete"
-msgstr "Dokončeno: {0}% celkového rozsahu"
+msgstr "Dokončené: {0} % celkovo"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Active"
-msgstr "Aktivní: {}"
+msgstr "Aktívne: {}"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Completed"
-msgstr "Dokončeno: {}"
+msgstr "Dokončené: {}"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Enrolled"
-msgstr "Zapsáno: {}"
+msgstr "Zapísaných: {}"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Granted"
-msgstr "Uděleno: {}"
+msgstr "Udelené: {}"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Passed"
-msgstr "Úspěšně absolvováno: {}"
+msgstr "Úspešne absolvované: {}"
 
 #. Count format of shortcut in the Learning Workspace
 #: lms/lms/workspace/learning/learning.json
 msgid "{} Published"
-msgstr "Zveřejněno: {}"
+msgstr "Zverejnené: {}"


### PR DESCRIPTION
This PR completes and contextually reviews the Czech (cs_CZ) translation catalog and adds full Slovak (sk_SK) language support for Frappe LMS.

- Updated Czech entries: added translations for previously untranslated strings and corrected existing translations.
- Added Slovak translations for all entries.
- All Czech and Slovak translations were completed and reviewed by a native speaker of both languages (me).
- Corrected inaccurate or misleading Czech UI terminology, including:

Check: Zkontrolovat instead of Zaškrtávací pole
Batch: Školicí kola
Assignments: Úkoly
Medium: Forma výuky
Change: Změnit instead of Mince
Free: Zdarma
Open as a status: Otevřeno

- Go preserved as the programming language name
- Improved grammar, wording, capitalization, action labels, status labels, and terminology across quizzes, courses, batches, jobs, billing, settings, profiles, and email templates.
- Used neutral wording for shared source strings that appear in different contexts, such as Apply / Pokračovat in Czech and Pokračovať in Slovak.
- Preserved all placeholders and formatting, including {0}, {{ ... }}, HTML markup, whitespace, and line breaks.
