### PR TITLE
fix(preview): give the preview video a fixed aspect box

### DIFF
--- a/frontend/src/components/VideoPreview.vue
+++ b/frontend/src/components/VideoPreview.vue
@@ -1,24 +1,29 @@
 <template>
-	<iframe
-		v-if="videoPreview.type === 'youtube'"
-		:src="videoPreview.src"
-		:title="__('Video preview')"
-		class="min-h-56 w-full rounded-t-md"
-		allowfullscreen
-	/>
-	<video
-		v-else-if="videoPreview.type === 'file' && !videoError"
-		:src="videoPreview.src"
-		controls
-		class="min-h-56 w-full rounded-t-md bg-black object-contain"
-		@error="videoError = true"
-	/>
-	<img
-		v-else-if="videoPreview.type === 'file' && videoError && fallbackImage"
-		:src="fallbackImage"
-		:alt="__('Video preview')"
-		class="min-h-56 w-full rounded-t-md object-cover"
-	/>
+	<div
+		v-if="hasPreview"
+		class="aspect-[750/422] w-full overflow-hidden rounded-t-md bg-black"
+	>
+		<iframe
+			v-if="videoPreview.type === 'youtube'"
+			:src="videoPreview.src"
+			:title="__('Video preview')"
+			class="size-full"
+			allowfullscreen
+		/>
+		<video
+			v-else-if="videoPreview.type === 'file' && !videoError"
+			:src="videoPreview.src"
+			controls
+			class="size-full object-contain"
+			@error="videoError = true"
+		/>
+		<img
+			v-else-if="fallbackImage"
+			:src="fallbackImage"
+			:alt="__('Video preview')"
+			class="size-full object-cover"
+		/>
+	</div>
 </template>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
@@ -37,6 +42,16 @@ const videoPreview = computed(() => getVideoPreview(props.videoLink))
 
 // Reset the in-browser playback error whenever the source changes.
 const videoError = ref(false)
+
+// The preview box keeps a fixed 750/422 ratio (same as the thumbnail fields), so
+// a portrait source letterboxes instead of stretching the card. Render nothing
+// at all when there is no playable source and no poster to fall back to.
+const hasPreview = computed(() => {
+	if (videoPreview.value.type === 'youtube') return true
+	if (videoPreview.value.type !== 'file') return false
+	return !videoError.value || !!props.fallbackImage
+})
+
 watch(
 	() => props.videoLink,
 	() => {


### PR DESCRIPTION
The preview video had no height and no aspect ratio, so it sized itself from the source's intrinsic ratio: a portrait upload stretched the batch and course cards to ~2x their intended height. The YouTube branch had the inverse problem, since an <iframe> has no intrinsic ratio and always collapsed to the min-h-56 floor.

Wrap all three branches in a fixed aspect-[750/422] box, the ratio the thumbnail fields already use, and let the media object-contain inside it.