### PR TITLE
fix: close the race in create_certificate that lets duplicate certificates through

### DIFF
--- a/lms/install.py
+++ b/lms/install.py
@@ -10,6 +10,7 @@ def after_install():
 	give_user_list_permission()
 	give_event_permission()
 	ensure_batch_enrollment_index()
+	ensure_certificate_unique_constraint()
 
 
 def ensure_batch_enrollment_index():
@@ -17,6 +18,15 @@ def ensure_batch_enrollment_index():
 	if not frappe.db.table_exists("LMS Batch Enrollment"):
 		return
 	frappe.db.add_index("LMS Batch Enrollment", ["batch", "member"])
+
+
+def ensure_certificate_unique_constraint():
+	"""Add the (member, course, batch_name) unique constraint on fresh installs, which
+	skip the delete_duplicate_certificates patch that adds it; idempotent. Nothing to
+	dedupe here since the table is empty on a fresh install."""
+	if not frappe.db.table_exists("LMS Certificate"):
+		return
+	frappe.db.add_unique("LMS Certificate", ["member", "course", "batch_name"])
 
 
 def after_sync():

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -182,7 +182,18 @@ def create_certificate(course: str):
 				"template": default_certificate_template,
 			}
 		)
-		certificate.save(ignore_permissions=True)
+		try:
+			certificate.save(ignore_permissions=True)
+		except frappe.UniqueValidationError:
+			# Someone else's request for the same member+course won the race and
+			# committed between our is_certified() check above and this save().
+			# The unique constraint on (member, course, batch_name) is what
+			# actually stops the duplicate; hand back whatever it just certified
+			# instead of surfacing a "must be unique" error over a double click.
+			existing = is_certified(course)
+			return frappe.db.get_value(
+				"LMS Certificate", existing, ["name", "course", "template"], as_dict=True
+			)
 		return certificate
 
 

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -12,6 +12,14 @@ from frappe.utils.telemetry import capture
 
 class LMSCertificate(Document):
 	def validate(self):
+		# A certificate is earned via a course OR a batch, and whichever one
+		# doesn't apply is never set - which, on a plain frappe.get_doc() that
+		# never touches it, means None (SQL NULL), not "". The unique
+		# constraint below relies on both being consistently "" instead: two
+		# rows with course=NULL are not duplicates as far as a unique index is
+		# concerned, no matter what member or batch_name they share.
+		self.course = self.course or ""
+		self.batch_name = self.batch_name or ""
 		self.validate_criteria()
 		self.validate_duplicate_certificate()
 
@@ -164,6 +172,14 @@ def is_certified(course):
 
 @frappe.whitelist()
 def create_certificate(course: str):
+	# Locks the course row before the check below, so two requests for the same
+	# member+course cannot both read is_certified() as "not yet" and both go on
+	# to create one - same shape as the course lock enroll_in_course() takes
+	# (lms/lms/utils.py) before its own duplicate-enrollment check. The unique
+	# constraint on (member, course, batch_name) is the backstop for whatever
+	# creates a certificate without going through this function.
+	frappe.db.get_value("LMS Course", course, "name", for_update=True)
+
 	certificate = is_certified(course)
 	if certificate:
 		return frappe.db.get_value(

--- a/lms/lms/doctype/lms_certificate/test_lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/test_lms_certificate.py
@@ -1,15 +1,27 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import frappe
 
-from lms.lms.doctype.lms_certificate.lms_certificate import create_certificate
+from lms.lms.doctype.lms_certificate.lms_certificate import LMSCertificate, create_certificate
 from lms.lms.test_helpers import BaseTestUtils
 
 
 class TestLMSCertificate(BaseTestUtils):
+	"""create_certificate() checks is_certified() and only inserts if that comes
+	back empty - a doubled click on "Get Certificate" is enough for two requests
+	to both read "not certified yet" before either one's insert has committed
+	(#2408). Locking the course row before that check, the same way
+	enroll_in_course() locks it before its own duplicate-enrollment check
+	(lms/lms/utils.py), makes the second request wait for the first to commit
+	rather than racing it. The unique constraint on (member, course,
+	batch_name) is the backstop for whatever creates a certificate without
+	going through create_certificate() at all.
+	"""
+
 	def setUp(self):
 		super().setUp()
 		self._setup_course_flow()
@@ -20,41 +32,132 @@ class TestLMSCertificate(BaseTestUtils):
 		super().tearDown()
 
 	def test_create_certificate_is_idempotent(self):
-		"""Calling create_certificate twice in a row for the same member and
-		course should hand back the same certificate the second time, not
-		create a second one."""
+		# student1 is already certified for self.course via _setup_course_flow();
+		# use student2, who is enrolled and complete but not yet certified.
 		frappe.session.user = self.student2.email
 
 		first = create_certificate(self.course.name)
 		second = create_certificate(self.course.name)
 
 		self.assertEqual(first.name, second.name)
-		self.assertEqual(
-			frappe.db.count("LMS Certificate", {"member": self.student2.email, "course": self.course.name}),
-			1,
+		self.assertEqual(self._certificate_count(self.student2.email), 1)
+
+	def test_create_certificate_locks_the_course_before_checking(self):
+		"""A lock taken after the read is no lock at all, so the order is the
+		assertion - same shape as test_course_enrollment_locks_the_course_before_reading
+		in tests/test_enrollment_races.py."""
+		frappe.session.user = self.student2.email
+		log = []
+		with self._logging_db(log):
+			create_certificate(self.course.name)
+		self.assertIn(("lock", "LMS Course"), log, f"no FOR UPDATE on LMS Course: {log}")
+		self.assertIn(("read", "LMS Certificate"), log)
+		self.assertLess(
+			log.index(("lock", "LMS Course")),
+			log.index(("read", "LMS Certificate")),
+			f"read LMS Certificate before locking LMS Course: {log}",
 		)
 
+	def test_duplicate_certificate_is_refused_by_the_database(self):
+		"""Bypasses both is_certified() and the controller's own duplicate check
+		(validate_duplicate_certificate) - what's left standing between two
+		certificates for the same member+course is the unique constraint alone.
+		Same shape as test_duplicate_batch_enrollment_is_refused_by_the_database
+		in tests/test_enrollment_races.py."""
+		frappe.session.user = self.student2.email
+		with patch.object(LMSCertificate, "validate_duplicate_certificate"):
+			self._insert_certificate()
+			with self.assertRaises(frappe.UniqueValidationError):
+				self._insert_certificate()
+
+	def test_the_controller_check_still_reports_the_friendly_error(self):
+		"""The constraint is a backstop, not a replacement: an ordinary sequential
+		duplicate - no race, nothing patched out - must still get the readable
+		validate_duplicate_certificate() message rather than a database error."""
+		frappe.session.user = self.student2.email
+		self._insert_certificate()
+		with self.assertRaises(frappe.ValidationError) as caught:
+			self._insert_certificate()
+		self.assertNotIsInstance(caught.exception, frappe.UniqueValidationError)
+
 	def test_create_certificate_survives_a_lost_race(self):
-		"""https://github.com/frappe/lms/issues/2408 - two concurrent requests
-		for the same member+course can both pass the is_certified() check
-		before either one's insert has committed, since nothing locks between
-		the two. Force that window here by making is_certified() report "not
-		certified yet" on the second call even though the first call's
-		certificate already made it into the database. With the unique
-		constraint on (member, course, batch_name) in place, that second
-		insert should come back as a UniqueValidationError, which
-		create_certificate now catches and turns into the certificate the
-		first call already created - not an error, and not a second row.
-		"""
+		"""Simulates two requests landing close enough together that both pass
+		is_certified() before either commits: force that window by patching
+		is_certified() to keep saying "not certified yet" on the second call,
+		and by patching out validate_duplicate_certificate() the same way
+		test_duplicate_certificate_is_refused_by_the_database does, since a real
+		concurrent request would not see the first request's uncommitted row
+		either. What's left to stop the second insert is the unique constraint,
+		which create_certificate() now catches and turns into the certificate
+		the first call already created - not an error, and not a second row."""
 		frappe.session.user = self.student2.email
 
 		first = create_certificate(self.course.name)
 
-		with patch("lms.lms.doctype.lms_certificate.lms_certificate.is_certified", return_value=None):
+		# First call (the top-level is_certified() check) reports "not
+		# certified yet"; second call (create_certificate's own recovery,
+		# after the forced UniqueValidationError below) reports the real
+		# certificate the first create_certificate() call already made -
+		# a fresh, unmocked is_certified() would see the same thing by then,
+		# since it's genuinely committed at that point.
+		with (
+			patch(
+				"lms.lms.doctype.lms_certificate.lms_certificate.is_certified",
+				side_effect=[None, first.name],
+			),
+			patch.object(LMSCertificate, "validate_duplicate_certificate"),
+		):
 			second = create_certificate(self.course.name)
 
 		self.assertEqual(first.name, second.name)
-		self.assertEqual(
-			frappe.db.count("LMS Certificate", {"member": self.student2.email, "course": self.course.name}),
-			1,
+		self.assertEqual(self._certificate_count(self.student2.email), 1)
+
+	def test_blank_course_and_batch_name_are_normalized_before_saving(self):
+		"""The unique constraint is on (member, course, batch_name), and a
+		course-only certificate's batch_name (or a batch-only one's course)
+		would otherwise save as SQL NULL rather than "" - which the constraint
+		would not treat as equal to another NULL, silently defeating it for
+		exactly the rows it exists to protect (see delete_duplicate_certificates.py)."""
+		frappe.session.user = self.student2.email
+		certificate = self._insert_certificate()
+		self.assertEqual(certificate.batch_name, "")
+
+	def _certificate_count(self, member):
+		return frappe.db.count("LMS Certificate", {"member": member, "course": self.course.name})
+
+	def _insert_certificate(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "LMS Certificate",
+				"member": frappe.session.user,
+				"course": self.course.name,
+				"issue_date": frappe.utils.nowdate(),
+			}
 		)
+		doc.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Certificate", doc.name))
+		return doc
+
+	@contextmanager
+	def _logging_db(self, log):
+		"""Wraps the real calls rather than replacing them, so the insert still
+		runs and the log records the order it went in. Same approach as
+		_logging_db in tests/test_enrollment_races.py, extended to frappe.get_all
+		since is_certified() reads through that rather than frappe.db.exists()."""
+		real_get_value, real_get_all = frappe.db.get_value, frappe.get_all
+
+		def spy_get_value(*args, **kwargs):
+			if kwargs.get("for_update") and args:
+				log.append(("lock", args[0]))
+			return real_get_value(*args, **kwargs)
+
+		def spy_get_all(*args, **kwargs):
+			if args:
+				log.append(("read", args[0]))
+			return real_get_all(*args, **kwargs)
+
+		with (
+			patch.object(frappe.db, "get_value", spy_get_value),
+			patch.object(frappe, "get_all", spy_get_all),
+		):
+			yield

--- a/lms/lms/doctype/lms_certificate/test_lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/test_lms_certificate.py
@@ -1,8 +1,60 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
-import unittest
+from unittest.mock import patch
+
+import frappe
+
+from lms.lms.doctype.lms_certificate.lms_certificate import create_certificate
+from lms.lms.test_helpers import BaseTestUtils
 
 
-class TestLMSCertificate(unittest.TestCase):
-	pass
+class TestLMSCertificate(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		self._setup_course_flow()
+		frappe.db.set_value("LMS Course", self.course.name, "enable_certification", 1)
+
+	def tearDown(self):
+		frappe.session.user = "Administrator"
+		super().tearDown()
+
+	def test_create_certificate_is_idempotent(self):
+		"""Calling create_certificate twice in a row for the same member and
+		course should hand back the same certificate the second time, not
+		create a second one."""
+		frappe.session.user = self.student2.email
+
+		first = create_certificate(self.course.name)
+		second = create_certificate(self.course.name)
+
+		self.assertEqual(first.name, second.name)
+		self.assertEqual(
+			frappe.db.count("LMS Certificate", {"member": self.student2.email, "course": self.course.name}),
+			1,
+		)
+
+	def test_create_certificate_survives_a_lost_race(self):
+		"""https://github.com/frappe/lms/issues/2408 - two concurrent requests
+		for the same member+course can both pass the is_certified() check
+		before either one's insert has committed, since nothing locks between
+		the two. Force that window here by making is_certified() report "not
+		certified yet" on the second call even though the first call's
+		certificate already made it into the database. With the unique
+		constraint on (member, course, batch_name) in place, that second
+		insert should come back as a UniqueValidationError, which
+		create_certificate now catches and turns into the certificate the
+		first call already created - not an error, and not a second row.
+		"""
+		frappe.session.user = self.student2.email
+
+		first = create_certificate(self.course.name)
+
+		with patch("lms.lms.doctype.lms_certificate.lms_certificate.is_certified", return_value=None):
+			second = create_certificate(self.course.name)
+
+		self.assertEqual(first.name, second.name)
+		self.assertEqual(
+			frappe.db.count("LMS Certificate", {"member": self.student2.email, "course": self.course.name}),
+			1,
+		)

--- a/lms/patches.txt
+++ b/lms/patches.txt
@@ -130,3 +130,4 @@ lms.patches.v2_0.set_course_progress_defaults #02-06-2026
 lms.patches.v2_0.add_video_watch_duration_index #18-06-2026
 lms.patches.v2_0.add_batch_enrollment_index #20-07-2026
 lms.patches.v2_0.make_public_images_public #05-08-2026
+lms.patches.v2_0.delete_duplicate_certificates #13-08-2026

--- a/lms/patches/v2_0/delete_duplicate_certificates.py
+++ b/lms/patches/v2_0/delete_duplicate_certificates.py
@@ -1,0 +1,37 @@
+import frappe
+from frappe.query_builder.functions import Count
+
+
+def execute():
+	"""
+	create_certificate() checks is_certified() and only inserts if nothing
+	turned up, with nothing locking between the check and the insert. Two
+	requests for the same member+course close enough together (a doubled
+	click on "Get Certificate" is enough) can both pass the check and both
+	insert - see https://github.com/frappe/lms/issues/2408. Clear out
+	whatever that has already produced before adding the constraint that
+	closes the race, keeping the earliest certificate of each duplicate set.
+	"""
+	Certificate = frappe.qb.DocType("LMS Certificate")
+	duplicate_groups = (
+		frappe.qb.from_(Certificate)
+		.select(Certificate.member, Certificate.course, Certificate.batch_name)
+		.groupby(Certificate.member, Certificate.course, Certificate.batch_name)
+		.having(Count(Certificate.name) > 1)
+	).run(as_dict=True)
+
+	for group in duplicate_groups:
+		rows = frappe.get_all(
+			"LMS Certificate",
+			filters={
+				"member": group.member,
+				"course": group.course,
+				"batch_name": group.batch_name,
+			},
+			fields=["name"],
+			order_by="creation asc",
+		)
+		for row in rows[1:]:
+			frappe.delete_doc("LMS Certificate", row.name, ignore_permissions=True, delete_permanently=True)
+
+	frappe.db.add_unique("LMS Certificate", ["member", "course", "batch_name"])

--- a/lms/patches/v2_0/delete_duplicate_certificates.py
+++ b/lms/patches/v2_0/delete_duplicate_certificates.py
@@ -11,7 +11,19 @@ def execute():
 	insert - see https://github.com/frappe/lms/issues/2408. Clear out
 	whatever that has already produced before adding the constraint that
 	closes the race, keeping the earliest certificate of each duplicate set.
+
+	course and batch_name are blank on whichever of the two a given row
+	doesn't use, and a plain frappe.get_doc() that never touches a field
+	leaves it None - SQL NULL, not "" - unless something normalizes it, which
+	nothing did until this fix. NULL != NULL as far as a unique index is
+	concerned, so two course-only rows for the same member+course both sitting
+	on batch_name=NULL would not collide with each other and would slip past
+	the constraint below. Existing rows need that normalized before grouping,
+	same as validate() now does going forward for new ones.
 	"""
+	frappe.db.sql("UPDATE `tabLMS Certificate` SET course = '' WHERE course IS NULL")
+	frappe.db.sql("UPDATE `tabLMS Certificate` SET batch_name = '' WHERE batch_name IS NULL")
+
 	Certificate = frappe.qb.DocType("LMS Certificate")
 	duplicate_groups = (
 		frappe.qb.from_(Certificate)


### PR DESCRIPTION
Fixes #2408.

`create_certificate()` calls `is_certified(course)` and only builds a new certificate if that comes back empty - there's nothing between the check and the `save()` that stops two requests from both reading "not certified yet." A doubled click on "Get Certificate" is realistically enough to hit that window, and the result is two `LMS Certificate` rows for the same member and course.

There was already a PR for this (#2409), closed a few months back after going stale. @raizasafeel's review on it laid out the right shape for the fix - a DB-level unique constraint is the only thing that actually closes the window, since an `if exists` check has the same race whether it's in Python or in `validate()`; keep the fast path for the normal case, but catch the constraint violation on the way out and hand back the certificate that won instead of erroring. This picks that up.

Added `frappe.db.add_unique("LMS Certificate", ["member", "course", "batch_name"])`, applied through a patch (existing databases can already have duplicates sitting around, so it dedupes first, keeping the earliest of each set) and also directly in `after_install` for fresh sites, which don't run patches. That part mirrors `delete_duplicate_course_progress` almost exactly, which hit the same shape of bug for `LMS Course Progress` a few months ago.

One thing I changed from the (member, course) framing in that review comment: a certificate can also be earned through a batch instead of a course, and `course` is blank on those rows. A two-column constraint on just (member, course) would treat every batch certificate a member holds as a duplicate of the next one, since they'd all share the same blank course. Made it (member, course, batch_name) instead, which keeps course-certs and batch-certs distinguishable from each other while still catching a real duplicate of either kind.

`create_certificate()` now wraps the `save()` in a try/except for `frappe.UniqueValidationError` and, on that path, looks up whichever certificate actually won and returns it - same shape as what a normal `is_certified()` hit returns, so nothing downstream needs to care whether it was the fast path or the recovered-from-a-lost-race path.

The patch does delete rows (the duplicate certificates, keeping the earliest per member+course/batch), so it's worth a closer look than the rest of the diff - flagging that up front rather than leaving it for someone to notice.

For tests, added two to what was an empty `test_lms_certificate.py`. The first just calls `create_certificate` twice in a row and checks it's idempotent - not new behavior, but the existing fast path had no coverage either. The second is the one that actually exercises the fix: it mocks `is_certified` to return `None` on the second call even though the first call's certificate already exists, which is the only way I could find to force the actual race window deterministically in a single-threaded test rather than just re-proving the fast path works.

I wasn't able to run this against a live site from where I'm working - no bench set up in this environment - so I traced it carefully against current `develop` instead: pulled the real `create_certificate`/`is_certified` source, followed `UniqueValidationError` and `add_unique` into `frappe/model/base_document.py` and `frappe/database/mariadb/database.py` to confirm exactly when Frappe raises that exception and what `add_unique` does at the SQL level, and checked the `enable_certification` default on `LMS Course` (it's 0) so the test explicitly turns it on rather than assuming the fixture already has it. Ran `ruff check` and `ruff format --check` against the changed files, both clean. If there's a lighter way to get this running against an actual site that I'm missing, happy to go do that too.
