### PR TITLE
fix(programs): persist reordered courses

### DIFF
--- a/frontend/src/pages/Forms/ProgramForm.vue
+++ b/frontend/src/pages/Forms/ProgramForm.vue
@@ -256,6 +256,7 @@ import ResponsiveListView from '@/components/ResponsiveListView.vue'
 import Draggable from 'vuedraggable'
 import ProgramProgressSummary from '@/components/Programs/ProgramProgressSummary.vue'
 import { submitResource } from '@/utils/resource'
+import { reindexProgramCourses } from '@/utils/programOrder'
 
 const showFormDialog = ref(false)
 const currentForm = ref<'course' | 'member'>('course')
@@ -535,40 +536,11 @@ const addMember = (close: () => void) => {
 	}
 }
 
-const updateOrder = async (e: any) => {
-	let sourceIdx = e.from.dataset.idx
-	let targetIdx = e.to.dataset.idx
-
-	if (isNew.value) {
-		let courses = program.value.program_courses
-		courses.splice(targetIdx, 0, courses.splice(sourceIdx, 1)[0])
-		courses.forEach((course, index) => {
-			course.idx = index + 1
-		})
-		dirty.value = true
-	} else {
-		let courses = programCourses.data
-		courses.splice(targetIdx, 0, courses.splice(sourceIdx, 1)[0])
-
-		for (const [index, course] of courses.entries()) {
-			submitResource(
-				programCourses.setValue,
-				{
-					name: course.name,
-					idx: index + 1,
-				},
-				{
-					onError(err: any) {
-						toast.warning(__(err.messages?.[0] || err))
-					},
-				}
-			)
-			await wait(100)
-		}
-	}
+const updateOrder = () => {
+	// vuedraggable updates the bound array before emitting `end`.
+	reindexProgramCourses(program.value.program_courses)
+	dirty.value = true
 }
-
-const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 const remove = (
 	selections: string[],

--- a/frontend/src/tests/programOrder.test.ts
+++ b/frontend/src/tests/programOrder.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { reindexProgramCourses } from '@/utils/programOrder'
+
+describe('reindexProgramCourses', () => {
+	it('persists the order already produced by vuedraggable', () => {
+		const courses = [
+			{ course: 'course-c', idx: 3 },
+			{ course: 'course-a', idx: 1 },
+			{ course: 'course-b', idx: 2 },
+		]
+
+		reindexProgramCourses(courses)
+
+		expect(courses).toEqual([
+			{ course: 'course-c', idx: 1 },
+			{ course: 'course-a', idx: 2 },
+			{ course: 'course-b', idx: 3 },
+		])
+	})
+
+	it('does not reorder the array a second time', () => {
+		const courses = [{ course: 'course-b' }, { course: 'course-a' }]
+
+		reindexProgramCourses(courses)
+
+		expect(courses.map((course) => course.course)).toEqual([
+			'course-b',
+			'course-a',
+		])
+	})
+})

--- a/frontend/src/utils/programOrder.ts
+++ b/frontend/src/utils/programOrder.ts
@@ -1,0 +1,7 @@
+type ProgramCourse = { idx?: number }
+
+export function reindexProgramCourses(courses: ProgramCourse[]): void {
+	courses.forEach((course, index) => {
+		course.idx = index + 1
+	})
+}


### PR DESCRIPTION
## What changed

- Keep the course order already produced by `vuedraggable` when its `end` event fires.
- Reindex the reordered child rows and persist them with the next Program save.
- Add focused tests for reindexing without moving the array a second time.

## Why

`vuedraggable` mutates the bound `program_courses` array before emitting `end`. The previous handler then tried to derive source and target indexes from container `data-idx` attributes and spliced the array again. Those attributes are not present on the list containers, so course reordering could move the wrong row or fail to persist.

This change treats the bound array as the source of truth, updates its child-row indexes, and marks the Program dirty so the existing Save flow persists the complete order consistently for both new and existing Programs.

## User impact

Program managers can drag courses into a new order and save that order reliably.

## Validation

- `yarn test src/tests/programOrder.test.ts src/tests/programForm.test.ts` — 14 tests passed
- `yarn build` — passed
