### PR TITLE
fix(programs): remove selected child rows

### DIFF
--- a/frontend/src/pages/Forms/ProgramForm.vue
+++ b/frontend/src/pages/Forms/ProgramForm.vue
@@ -256,6 +256,7 @@ import ResponsiveListView from '@/components/ResponsiveListView.vue'
 import Draggable from 'vuedraggable'
 import ProgramProgressSummary from '@/components/Programs/ProgramProgressSummary.vue'
 import { submitResource } from '@/utils/resource'
+import { withoutSelectedRows } from '@/utils/programSelection'
 
 const showFormDialog = ref(false)
 const currentForm = ref<'course' | 'member'>('course')
@@ -577,12 +578,16 @@ const remove = (
 ) => {
 	const selectionsArray = Array.from(selections)
 	if (type === 'courses') {
-		program.value.program_courses = program.value.program_courses.filter(
-			(c: any) => !selectionsArray.includes(c.name || c.course)
+		program.value.program_courses = withoutSelectedRows(
+			program.value.program_courses,
+			selectionsArray,
+			['name', 'course']
 		)
 	} else {
-		program.value.program_members = program.value.program_members.filter(
-			(m: any) => !selectionsArray.includes(m.name || m.member)
+		program.value.program_members = withoutSelectedRows(
+			program.value.program_members,
+			selectionsArray,
+			['name', 'member']
 		)
 	}
 	dirty.value = true

--- a/frontend/src/tests/programSelection.test.ts
+++ b/frontend/src/tests/programSelection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { withoutSelectedRows } from '@/utils/programSelection'
+
+describe('withoutSelectedRows', () => {
+	it('removes a persisted course selected by its course key', () => {
+		const rows = [
+			{ name: 'child-row-1', course: 'course-a' },
+			{ name: 'child-row-2', course: 'course-b' },
+		]
+
+		expect(withoutSelectedRows(rows, ['course-a'], ['name', 'course'])).toEqual([
+			{ name: 'child-row-2', course: 'course-b' },
+		])
+	})
+
+	it('removes a persisted member selected by its member key', () => {
+		const rows = [
+			{ name: 'child-row-1', member: 'one@example.com' },
+			{ name: 'child-row-2', member: 'two@example.com' },
+		]
+
+		expect(
+			withoutSelectedRows(rows, ['one@example.com'], ['name', 'member']),
+		).toEqual([{ name: 'child-row-2', member: 'two@example.com' }])
+	})
+
+	it('also accepts the child row name as the selection identity', () => {
+		const rows = [{ name: 'child-row-1', course: 'course-a' }]
+
+		expect(
+			withoutSelectedRows(rows, ['child-row-1'], ['name', 'course']),
+		).toEqual([])
+	})
+})

--- a/frontend/src/utils/programSelection.ts
+++ b/frontend/src/utils/programSelection.ts
@@ -1,0 +1,10 @@
+export function withoutSelectedRows<T extends Record<string, unknown>>(
+	rows: T[],
+	selections: string[],
+	identityKeys: (keyof T)[],
+): T[] {
+	const selected = new Set(selections)
+	return rows.filter((row) =>
+		identityKeys.every((key) => !selected.has(String(row[key] ?? ''))),
+	)
+}


### PR DESCRIPTION
## What changed

- Remove selected Program Course and Program Member rows by checking every supported row identity.
- Add focused tests for selections keyed by course, member, or child-row name.

## Why

The Program lists use `course` and `member` as their row keys, while persisted child rows also have a `name`. The previous filter used expressions such as `row.name || row.course`. Once `name` existed, the selected `course` or `member` value was never compared, so clicking Delete left persisted rows in the Program.

The new helper checks both possible identities independently, matching the selection keys emitted by the list components while retaining support for child-row-name selections.

## User impact

Program managers can delete selected courses and members from an existing Program and save the result.

## Validation

- `yarn test src/tests/programSelection.test.ts src/tests/programForm.test.ts` — 15 tests passed
- `yarn build` — passed
