### PR TITLE
feat: enforce lesson completion

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -91,6 +91,7 @@ declare module 'vue' {
     ListPage: typeof import('./src/components/Layouts/ListPage.vue')['default']
     LiveClassAttendance: typeof import('./src/components/Modals/LiveClassAttendance.vue')['default']
     LMSLogo: typeof import('./src/components/Icons/LMSLogo.vue')['default']
+    LockedLessonNotice: typeof import('./src/components/LockedLessonNotice.vue')['default']
     LucideChevronLeft: typeof import('~icons/lucide/chevron-left')['default']
     LucideChevronRight: typeof import('~icons/lucide/chevron-right')['default']
     LucideStar: typeof import('~icons/lucide/star')['default']

--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -13,7 +13,10 @@
 			/>
 			<div
 				class="ms-2 min-w-0 flex-1 text-start"
-				:class="inlineSelect ? '' : 'flex items-baseline justify-between gap-3'"
+				:class="[
+					inlineSelect ? '' : 'flex items-baseline justify-between gap-3',
+					isScormChapterLocked ? 'cursor-not-allowed opacity-60' : '',
+				]"
 				@click="redirectToChapter"
 			>
 				<TextInput
@@ -60,8 +63,16 @@
 					/>
 				</Tooltip>
 			</div>
+			<template v-if="isScormChapterLocked">
+				<span
+					class="lucide-lock-keyhole size-4 text-ink-gray-4"
+					:title="__('Complete the previous lessons to unlock this one')"
+					aria-hidden="true"
+				/>
+				<span class="sr-only">{{ __('Locked') }}</span>
+			</template>
 			<span
-				v-if="chapter.is_scorm_package && isScormChapterComplete"
+				v-else-if="chapter.is_scorm_package && isScormChapterComplete"
 				class="lucide-check size-4 text-green-700"
 			/>
 		</DisclosureButton>
@@ -96,6 +107,9 @@
 									: ''
 							"
 							:aria-disabled="lesson.locked ? 'true' : undefined"
+							:aria-label="
+								lesson.locked ? lesson.title + ' — ' + __('locked') : undefined
+							"
 							@click="onLessonClick(lesson)"
 						>
 							<div class="flex items-center text-sm leading-5 group">
@@ -261,6 +275,18 @@ const isScormChapterComplete = computed<boolean>(() =>
 	)
 )
 
+// A SCORM chapter has no DisclosurePanel, so it never reaches the per-lesson lock
+// affordance below: without this it looks identical to an open one and the student
+// only learns it is locked after SCORMChapter.vue bounces them back. Same rule as
+// that page's own isLocked.
+const isScormChapterLocked = computed<boolean>(() =>
+	Boolean(
+		props.chapter.is_scorm_package &&
+			props.chapter.lessons?.length &&
+			props.chapter.lessons.every((l) => l.locked)
+	)
+)
+
 function isActiveLesson(lessonNumber: string): boolean {
 	if (props.inlineSelect) return props.selectedLessonNumber === lessonNumber
 	return (
@@ -306,6 +332,7 @@ function addLesson() {
 function redirectToChapter() {
 	if (!props.chapter.is_scorm_package) return
 	;(event as Event | undefined)?.preventDefault()
+	if (isScormChapterLocked.value) return
 	if (!user.data) {
 		toast.success(__('Please enroll for this course to view this lesson'))
 		return

--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -84,9 +84,18 @@
 						"
 					>
 						<component
-							:is="inlineSelect ? 'div' : 'router-link'"
-							:to="inlineSelect ? undefined : lessonRoute(lesson)"
-							:class="inlineSelect ? 'cursor-pointer' : ''"
+							:is="inlineSelect || lesson.locked ? 'div' : 'router-link'"
+							:to="
+								inlineSelect || lesson.locked ? undefined : lessonRoute(lesson)
+							"
+							:class="
+								lesson.locked
+									? 'cursor-not-allowed opacity-60'
+									: inlineSelect
+									? 'cursor-pointer'
+									: ''
+							"
+							:aria-disabled="lesson.locked ? 'true' : undefined"
 							@click="onLessonClick(lesson)"
 						>
 							<div class="flex items-center text-sm leading-5 group">
@@ -123,7 +132,12 @@
 									/>
 								</div>
 								<span
-									v-if="lesson.is_complete"
+									v-if="lesson.locked"
+									class="lucide-lock-keyhole h-4 w-4 text-ink-gray-4 ms-2"
+									:title="__('Complete the previous lesson to unlock this one')"
+								/>
+								<span
+									v-else-if="lesson.is_complete"
 									class="lucide-check h-4 w-4 text-green-700 ms-2"
 								/>
 							</div>
@@ -274,6 +288,7 @@ function lessonRoute(lesson: OutlineLesson): RouteLocationRaw {
 }
 
 function onLessonClick(lesson: OutlineLesson) {
+	if (lesson.locked) return
 	if (!props.inlineSelect) return
 	emit('select-lesson', {
 		chapterNumber: lesson.number.split('-')[0],

--- a/frontend/src/components/ChapterRow.vue
+++ b/frontend/src/components/ChapterRow.vue
@@ -106,10 +106,6 @@
 									? 'cursor-pointer'
 									: ''
 							"
-							:aria-disabled="lesson.locked ? 'true' : undefined"
-							:aria-label="
-								lesson.locked ? lesson.title + ' — ' + __('locked') : undefined
-							"
 							@click="onLessonClick(lesson)"
 						>
 							<div class="flex items-center text-sm leading-5 group">
@@ -145,11 +141,16 @@
 										class="lucide-trash-2 h-4 w-4 text-ink-red-6 invisible group-hover:visible"
 									/>
 								</div>
-								<span
-									v-if="lesson.locked"
-									class="lucide-lock-keyhole h-4 w-4 text-ink-gray-4 ms-2"
-									:title="__('Complete the previous lesson to unlock this one')"
-								/>
+								<template v-if="lesson.locked">
+									<span
+										class="lucide-lock-keyhole h-4 w-4 text-ink-gray-4 ms-2"
+										:title="
+											__('Complete the previous lesson to unlock this one')
+										"
+										aria-hidden="true"
+									/>
+									<span class="sr-only">{{ __('Locked') }}</span>
+								</template>
 								<span
 									v-else-if="lesson.is_complete"
 									class="lucide-check h-4 w-4 text-green-700 ms-2"

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -1,14 +1,10 @@
 <template>
-	<div v-if="youtube">
-		<iframe
-			class="youtube-video"
-			:src="safeUrl(getYouTubeVideoSource(youtube.split('/').pop()))"
-			:title="__('YouTube video')"
-			width="100%"
-			:height="screenSize.width < 640 ? 200 : 400"
-			frameborder="0"
-			allowfullscreen
-		></iframe>
+	<div v-if="youtubeEmbedId(youtube)">
+		<div
+			class="video-player"
+			data-plyr-provider="youtube"
+			:data-plyr-embed-id="youtubeEmbedId(youtube)"
+		></div>
 	</div>
 	<!-- Keyed on the block text, not just the index: position N of the outgoing
 	     lesson and position N of the incoming one share an index, so Vue reuses
@@ -19,15 +15,12 @@
 		:key="`${index}:${block}`"
 	>
 		<div v-if="block.includes('{{ YouTubeVideo')">
-			<iframe
-				class="youtube-video"
-				:src="safeUrl(getYouTubeVideoSource(block))"
-				:title="__('YouTube video')"
-				width="100%"
-				:height="screenSize.width < 640 ? 200 : 400"
-				frameborder="0"
-				allowfullscreen
-			></iframe>
+			<div
+				v-if="youtubeEmbedId(getId(block))"
+				class="video-player"
+				data-plyr-provider="youtube"
+				:data-plyr-embed-id="youtubeEmbedId(getId(block))"
+			></div>
 		</div>
 		<div v-else-if="block.includes('{{ Quiz')">
 			<Quiz :quiz="getId(block)" />
@@ -80,12 +73,10 @@
 import Quiz from '@/components/QuizBlock.vue'
 import PdfBlock from '@/components/PdfBlock.vue'
 import MarkdownIt from 'markdown-it'
-import { useScreenSize } from '@/utils/composables'
-import { getMacroArg } from '@/utils/lessonMacros'
+import { extractYoutubeID, getMacroArg } from '@/utils/lessonMacros'
 import { usesWebkitPdfViewer } from '@/utils/pdfViewer'
 import { safeUrl } from '@/utils/safeUrl'
 
-const screenSize = useScreenSize()
 const inlinePdf = usesWebkitPdfViewer()
 
 const markdown = new MarkdownIt({
@@ -112,16 +103,17 @@ const props = defineProps({
 	},
 })
 
-const getYouTubeVideoSource = (block) => {
-	if (block.includes('{{')) {
-		block = getId(block)
-	}
-	return `https://www.youtube.com/embed/${block}`
-}
-
 const getId = (block) => {
 	// Guard the match: a malformed `{{ PDF() }}` / unbalanced-quote macro yields
 	// null, and the old unguarded [1] threw and killed the whole lesson render.
 	return getMacroArg(block) ?? ''
 }
+
+// Both authoring paths (the `youtube` field and the `{{ YouTubeVideo }}` macro)
+// must land in the same Plyr-wrapped `.video-player` the EditorJS embed block
+// renders. A bare <iframe> is invisible to the watch tracker in Lesson.vue, so
+// enforce_video_completion saw "no video" and auto-completed on the dwell timer.
+// Falsy id => render nothing rather than a Plyr player with no video, which
+// would suppress the dwell timer and leave the lesson uncompletable.
+const youtubeEmbedId = (source) => (source ? extractYoutubeID(source) : '')
 </script>

--- a/frontend/src/components/LessonContent.vue
+++ b/frontend/src/components/LessonContent.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="youtubeEmbedId(youtube)">
+	<div v-if="youtubeEmbedId(youtube)" :key="youtubeEmbedId(youtube)">
 		<div
 			class="video-player"
 			data-plyr-provider="youtube"
@@ -17,6 +17,7 @@
 		<div v-if="block.includes('{{ YouTubeVideo')">
 			<div
 				v-if="youtubeEmbedId(getId(block))"
+				:key="youtubeEmbedId(getId(block))"
 				class="video-player"
 				data-plyr-provider="youtube"
 				:data-plyr-embed-id="youtubeEmbedId(getId(block))"

--- a/frontend/src/components/LockedLessonNotice.vue
+++ b/frontend/src/components/LockedLessonNotice.vue
@@ -21,22 +21,19 @@
 						:style="{ width: `${(secondsLeft / seconds) * 100}%` }"
 					/>
 				</div>
-				<div
-					class="text-p-xs text-ink-gray-5 tabular-nums"
-					role="status"
-					aria-live="polite"
-				>
+				<div class="text-p-xs text-ink-gray-5 tabular-nums" aria-hidden="true">
 					{{
 						__('Taking you to your current lesson in {0}s').format(secondsLeft)
 					}}
 				</div>
+				<div class="sr-only" role="status">{{ announcement }}</div>
 			</div>
 		</div>
 	</div>
 </template>
 
 <script setup>
-import { onBeforeUnmount, ref, watch } from 'vue'
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps({
 	redirect: {
@@ -52,6 +49,7 @@ const props = defineProps({
 const emit = defineEmits(['done'])
 
 const secondsLeft = ref(props.seconds)
+const announcement = ref('')
 let timer = null
 
 const stop = () => {
@@ -61,11 +59,25 @@ const stop = () => {
 	}
 }
 
+// role="status" implies aria-atomic, so a per-second countdown queues one full
+// polite announcement per tick and crowds out the sentence explaining the lock.
+// The visible counter is hidden from AT and the reason is announced once, after
+// a tick so the live region registers it as a change rather than initial content.
+const announce = () => {
+	announcement.value = ''
+	nextTick(() => {
+		announcement.value = __(
+			'This lesson is locked. Taking you to your current lesson in {0} seconds.'
+		).format(props.seconds)
+	})
+}
+
 // The bar drains rather than the page jumping on arrival, so the student reads why
 // they were moved instead of landing on an unexplained lesson.
 const start = () => {
 	stop()
 	secondsLeft.value = props.seconds
+	announce()
 	timer = setInterval(() => {
 		secondsLeft.value -= 1
 		if (secondsLeft.value > 0) return

--- a/frontend/src/components/LockedLessonNotice.vue
+++ b/frontend/src/components/LockedLessonNotice.vue
@@ -1,45 +1,47 @@
 <template>
-	<div class="flex h-full items-center justify-center px-5 py-20">
-		<div class="flex flex-col items-center gap-4">
-			<div
-				class="size-14 rounded-full bg-surface-gray-2 flex items-center justify-center"
-			>
+	<div class="p-5">
+		<div class="flex items-center gap-3 rounded-lg bg-surface-amber-2 p-3">
+			<div class="grid size-7 shrink-0 place-items-center text-ink-amber-6">
 				<span
 					:class="notFound ? 'lucide-file-question' : 'lucide-lock-keyhole'"
-					class="size-6 text-ink-gray-6"
+					class="size-4"
+					aria-hidden="true"
 				/>
 			</div>
-			<div class="flex flex-col items-center gap-1">
-				<div class="text-p-lg-medium text-ink-gray-8">
+			<div class="flex min-w-0 flex-1 flex-col">
+				<span class="text-p-sm-medium text-ink-gray-8">
 					{{ notFound ? __('Lesson not found') : __('This lesson is locked') }}
-				</div>
-				<div class="text-center text-p-sm text-ink-gray-6 max-w-72">
+				</span>
+				<span class="text-p-sm text-ink-gray-6">
 					{{
 						notFound
-							? __('There is no such lesson in this course.')
-							: __('Finish the earlier lessons to unlock this one.')
+							? __('There is no lesson at this address in this course.')
+							: __('Finish the lessons before it to unlock this one.')
 					}}
-				</div>
+				</span>
 			</div>
-			<div v-if="redirect" class="flex flex-col items-center gap-2 w-52 mt-1">
-				<div class="h-1 w-full rounded-full bg-surface-gray-3 overflow-hidden">
-					<div
-						class="h-full rounded-full bg-surface-gray-6 transition-[width] duration-1000 ease-linear"
-						:style="{ width: `${(secondsLeft / seconds) * 100}%` }"
-					/>
-				</div>
-				<div class="text-p-xs text-ink-gray-5 tabular-nums" aria-hidden="true">
-					{{
-						__('Taking you to your current lesson in {0}s').format(secondsLeft)
-					}}
-				</div>
-			</div>
-			<div class="sr-only" role="status">{{ announcement }}</div>
+			<template v-if="redirect">
+				<span
+					class="shrink-0 text-p-xs text-ink-gray-5 tabular-nums"
+					aria-hidden="true"
+				>
+					{{ __('{0}s').format(secondsLeft) }}
+				</span>
+				<Button
+					theme="gray"
+					variant="subtle"
+					class="border border-outline-gray-2 bg-surface-base hover:bg-surface-base hover:border-outline-gray-3 active:bg-surface-gray-2 focus-visible:bg-surface-base"
+					:label="__('Go now')"
+					@click="goNow()"
+				/>
+			</template>
 		</div>
+		<div class="sr-only" role="status">{{ announcement }}</div>
 	</div>
 </template>
 
 <script setup>
+import { Button } from 'frappe-ui'
 import { onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps({
@@ -101,8 +103,8 @@ const announce = () => {
 	}, ANNOUNCE_DELAY)
 }
 
-// The bar drains rather than the page jumping on arrival, so the student reads why
-// they were moved instead of landing on an unexplained lesson.
+// The counter runs down rather than the page jumping on arrival, so the student
+// reads why they were moved instead of landing on an unexplained lesson.
 const start = () => {
 	stop()
 	secondsLeft.value = props.seconds
@@ -113,6 +115,13 @@ const start = () => {
 		stop()
 		emit('done')
 	}, 1000)
+}
+
+// Skipping the wait must also kill the interval, or it fires again on a page the
+// student has already left.
+const goNow = () => {
+	stop()
+	emit('done')
 }
 
 watch(

--- a/frontend/src/components/LockedLessonNotice.vue
+++ b/frontend/src/components/LockedLessonNotice.vue
@@ -26,14 +26,14 @@
 						__('Taking you to your current lesson in {0}s').format(secondsLeft)
 					}}
 				</div>
-				<div class="sr-only" role="status">{{ announcement }}</div>
 			</div>
+			<div class="sr-only" role="status">{{ announcement }}</div>
 		</div>
 	</div>
 </template>
 
 <script setup>
-import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps({
 	redirect: {
@@ -51,25 +51,36 @@ const emit = defineEmits(['done'])
 const secondsLeft = ref(props.seconds)
 const announcement = ref('')
 let timer = null
+let announceTimer = null
 
 const stop = () => {
 	if (timer) {
 		clearInterval(timer)
 		timer = null
 	}
+	if (announceTimer) {
+		clearTimeout(announceTimer)
+		announceTimer = null
+	}
 }
 
 // role="status" implies aria-atomic, so a per-second countdown queues one full
 // polite announcement per tick and crowds out the sentence explaining the lock.
-// The visible counter is hidden from AT and the reason is announced once, after
-// a tick so the live region registers it as a change rather than initial content.
+// The visible counter is hidden from AT and the reason is announced once.
+//
+// The region is rendered unconditionally, outside the redirect block, so it is
+// already in the accessibility tree before it has content. Populating it in the
+// same frame as its own insertion reads as initial content, which most screen
+// readers do not announce at all, so the text lands a frame later.
+const ANNOUNCE_DELAY = 100
+
 const announce = () => {
 	announcement.value = ''
-	nextTick(() => {
+	announceTimer = setTimeout(() => {
 		announcement.value = __(
 			'This lesson is locked. Taking you to your current lesson in {0} seconds.'
 		).format(props.seconds)
-	})
+	}, ANNOUNCE_DELAY)
 }
 
 // The bar drains rather than the page jumping on arrival, so the student reads why

--- a/frontend/src/components/LockedLessonNotice.vue
+++ b/frontend/src/components/LockedLessonNotice.vue
@@ -4,14 +4,21 @@
 			<div
 				class="size-14 rounded-full bg-surface-gray-2 flex items-center justify-center"
 			>
-				<span class="lucide-lock-keyhole size-6 text-ink-gray-6" />
+				<span
+					:class="notFound ? 'lucide-file-question' : 'lucide-lock-keyhole'"
+					class="size-6 text-ink-gray-6"
+				/>
 			</div>
 			<div class="flex flex-col items-center gap-1">
 				<div class="text-p-lg-medium text-ink-gray-8">
-					{{ __('This lesson is locked') }}
+					{{ notFound ? __('Lesson not found') : __('This lesson is locked') }}
 				</div>
 				<div class="text-center text-p-sm text-ink-gray-6 max-w-72">
-					{{ __('Finish the earlier lessons to unlock this one.') }}
+					{{
+						notFound
+							? __('There is no such lesson in this course.')
+							: __('Finish the earlier lessons to unlock this one.')
+					}}
 				</div>
 			</div>
 			<div v-if="redirect" class="flex flex-col items-center gap-2 w-52 mt-1">
@@ -43,6 +50,13 @@ const props = defineProps({
 	seconds: {
 		type: Number,
 		default: 3,
+	},
+	// The gate answers a lesson number that resolves to nothing with the same
+	// redirecting payload, and telling that student to finish the earlier lessons
+	// to unlock this one would be a lie.
+	notFound: {
+		type: Boolean,
+		default: false,
 	},
 })
 
@@ -77,9 +91,13 @@ const ANNOUNCE_DELAY = 100
 const announce = () => {
 	announcement.value = ''
 	announceTimer = setTimeout(() => {
-		announcement.value = __(
-			'This lesson is locked. Taking you to your current lesson in {0} seconds.'
-		).format(props.seconds)
+		announcement.value = props.notFound
+			? __(
+					'Lesson not found. Taking you to your current lesson in {0} seconds.'
+			  ).format(props.seconds)
+			: __(
+					'This lesson is locked. Taking you to your current lesson in {0} seconds.'
+			  ).format(props.seconds)
 	}, ANNOUNCE_DELAY)
 }
 

--- a/frontend/src/components/LockedLessonNotice.vue
+++ b/frontend/src/components/LockedLessonNotice.vue
@@ -1,0 +1,87 @@
+<template>
+	<div class="flex h-full items-center justify-center px-5 py-20">
+		<div class="flex flex-col items-center gap-4">
+			<div
+				class="size-14 rounded-full bg-surface-gray-2 flex items-center justify-center"
+			>
+				<span class="lucide-lock-keyhole size-6 text-ink-gray-6" />
+			</div>
+			<div class="flex flex-col items-center gap-1">
+				<div class="text-p-lg-medium text-ink-gray-8">
+					{{ __('This lesson is locked') }}
+				</div>
+				<div class="text-center text-p-sm text-ink-gray-6 max-w-72">
+					{{ __('Finish the earlier lessons to unlock this one.') }}
+				</div>
+			</div>
+			<div v-if="redirect" class="flex flex-col items-center gap-2 w-52 mt-1">
+				<div class="h-1 w-full rounded-full bg-surface-gray-3 overflow-hidden">
+					<div
+						class="h-full rounded-full bg-surface-gray-6 transition-[width] duration-1000 ease-linear"
+						:style="{ width: `${(secondsLeft / seconds) * 100}%` }"
+					/>
+				</div>
+				<div
+					class="text-p-xs text-ink-gray-5 tabular-nums"
+					role="status"
+					aria-live="polite"
+				>
+					{{
+						__('Taking you to your current lesson in {0}s').format(secondsLeft)
+					}}
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+const props = defineProps({
+	redirect: {
+		type: Boolean,
+		default: true,
+	},
+	seconds: {
+		type: Number,
+		default: 3,
+	},
+})
+
+const emit = defineEmits(['done'])
+
+const secondsLeft = ref(props.seconds)
+let timer = null
+
+const stop = () => {
+	if (timer) {
+		clearInterval(timer)
+		timer = null
+	}
+}
+
+// The bar drains rather than the page jumping on arrival, so the student reads why
+// they were moved instead of landing on an unexplained lesson.
+const start = () => {
+	stop()
+	secondsLeft.value = props.seconds
+	timer = setInterval(() => {
+		secondsLeft.value -= 1
+		if (secondsLeft.value > 0) return
+		stop()
+		emit('done')
+	}, 1000)
+}
+
+watch(
+	() => props.redirect,
+	(redirect) => {
+		if (redirect) start()
+		else stop()
+	},
+	{ immediate: true }
+)
+
+onBeforeUnmount(stop)
+</script>

--- a/frontend/src/components/StudentLessonSidebar.vue
+++ b/frontend/src/components/StudentLessonSidebar.vue
@@ -53,10 +53,16 @@
 						<ul class="list-none">
 							<li v-for="lesson in chapter.lessons || []" :key="lesson.name">
 								<component
-									:is="inlineSelect ? 'button' : 'router-link'"
-									:type="inlineSelect ? 'button' : undefined"
+									:is="
+										lesson.locked
+											? 'div'
+											: inlineSelect
+											? 'button'
+											: 'router-link'
+									"
+									:type="!lesson.locked && inlineSelect ? 'button' : undefined"
 									:to="
-										inlineSelect
+										lesson.locked || inlineSelect
 											? undefined
 											: {
 													name: 'Lesson',
@@ -70,25 +76,34 @@
 									"
 									class="flex w-full items-center gap-3 rounded ps-9 pe-3 py-2 text-start text-sm leading-5 text-ink-gray-8 hover:bg-surface-gray-2"
 									:class="[
-										inlineSelect ? 'cursor-pointer' : '',
+										lesson.locked
+											? 'cursor-not-allowed opacity-60'
+											: inlineSelect
+											? 'cursor-pointer'
+											: '',
 										isActive(lesson.number)
 											? 'bg-surface-gray-2 text-ink-gray-9'
 											: '',
 									]"
-									@click="
-										emit('select-lesson', {
-											chapterNumber: lesson.number.split('-')[0],
-											lessonNumber: lesson.number.split('-')[1],
-										})
+									:aria-disabled="lesson.locked ? 'true' : undefined"
+									:aria-label="
+										lesson.locked
+											? lesson.title + ' — ' + __('locked')
+											: undefined
 									"
+									@click="onLessonClick(lesson)"
 								>
 									<component
 										:is="iconFor(lesson.icon)"
 										class="size-4 stroke-1.5 shrink-0 text-ink-gray-7"
 									/>
 									<span class="truncate flex-1">{{ lesson.title }}</span>
+									<LockKeyhole
+										v-if="lesson.locked"
+										class="size-4 stroke-1.5 shrink-0 text-ink-gray-4"
+									/>
 									<CircleCheck
-										v-if="lesson.is_complete"
+										v-else-if="lesson.is_complete"
 										class="size-4 stroke-1.5 shrink-0 text-green-700 fill-none"
 									/>
 									<Circle
@@ -200,6 +215,14 @@ function iconFor(icon) {
 
 function isActive(number) {
 	return props.selectedLessonNumber === number
+}
+
+function onLessonClick(lesson) {
+	if (lesson.locked) return
+	emit('select-lesson', {
+		chapterNumber: lesson.number.split('-')[0],
+		lessonNumber: lesson.number.split('-')[1],
+	})
 }
 
 function chapterDefaultOpen(chapter) {

--- a/frontend/src/components/StudentLessonSidebar.vue
+++ b/frontend/src/components/StudentLessonSidebar.vue
@@ -85,12 +85,6 @@
 											? 'bg-surface-gray-2 text-ink-gray-9'
 											: '',
 									]"
-									:aria-disabled="lesson.locked ? 'true' : undefined"
-									:aria-label="
-										lesson.locked
-											? lesson.title + ' — ' + __('locked')
-											: undefined
-									"
 									@click="onLessonClick(lesson)"
 								>
 									<component
@@ -98,10 +92,13 @@
 										class="size-4 stroke-1.5 shrink-0 text-ink-gray-7"
 									/>
 									<span class="truncate flex-1">{{ lesson.title }}</span>
-									<LockKeyhole
-										v-if="lesson.locked"
-										class="size-4 stroke-1.5 shrink-0 text-ink-gray-4"
-									/>
+									<template v-if="lesson.locked">
+										<LockKeyhole
+											class="size-4 stroke-1.5 shrink-0 text-ink-gray-4"
+											aria-hidden="true"
+										/>
+										<span class="sr-only">{{ __('Locked') }}</span>
+									</template>
 									<CircleCheck
 										v-else-if="lesson.is_complete"
 										class="size-4 stroke-1.5 shrink-0 text-green-700 fill-none"

--- a/frontend/src/pages/Courses/CourseForm.vue
+++ b/frontend/src/pages/Courses/CourseForm.vue
@@ -186,6 +186,7 @@ const updateCourseData = (): void => {
 		'published',
 		'upcoming',
 		'disable_self_learning',
+		'enforce_lesson_completion',
 		'paid_course',
 		'featured',
 		'enable_certification',

--- a/frontend/src/pages/Courses/CoursePublishSettings.vue
+++ b/frontend/src/pages/Courses/CoursePublishSettings.vue
@@ -22,6 +22,15 @@
 					:label="__('Self enrollment')"
 					:description="__('Let users enroll themselves.')"
 				/>
+				<BooleanSwitch
+					size="sm"
+					v-model="doc.enforce_lesson_completion"
+					:label="__('Enforce Lesson Completion')"
+					:description="
+						__('Students must complete each lesson before the next one opens.')
+					"
+					@update:modelValue="markDirty()"
+				/>
 			</div>
 		</CollapsibleSection>
 

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -262,7 +262,10 @@
 							v-else-if="lesson.data.instructor_notes"
 							class="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none !whitespace-normal mt-8"
 						>
-							<LessonContent :content="lesson.data.instructor_notes" />
+							<LessonContent
+								:key="lesson.data.name"
+								:content="lesson.data.instructor_notes"
+							/>
 						</div>
 						<div
 							v-if="lesson.data.content"
@@ -277,6 +280,7 @@
 						>
 							<LessonContent
 								v-if="lesson.data?.body"
+								:key="lesson.data.name"
 								:content="lesson.data.body"
 								:youtube="lesson.data.youtube"
 								:quizId="lesson.data.quiz_id"

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -496,12 +496,19 @@ onMounted(() => {
 		collapsedByLesson = true
 	}
 	document.addEventListener('fullscreenchange', attachFullscreenEvent)
-	socket.on('update_lesson_progress', (data) => {
-		if (data.course === props.courseName) {
-			lessonProgress.value = data.progress
-		}
-	})
+	socket.on('update_lesson_progress', onLessonProgress)
 })
+
+const onLessonProgress = (data) => {
+	if (data.course !== props.courseName) return
+	lessonProgress.value = data.progress
+	// A quiz or an assignment completes its lesson by calling
+	// mark_lesson_progress directly, never touching this page's progress
+	// resource, so this event is the only signal that they unlocked the next
+	// lesson. The server now addresses it to the completing member alone.
+	// Skip the ones the progress resource already reloaded for.
+	if (data.lesson !== completedLesson.value) outline.reload()
+}
 
 const attachFullscreenEvent = () => {
 	if (document.fullscreenElement) {
@@ -517,6 +524,9 @@ const attachFullscreenEvent = () => {
 
 onBeforeUnmount(() => {
 	document.removeEventListener('fullscreenchange', attachFullscreenEvent)
+	// Without this the handler outlives the page, and every revisit adds another
+	// one — so a single progress event fires one outline reload per past visit.
+	socket.off('update_lesson_progress', onLessonProgress)
 	if (collapsedByLesson) sidebarStore.isSidebarCollapsed = false
 	trackVideoWatchDuration()
 })
@@ -649,10 +659,8 @@ const progress = createResource({
 	onSuccess(data) {
 		lessonProgress.value = data
 		completedLesson.value = lesson.data?.name
-		// This user's own completion is the only thing that changes this user's lock
-		// state. update_lesson_progress is broadcast to the whole website room, so
-		// reloading from the socket handler refetched the outline in every concurrent
-		// viewer's browser whenever anyone completed anything.
+		// Reload here rather than waiting on the socket, so this page's own
+		// completion unlocks the next lesson even where realtime is unavailable.
 		outline.reload()
 	},
 })

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -92,6 +92,7 @@
 			<div v-else-if="lesson.data.locked" class="sm:border-e">
 				<LockedLessonNotice
 					:redirect="!!lesson.data.redirect_to"
+					:notFound="!!lesson.data.not_found"
 					@done="goToCurrentLesson()"
 				/>
 			</div>

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -499,6 +499,7 @@ onMounted(() => {
 	socket.on('update_lesson_progress', (data) => {
 		if (data.course === props.courseName) {
 			lessonProgress.value = data.progress
+			outline.reload()
 		}
 	})
 })

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -499,7 +499,6 @@ onMounted(() => {
 	socket.on('update_lesson_progress', (data) => {
 		if (data.course === props.courseName) {
 			lessonProgress.value = data.progress
-			outline.reload()
 		}
 	})
 })
@@ -650,6 +649,11 @@ const progress = createResource({
 	onSuccess(data) {
 		lessonProgress.value = data
 		completedLesson.value = lesson.data?.name
+		// This user's own completion is the only thing that changes this user's lock
+		// state. update_lesson_progress is broadcast to the whole website room, so
+		// reloading from the socket handler refetched the outline in every concurrent
+		// viewer's browser whenever anyone completed anything.
+		outline.reload()
 	},
 })
 
@@ -728,7 +732,15 @@ const outlineLessons = computed(() =>
 const nextLessonLocked = computed(
 	() => !!outlineLessons.value[currentIndex.value + 1]?.locked
 )
-const canGoNext = computed(() => hasNext.value && !nextLessonLocked.value)
+const outlineReady = computed(() => Array.isArray(outline.data))
+// Next used to be outline-independent (v-if="lesson.data.next"). Keep that
+// behaviour until the outline resolves, and if it never does: an unresolved,
+// errored or rate-limited outline would otherwise hide Next AND the Back to
+// Course fallback, leaving no forward affordance at all — on ungated courses too.
+const canGoNext = computed(() => {
+	if (!outlineReady.value) return !!lesson.data?.next
+	return hasNext.value && !nextLessonLocked.value
+})
 
 const goToLessonNumber = (number, { replace = false } = {}) => {
 	trackVideoWatchDuration()
@@ -757,7 +769,9 @@ const goPrev = () => {
 }
 
 const goNext = () => {
-	if (canGoNext.value)
+	// The mobile pager is driven by the outline, so it needs the outline-derived
+	// index too — canGoNext alone can be true before the outline resolves.
+	if (canGoNext.value && hasNext.value)
 		goToLessonNumber(lessonNumbers.value[currentIndex.value + 1])
 }
 

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -90,30 +90,10 @@
 				</div>
 			</div>
 			<div v-else-if="lesson.data.locked" class="sm:border-e">
-				<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
-					<div class="flex items-center justify-center mt-4 gap-x-2">
-						<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
-						<div class="text-p-lg-semibold text-ink-gray-7">
-							{{ __('This lesson is locked') }}
-						</div>
-					</div>
-					<div class="mt-1 text-p-base text-ink-gray-7">
-						{{
-							__('This lesson is locked until the previous lessons are done.')
-						}}
-					</div>
-					<div
-						class="mt-2 mb-4 text-p-sm text-ink-gray-5 tabular-nums"
-						role="status"
-						aria-live="polite"
-					>
-						{{
-							__('Taking you to your current lesson in {0}...').format(
-								redirectCountdown
-							)
-						}}
-					</div>
-				</div>
+				<LockedLessonNotice
+					:redirect="!!lesson.data.redirect_to"
+					@done="goToCurrentLesson()"
+				/>
 			</div>
 			<div
 				v-else
@@ -429,6 +409,7 @@ import ProgressBar from '@/components/ProgressBar.vue'
 import Discussions from '@/components/Discussions.vue'
 import CertificationLinks from '@/components/CertificationLinks.vue'
 import CourseOutline from '@/components/CourseOutline.vue'
+import LockedLessonNotice from '@/components/LockedLessonNotice.vue'
 import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
 import BottomSheet from '@/components/BottomSheet.vue'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
@@ -558,7 +539,6 @@ const setupLesson = (data) => {
 		return
 	}
 	if (data.locked) {
-		startLockedRedirect(data.redirect_to)
 		return
 	}
 	if (data.is_scorm_package) {
@@ -772,34 +752,10 @@ const goToLessonNumber = (number, { replace = false } = {}) => {
 	else router.push(target)
 }
 
-const REDIRECT_SECONDS = 3
-const redirectCountdown = ref(REDIRECT_SECONDS)
-let redirectTimer = null
-
-const clearLockedRedirect = () => {
-	if (redirectTimer) {
-		clearInterval(redirectTimer)
-		redirectTimer = null
-	}
+const goToCurrentLesson = () => {
+	if (lesson.data?.redirect_to)
+		goToLessonNumber(lesson.data.redirect_to, { replace: true })
 }
-
-// The panel counts down rather than redirecting on arrival, so the student reads why
-// they were moved instead of landing on an unexplained lesson.
-const startLockedRedirect = (target) => {
-	clearLockedRedirect()
-	if (!target) return
-	redirectCountdown.value = REDIRECT_SECONDS
-	redirectTimer = setInterval(() => {
-		redirectCountdown.value -= 1
-		if (redirectCountdown.value > 0) return
-		clearLockedRedirect()
-		goToLessonNumber(target, { replace: true })
-	}, 1000)
-}
-
-onBeforeUnmount(() => {
-	clearLockedRedirect()
-})
 
 const goPrev = () => {
 	if (hasPrev.value)

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -38,10 +38,10 @@
 				{{ lessonIndex }} / {{ lessonTotal }}
 			</div>
 			<Button
+				v-if="canGoNext"
 				variant="subtle"
 				class="!size-9"
 				:label="__('Next lesson')"
-				:disabled="!hasNext"
 				@click="goNext()"
 			>
 				<template #icon>
@@ -86,6 +86,26 @@
 							<span class="lucide-log-in size-4" />
 						</template>
 						{{ __('Login') }}
+					</Button>
+				</div>
+			</div>
+			<div v-else-if="lesson.data.locked" class="sm:border-e">
+				<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
+					<div class="flex items-center justify-center mt-4 gap-x-2">
+						<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
+						<div class="text-lg-semibold text-ink-gray-7">
+							{{ __('This lesson is locked') }}
+						</div>
+					</div>
+					<div class="mt-1 mb-4 text-ink-gray-7">
+						{{
+							__(
+								'Complete the previous lesson to unlock this one. Taking you back to where you left off.'
+							)
+						}}
+					</div>
+					<Button variant="solid" @click="goToCurrentLesson()">
+						{{ __('Go to my current lesson') }}
 					</Button>
 				</div>
 			</div>
@@ -147,7 +167,10 @@
 									</template>
 									<span>{{ __('Previous') }}</span>
 								</Button>
-								<Button v-if="lesson.data.next" @click="switchLesson('next')">
+								<Button
+									v-if="lesson.data.next && canGoNext"
+									@click="switchLesson('next')"
+								>
 									<template #suffix>
 										<span class="lucide-chevron-right size-4" />
 									</template>
@@ -187,7 +210,10 @@
 									</span>
 								</Button>
 
-								<Button v-if="lesson.data.next" @click="switchLesson('next')">
+								<Button
+									v-if="lesson.data.next && canGoNext"
+									@click="switchLesson('next')"
+								>
 									<template #suffix>
 										<span class="lucide-chevron-right size-4" />
 									</template>
@@ -515,6 +541,10 @@ const setupLesson = (data) => {
 		})
 		return
 	}
+	if (data.locked) {
+		goToLessonNumber(data.redirect_to, { replace: true })
+		return
+	}
 	if (data.is_scorm_package) {
 		router.push({
 			name: 'SCORMChapter',
@@ -691,11 +721,18 @@ const hasPrev = computed(() => currentIndex.value > 0)
 const hasNext = computed(
 	() => currentIndex.value >= 0 && currentIndex.value < lessonTotal.value - 1
 )
+const outlineLessons = computed(() =>
+	(outline.data ?? []).flatMap((c) => c.lessons ?? [])
+)
+const nextLessonLocked = computed(
+	() => !!outlineLessons.value[currentIndex.value + 1]?.locked
+)
+const canGoNext = computed(() => hasNext.value && !nextLessonLocked.value)
 
-const goToLessonNumber = (number) => {
+const goToLessonNumber = (number, { replace = false } = {}) => {
 	trackVideoWatchDuration()
 	const [chapterNumber, lessonNumber] = number.split('-')
-	router.push({
+	const target = {
 		name: 'Lesson',
 		params: {
 			courseName: props.courseName,
@@ -703,7 +740,14 @@ const goToLessonNumber = (number) => {
 			lessonNumber,
 		},
 		query: studentViewQuery.value,
-	})
+	}
+	if (replace) router.replace(target)
+	else router.push(target)
+}
+
+const goToCurrentLesson = () => {
+	if (lesson.data?.redirect_to)
+		goToLessonNumber(lesson.data.redirect_to, { replace: true })
 }
 
 const goPrev = () => {
@@ -712,11 +756,12 @@ const goPrev = () => {
 }
 
 const goNext = () => {
-	if (hasNext.value)
+	if (canGoNext.value)
 		goToLessonNumber(lessonNumbers.value[currentIndex.value + 1])
 }
 
 const switchLesson = (direction) => {
+	if (direction === 'next' && !canGoNext.value) return
 	trackVideoWatchDuration()
 	let target =
 		direction === 'prev'

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -97,16 +97,22 @@
 							{{ __('This lesson is locked') }}
 						</div>
 					</div>
-					<div class="mt-1 mb-4 text-ink-gray-7">
+					<div class="mt-1 text-ink-gray-7">
 						{{
-							__(
-								'Complete the previous lesson to unlock this one. Taking you back to where you left off.'
+							__('This lesson is locked until the previous lessons are done.')
+						}}
+					</div>
+					<div
+						class="mt-2 mb-4 text-ink-gray-5 tabular-nums"
+						role="status"
+						aria-live="polite"
+					>
+						{{
+							__('Taking you to your current lesson in {0}...').format(
+								redirectCountdown
 							)
 						}}
 					</div>
-					<Button variant="solid" @click="goToCurrentLesson()">
-						{{ __('Go to my current lesson') }}
-					</Button>
 				</div>
 			</div>
 			<div
@@ -552,7 +558,7 @@ const setupLesson = (data) => {
 		return
 	}
 	if (data.locked) {
-		goToLessonNumber(data.redirect_to, { replace: true })
+		startLockedRedirect(data.redirect_to)
 		return
 	}
 	if (data.is_scorm_package) {
@@ -766,10 +772,34 @@ const goToLessonNumber = (number, { replace = false } = {}) => {
 	else router.push(target)
 }
 
-const goToCurrentLesson = () => {
-	if (lesson.data?.redirect_to)
-		goToLessonNumber(lesson.data.redirect_to, { replace: true })
+const REDIRECT_SECONDS = 3
+const redirectCountdown = ref(REDIRECT_SECONDS)
+let redirectTimer = null
+
+const clearLockedRedirect = () => {
+	if (redirectTimer) {
+		clearInterval(redirectTimer)
+		redirectTimer = null
+	}
 }
+
+// The panel counts down rather than redirecting on arrival, so the student reads why
+// they were moved instead of landing on an unexplained lesson.
+const startLockedRedirect = (target) => {
+	clearLockedRedirect()
+	if (!target) return
+	redirectCountdown.value = REDIRECT_SECONDS
+	redirectTimer = setInterval(() => {
+		redirectCountdown.value -= 1
+		if (redirectCountdown.value > 0) return
+		clearLockedRedirect()
+		goToLessonNumber(target, { replace: true })
+	}, 1000)
+}
+
+onBeforeUnmount(() => {
+	clearLockedRedirect()
+})
 
 const goPrev = () => {
 	if (hasPrev.value)

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -93,17 +93,17 @@
 				<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
 					<div class="flex items-center justify-center mt-4 gap-x-2">
 						<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
-						<div class="text-lg-semibold text-ink-gray-7">
+						<div class="text-p-lg-semibold text-ink-gray-7">
 							{{ __('This lesson is locked') }}
 						</div>
 					</div>
-					<div class="mt-1 text-ink-gray-7">
+					<div class="mt-1 text-p-base text-ink-gray-7">
 						{{
 							__('This lesson is locked until the previous lessons are done.')
 						}}
 					</div>
 					<div
-						class="mt-2 mb-4 text-ink-gray-5 tabular-nums"
+						class="mt-2 mb-4 text-p-sm text-ink-gray-5 tabular-nums"
 						role="status"
 						aria-live="polite"
 					>

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -1,8 +1,29 @@
 <template>
 	<PageHeader :breadcrumbs="breadcrumbs" />
+	<div v-if="isLocked" class="sm:border-e">
+		<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
+			<div class="flex items-center justify-center mt-4 gap-x-2">
+				<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
+				<div class="text-lg-semibold text-ink-gray-7">
+					{{ __('This lesson is locked') }}
+				</div>
+			</div>
+			<div class="mt-1 mb-4 text-ink-gray-7">
+				{{ __('Complete the previous lesson to unlock this one.') }}
+			</div>
+			<Button
+				v-if="currentLessonNumber"
+				variant="solid"
+				@click="goToCurrentLesson()"
+			>
+				{{ __('Go to my current lesson') }}
+			</Button>
+		</div>
+	</div>
 	<div
-		v-if="
+		v-else-if="
 			readyToRender &&
+			outlineSettled &&
 			(enrollment.data?.length ||
 				user.data?.is_moderator ||
 				user.data?.is_instructor)
@@ -41,11 +62,13 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 import { computed, inject, onBeforeMount, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
 import { useSidebar } from '@/stores/sidebar'
 import { sessionStore } from '../stores/session'
 import { safeUrl } from '@/utils/safeUrl'
 
+const router = useRouter()
 const { brand } = sessionStore()
 const sidebarStore = useSidebar()
 const user = inject('$user')
@@ -82,6 +105,64 @@ const chapter = createDocumentResource({
 		progress.submit()
 	},
 })
+
+// This page reads the Course Chapter doc straight from the DB and iframes its
+// launch file; it never calls get_lesson, so without the outline it is a route
+// around the sequential-completion gate. The server refuses the SCORM bytes
+// either way (SCORMRenderer._check_permission), this turns that refusal into the
+// same locked treatment the lesson page shows.
+const outline = createResource({
+	url: 'lms.lms.utils.get_course_outline',
+	cache: ['course_outline_student', props.courseName, 'progress'],
+	makeParams() {
+		return {
+			course: props.courseName,
+			progress: true,
+		}
+	},
+	auto: true,
+})
+
+const outlineLessons = computed(() =>
+	(outline.data ?? []).flatMap((chapter) => chapter.lessons ?? [])
+)
+
+// The chapter doc and its progress resolve on a chain of their own, so without
+// this the iframe can mount before the outline has said whether the chapter is
+// locked — and the student reads the server's 403 page for the package before the
+// locked notice replaces it. An outline that errors still settles: the bytes are
+// refused server side either way, and waiting forever would leave a blank page.
+const outlineSettled = computed(
+	() => Array.isArray(outline.data) || !!outline.error
+)
+
+const isLocked = computed(() => {
+	const chapter = (outline.data ?? []).find(
+		(item) => item.name === props.chapterName
+	)
+	const lessons = chapter?.lessons ?? []
+	return lessons.length > 0 && lessons.every((lesson) => lesson.locked)
+})
+
+// The rule leaves exactly one incomplete lesson open: the one to resume at.
+const currentLessonNumber = computed(
+	() =>
+		outlineLessons.value.find((lesson) => !lesson.locked && !lesson.is_complete)
+			?.number
+)
+
+const goToCurrentLesson = () => {
+	if (!currentLessonNumber.value) return
+	const [chapterNumber, lessonNumber] = currentLessonNumber.value.split('-')
+	router.replace({
+		name: 'Lesson',
+		params: {
+			courseName: props.courseName,
+			chapterNumber,
+			lessonNumber,
+		},
+	})
+}
 
 const enrollment = createListResource({
 	doctype: 'LMS Enrollment',

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -1,29 +1,10 @@
 <template>
 	<PageHeader :breadcrumbs="breadcrumbs" />
 	<div v-if="isLocked" class="sm:border-e">
-		<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
-			<div class="flex items-center justify-center mt-4 gap-x-2">
-				<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
-				<div class="text-p-lg-semibold text-ink-gray-7">
-					{{ __('This lesson is locked') }}
-				</div>
-			</div>
-			<div class="mt-1 text-p-base text-ink-gray-7">
-				{{ __('This lesson is locked until the previous lessons are done.') }}
-			</div>
-			<div
-				v-if="currentLessonNumber"
-				class="mt-2 mb-4 text-p-sm text-ink-gray-5 tabular-nums"
-				role="status"
-				aria-live="polite"
-			>
-				{{
-					__('Taking you to your current lesson in {0}...').format(
-						redirectCountdown
-					)
-				}}
-			</div>
-		</div>
+		<LockedLessonNotice
+			:redirect="!!currentLessonNumber"
+			@done="goToCurrentLesson()"
+		/>
 	</div>
 	<div
 		v-else-if="
@@ -66,16 +47,10 @@ import {
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
-import {
-	computed,
-	inject,
-	onBeforeMount,
-	onBeforeUnmount,
-	ref,
-	watch,
-} from 'vue'
+import { computed, inject, onBeforeMount, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
+import LockedLessonNotice from '@/components/LockedLessonNotice.vue'
 import { useSidebar } from '@/stores/sidebar'
 import { sessionStore } from '../stores/session'
 import { safeUrl } from '@/utils/safeUrl'
@@ -176,10 +151,6 @@ const currentLessonNumber = computed(
 			?.number
 )
 
-const REDIRECT_SECONDS = 3
-const redirectCountdown = ref(REDIRECT_SECONDS)
-let redirectTimer = null
-
 const goToCurrentLesson = () => {
 	if (!currentLessonNumber.value) return
 	const [chapterNumber, lessonNumber] = currentLessonNumber.value.split('-')
@@ -192,28 +163,6 @@ const goToCurrentLesson = () => {
 		},
 	})
 }
-
-// Counts down rather than redirecting on arrival, so the student reads why they were
-// moved instead of landing on an unexplained lesson.
-watch(
-	[isLocked, currentLessonNumber],
-	([locked, target]) => {
-		if (redirectTimer || !locked || !target) return
-		redirectCountdown.value = REDIRECT_SECONDS
-		redirectTimer = setInterval(() => {
-			redirectCountdown.value -= 1
-			if (redirectCountdown.value > 0) return
-			clearInterval(redirectTimer)
-			redirectTimer = null
-			goToCurrentLesson()
-		}, 1000)
-	},
-	{ immediate: true }
-)
-
-onBeforeUnmount(() => {
-	if (redirectTimer) clearInterval(redirectTimer)
-})
 
 const enrollment = createListResource({
 	doctype: 'LMS Enrollment',

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -8,16 +8,21 @@
 					{{ __('This lesson is locked') }}
 				</div>
 			</div>
-			<div class="mt-1 mb-4 text-ink-gray-7">
-				{{ __('Complete the previous lesson to unlock this one.') }}
+			<div class="mt-1 text-ink-gray-7">
+				{{ __('This lesson is locked until the previous lessons are done.') }}
 			</div>
-			<Button
+			<div
 				v-if="currentLessonNumber"
-				variant="solid"
-				@click="goToCurrentLesson()"
+				class="mt-2 mb-4 text-ink-gray-5 tabular-nums"
+				role="status"
+				aria-live="polite"
 			>
-				{{ __('Go to my current lesson') }}
-			</Button>
+				{{
+					__('Taking you to your current lesson in {0}...').format(
+						redirectCountdown
+					)
+				}}
+			</div>
 		</div>
 	</div>
 	<div
@@ -61,7 +66,14 @@ import {
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
-import { computed, inject, onBeforeMount, ref } from 'vue'
+import {
+	computed,
+	inject,
+	onBeforeMount,
+	onBeforeUnmount,
+	ref,
+	watch,
+} from 'vue'
 import { useRouter } from 'vue-router'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
 import { useSidebar } from '@/stores/sidebar'
@@ -104,7 +116,20 @@ const chapter = createDocumentResource({
 	onSuccess(data) {
 		progress.submit()
 	},
+	// `/learn/:chapterName` also matches a lesson URL with no lesson number, so a
+	// mistyped or tampered address resolves to a chapter that does not exist. Without
+	// this the page renders nothing at all.
+	onError() {
+		leaveForCourse()
+	},
 })
+
+const leaveForCourse = () => {
+	router.replace({
+		name: 'CourseDetail',
+		params: { courseName: props.courseName },
+	})
+}
 
 // This page reads the Course Chapter doc straight from the DB and iframes its
 // launch file; it never calls get_lesson, so without the outline it is a route
@@ -151,6 +176,10 @@ const currentLessonNumber = computed(
 			?.number
 )
 
+const REDIRECT_SECONDS = 3
+const redirectCountdown = ref(REDIRECT_SECONDS)
+let redirectTimer = null
+
 const goToCurrentLesson = () => {
 	if (!currentLessonNumber.value) return
 	const [chapterNumber, lessonNumber] = currentLessonNumber.value.split('-')
@@ -163,6 +192,28 @@ const goToCurrentLesson = () => {
 		},
 	})
 }
+
+// Counts down rather than redirecting on arrival, so the student reads why they were
+// moved instead of landing on an unexplained lesson.
+watch(
+	[isLocked, currentLessonNumber],
+	([locked, target]) => {
+		if (redirectTimer || !locked || !target) return
+		redirectCountdown.value = REDIRECT_SECONDS
+		redirectTimer = setInterval(() => {
+			redirectCountdown.value -= 1
+			if (redirectCountdown.value > 0) return
+			clearInterval(redirectTimer)
+			redirectTimer = null
+			goToCurrentLesson()
+		}, 1000)
+	},
+	{ immediate: true }
+)
+
+onBeforeUnmount(() => {
+	if (redirectTimer) clearInterval(redirectTimer)
+})
 
 const enrollment = createListResource({
 	doctype: 'LMS Enrollment',

--- a/frontend/src/pages/SCORMChapter.vue
+++ b/frontend/src/pages/SCORMChapter.vue
@@ -4,16 +4,16 @@
 		<div class="shadow rounded-md w-3/4 mt-10 mx-auto text-center p-4">
 			<div class="flex items-center justify-center mt-4 gap-x-2">
 				<span class="lucide-lock-keyhole size-4 text-ink-gray-5" />
-				<div class="text-lg-semibold text-ink-gray-7">
+				<div class="text-p-lg-semibold text-ink-gray-7">
 					{{ __('This lesson is locked') }}
 				</div>
 			</div>
-			<div class="mt-1 text-ink-gray-7">
+			<div class="mt-1 text-p-base text-ink-gray-7">
 				{{ __('This lesson is locked until the previous lessons are done.') }}
 			</div>
 			<div
 				v-if="currentLessonNumber"
-				class="mt-2 mb-4 text-ink-gray-5 tabular-nums"
+				class="mt-2 mb-4 text-p-sm text-ink-gray-5 tabular-nums"
 				role="status"
 				aria-live="polite"
 			>

--- a/frontend/src/tests/ChapterRow.test.ts
+++ b/frontend/src/tests/ChapterRow.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ChapterRow from '@/components/ChapterRow.vue'
+import type { OutlineChapter } from '@/types'
 
 const pushMock = vi.hoisted(() => vi.fn())
 
@@ -48,7 +49,7 @@ vi.mock('vuedraggable', () => ({
 
 vi.stubGlobal('__', (s: string) => s)
 
-const chapter = {
+const chapter: OutlineChapter = {
 	name: 'CH-2',
 	title: 'Old Chapter',
 	idx: 2,
@@ -56,10 +57,10 @@ const chapter = {
 	lessons: [{ name: 'LESSON-1', title: 'Lesson 1', number: '2-1' }],
 }
 
-const mountRow = () =>
+const mountRow = (chapterOverride: OutlineChapter = chapter) =>
 	mount(ChapterRow, {
 		props: {
-			chapter,
+			chapter: chapterOverride,
 			index: 1,
 			courseName: 'course-1',
 			allowEdit: true,
@@ -89,5 +90,50 @@ describe('ChapterRow inline rename', () => {
 			{ chapter, title: 'Renamed Chapter' },
 		])
 		expect(wrapper.text()).not.toContain('Lesson 1')
+	})
+})
+
+describe('ChapterRow locked lesson', () => {
+	it('renders a lock and no router-link for a locked lesson', () => {
+		const wrapper = mountRow({
+			...chapter,
+			idx: 1,
+			lessons: [
+				{ name: 'LESSON-1', title: 'Lesson 1', number: '2-1', locked: 1 },
+			],
+		})
+
+		expect(wrapper.find('.lucide-lock-keyhole').exists()).toBe(true)
+		expect(wrapper.find('a').exists()).toBe(false)
+	})
+
+	it('does not emit select-lesson when a locked inline row is clicked', async () => {
+		const wrapper = mount(ChapterRow, {
+			props: {
+				chapter: {
+					...chapter,
+					idx: 1,
+					lessons: [
+						{
+							name: 'LESSON-1',
+							title: 'Lesson 1',
+							number: '2-1',
+							locked: 1,
+						},
+					],
+				},
+				index: 1,
+				courseName: 'course-1',
+				inlineSelect: true,
+			},
+			global: {
+				mocks: { __: (s: string) => s },
+				provide: { $user: { data: { name: 'admin@example.com' } } },
+			},
+		})
+
+		await wrapper.get('[aria-disabled="true"]').trigger('click')
+
+		expect(wrapper.emitted('select-lesson')).toBeUndefined()
 	})
 })

--- a/frontend/src/tests/ChapterRow.test.ts
+++ b/frontend/src/tests/ChapterRow.test.ts
@@ -68,6 +68,9 @@ const mountRow = (chapterOverride: OutlineChapter = chapter) =>
 		global: {
 			mocks: { __: (s: string) => s },
 			provide: { $user: { data: { name: 'admin@example.com' } } },
+			stubs: {
+				'router-link': { template: '<a><slot /></a>' },
+			},
 		},
 	})
 
@@ -105,6 +108,56 @@ describe('ChapterRow locked lesson', () => {
 
 		expect(wrapper.find('.lucide-lock-keyhole').exists()).toBe(true)
 		expect(wrapper.find('a').exists()).toBe(false)
+	})
+
+	it('still links an unlocked lesson', () => {
+		const wrapper = mountRow({
+			...chapter,
+			idx: 1,
+			lessons: [
+				{ name: 'LESSON-1', title: 'Lesson 1', number: '2-1', locked: 0 },
+			],
+		})
+
+		expect(wrapper.find('a').exists()).toBe(true)
+		expect(wrapper.find('.lucide-lock-keyhole').exists()).toBe(false)
+	})
+
+	// A SCORM chapter renders no DisclosurePanel, so it never reaches the per-lesson
+	// lock affordance above: it used to look identical to an open chapter, and the
+	// student learned it was locked only after SCORMChapter.vue bounced them back.
+	const scormChapter = (locked: 0 | 1): OutlineChapter => ({
+		...chapter,
+		idx: 1,
+		is_scorm_package: 1 as const,
+		lessons: [
+			{ name: 'LESSON-1', title: 'SCORM Lesson', number: '1-1', locked },
+		],
+	})
+
+	it('marks a locked SCORM chapter and refuses to open it', async () => {
+		const wrapper = mountRow(scormChapter(1))
+
+		const lock = wrapper.get('.lucide-lock-keyhole')
+		expect(lock.attributes('aria-hidden')).toBe('true')
+		expect(wrapper.get('.sr-only').text()).toBe('Locked')
+
+		await wrapper.get('[title="Old Chapter"]').trigger('click')
+		expect(pushMock).not.toHaveBeenCalled()
+	})
+
+	it('still opens an unlocked SCORM chapter', async () => {
+		const wrapper = mountRow(scormChapter(0))
+
+		expect(wrapper.find('.lucide-lock-keyhole').exists()).toBe(false)
+
+		await wrapper.get('[title="Old Chapter"]').trigger('click')
+		expect(pushMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'SCORMChapter',
+				params: { courseName: 'course-1', chapterName: 'CH-2' },
+			})
+		)
 	})
 
 	it('does not emit select-lesson when a locked inline row is clicked', async () => {

--- a/frontend/src/tests/ChapterRow.test.ts
+++ b/frontend/src/tests/ChapterRow.test.ts
@@ -110,6 +110,30 @@ describe('ChapterRow locked lesson', () => {
 		expect(wrapper.find('a').exists()).toBe(false)
 	})
 
+	// The locked row is a plain <div> (implicit role="generic"), and ARIA
+	// prohibits naming a generic element, so `aria-label` on it is not
+	// guaranteed to reach a screen reader. The state travels as real text
+	// instead, which is exposed whatever the role, and the icon is hidden so
+	// it is not announced twice.
+	it('exposes the locked state as text, not as aria-label on a div', () => {
+		const wrapper = mountRow({
+			...chapter,
+			idx: 1,
+			lessons: [
+				{ name: 'LESSON-1', title: 'Lesson 1', number: '2-1', locked: 1 },
+			],
+		})
+
+		const row = wrapper.get('.cursor-not-allowed')
+		expect(row.attributes('aria-label')).toBeUndefined()
+		expect(row.attributes('aria-disabled')).toBeUndefined()
+		expect(row.get('.sr-only').text()).toBe('Locked')
+		expect(row.text()).toContain('Lesson 1')
+
+		const lock = wrapper.get('.lucide-lock-keyhole')
+		expect(lock.attributes('aria-hidden')).toBe('true')
+	})
+
 	it('still links an unlocked lesson', () => {
 		const wrapper = mountRow({
 			...chapter,
@@ -121,6 +145,7 @@ describe('ChapterRow locked lesson', () => {
 
 		expect(wrapper.find('a').exists()).toBe(true)
 		expect(wrapper.find('.lucide-lock-keyhole').exists()).toBe(false)
+		expect(wrapper.text()).not.toContain('Locked')
 	})
 
 	// A SCORM chapter renders no DisclosurePanel, so it never reaches the per-lesson
@@ -185,7 +210,7 @@ describe('ChapterRow locked lesson', () => {
 			},
 		})
 
-		await wrapper.get('[aria-disabled="true"]').trigger('click')
+		await wrapper.get('.cursor-not-allowed').trigger('click')
 
 		expect(wrapper.emitted('select-lesson')).toBeUndefined()
 	})

--- a/frontend/src/tests/coursePublishSettings.test.ts
+++ b/frontend/src/tests/coursePublishSettings.test.ts
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import CoursePublishSettings from '@/pages/Courses/CoursePublishSettings.vue'
+
+vi.hoisted(() => {
+	// @/utils pulls in plyr, which touches matchMedia at import time.
+	window.matchMedia ??= (() => ({
+		matches: false,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+	})) as unknown as typeof window.matchMedia
+})
+
+vi.mock('@/stores/settings', () => ({
+	useSettings: () => ({
+		settings: { data: { is_payments_app_installed: 1 } },
+	}),
+}))
+
+vi.mock('frappe-ui', () => ({
+	Dialog: { template: '<div><slot /></div>' },
+	FormControl: { template: '<div />' },
+	createResource: () => ({ data: null, reload: vi.fn(), submit: vi.fn() }),
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const doc = {
+	name: 'COURSE-1',
+	upcoming: 0,
+	featured: 0,
+	disable_self_learning: 0,
+	enforce_lesson_completion: 0,
+}
+
+describe('CoursePublishSettings', () => {
+	it('renders a switch bound to enforce_lesson_completion', () => {
+		const markDirty = vi.fn()
+		const wrapper = mount(CoursePublishSettings, {
+			global: {
+				mocks: { __: (s: string) => s },
+				provide: {
+					courseForm: { resource: { doc }, markDirty },
+					$dayjs: (v: unknown) => ({ format: () => String(v) }),
+				},
+				stubs: {
+					CollapsibleSection: { template: '<div><slot /></div>' },
+					Link: true,
+					NewMemberModal: true,
+					BooleanSwitch: {
+						props: ['modelValue', 'label'],
+						emits: ['update:modelValue'],
+						template: `<button
+							:data-label="label"
+							@click="$emit('update:modelValue', !modelValue)"
+						/>`,
+					},
+				},
+			},
+		})
+
+		const toggle = wrapper.find('[data-label="Enforce Lesson Completion"]')
+		expect(toggle.exists()).toBe(true)
+	})
+
+	it('marks the form dirty when the switch is flipped', async () => {
+		const markDirty = vi.fn()
+		const wrapper = mount(CoursePublishSettings, {
+			global: {
+				mocks: { __: (s: string) => s },
+				provide: {
+					courseForm: { resource: { doc: { ...doc } }, markDirty },
+					$dayjs: (v: unknown) => ({ format: () => String(v) }),
+				},
+				stubs: {
+					CollapsibleSection: { template: '<div><slot /></div>' },
+					Link: true,
+					NewMemberModal: true,
+					BooleanSwitch: {
+						props: ['modelValue', 'label'],
+						emits: ['update:modelValue'],
+						template: `<button
+							:data-label="label"
+							@click="$emit('update:modelValue', !modelValue)"
+						/>`,
+					},
+				},
+			},
+		})
+
+		await wrapper
+			.find('[data-label="Enforce Lesson Completion"]')
+			.trigger('click')
+		expect(markDirty).toHaveBeenCalled()
+	})
+})

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -372,8 +372,20 @@ describe('Lesson.vue locked lesson payload', () => {
 	})
 })
 
+const progressHandler = () => {
+	const handlerCall = socketOnMock.mock.calls.find(
+		(call: unknown[]) => call[0] === 'update_lesson_progress'
+	)
+	expect(handlerCall).toBeDefined()
+	return handlerCall![1] as (data: {
+		course: string
+		lesson?: string
+		progress: number
+	}) => void
+}
+
 describe('Lesson.vue unlocks the next lesson without a reload', () => {
-	it('reloads the outline from this user own completion, not from the broadcast', async () => {
+	it('reloads the outline when this page marks the lesson complete', async () => {
 		wrapper = await mountLesson()
 		const outline = findResource('lms.lms.utils.get_course_outline')
 		const progress = findResource(
@@ -392,25 +404,67 @@ describe('Lesson.vue unlocks the next lesson without a reload', () => {
 		expect(outline.reload).toHaveBeenCalledTimes(1)
 	})
 
-	it('leaves the outline alone when someone else completion is broadcast', async () => {
-		// update_lesson_progress goes to the site-wide website room, so reloading from
-		// it refetched the outline in every concurrent viewer of the course.
+	it('reloads the outline when a quiz completes the lesson', async () => {
+		// Quiz.vue and Assignment.vue complete a lesson by calling
+		// mark_lesson_progress directly; they never touch this page's progress
+		// resource, so update_lesson_progress is the only signal that the next
+		// lesson unlocked. With enforce_quiz_completion on by default, this is
+		// the ordinary unlock path for a gated course.
 		wrapper = await mountLesson()
 		const outline = findResource('lms.lms.utils.get_course_outline')
-		const handlerCall = socketOnMock.mock.calls.find(
-			(call: unknown[]) => call[0] === 'update_lesson_progress'
-		)
-		expect(handlerCall).toBeDefined()
-		const handler = handlerCall![1] as (data: {
-			course: string
-			progress: number
-		}) => void
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			membership: { progress: 0 },
+		}
+		await flushPromises()
 		outline.reload.mockClear()
 
-		handler({ course: 'COURSE-1', progress: 40 })
+		progressHandler()({ course: 'COURSE-1', lesson: 'L1', progress: 40 })
+
+		expect(outline.reload).toHaveBeenCalledTimes(1)
+		expect((wrapper.vm as any).lessonProgress).toBe(40)
+	})
+
+	it('ignores progress events for another course', async () => {
+		wrapper = await mountLesson()
+		const outline = findResource('lms.lms.utils.get_course_outline')
+		outline.reload.mockClear()
+
+		progressHandler()({ course: 'OTHER-COURSE', lesson: 'L9', progress: 90 })
 
 		expect(outline.reload).not.toHaveBeenCalled()
-		expect((wrapper.vm as any).lessonProgress).toBe(40)
+		expect((wrapper.vm as any).lessonProgress).not.toBe(90)
+	})
+
+	it('takes its progress listener with it when the page is left', async () => {
+		// The listener outlived the page, so revisiting the lesson N times left N
+		// handlers subscribed and one progress event fired N outline reloads.
+		wrapper = await mountLesson()
+		const handler = progressHandler()
+
+		wrapper.unmount()
+
+		expect(socketOffMock).toHaveBeenCalledWith(
+			'update_lesson_progress',
+			handler
+		)
+	})
+
+	it('does not reload twice for the completion this page already handled', async () => {
+		wrapper = await mountLesson()
+		const outline = findResource('lms.lms.utils.get_course_outline')
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			membership: { progress: 0 },
+		}
+		await flushPromises()
+		;(wrapper.vm as any).markProgress()
+		await flushPromises()
+		outline.reload.mockClear()
+
+		progressHandler()({ course: 'COURSE-1', lesson: 'L1', progress: 40 })
+
+		expect(outline.reload).not.toHaveBeenCalled()
 	})
 })
 

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -351,16 +351,12 @@ describe('Lesson.vue locked lesson payload', () => {
 			await flushPromises()
 
 			expect(wrapper.text()).toContain('This lesson is locked')
-			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 3s'
-			)
+			expect(wrapper.text()).toContain('3s')
 			expect(replaceMock).not.toHaveBeenCalled()
 
 			vi.advanceTimersByTime(1000)
 			await flushPromises()
-			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 2s'
-			)
+			expect(wrapper.text()).toContain('2s')
 			expect(replaceMock).not.toHaveBeenCalled()
 
 			vi.advanceTimersByTime(2000)
@@ -398,7 +394,7 @@ describe('Lesson.vue locked lesson payload', () => {
 		expect(wrapper.text()).toContain('Lesson not found')
 		expect(wrapper.text()).not.toContain('This lesson is locked')
 		expect(wrapper.text()).not.toContain(
-			'Finish the earlier lessons to unlock this one'
+			'Finish the lessons before it to unlock this one'
 		)
 	})
 

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -138,7 +138,22 @@ vi.mock('@/components/Notes/InlineLessonMenu.vue', () => ({
 	default: stub('InlineLessonMenu'),
 }))
 
-vi.stubGlobal('__', (s: string) => s)
+// Mirrors src/translation.js: a message with {0}-style placeholders returns a
+// formatter object, not a string. A stub that always returns the string hides a
+// real "__(...).format is not a function" crash.
+const translateStub = (s: string) =>
+	/{\d+}/.test(s)
+		? {
+				format: (...args: unknown[]) =>
+					s.replace(/{(\d+)}/g, (match, index) =>
+						args[Number(index)] === undefined
+							? match
+							: String(args[Number(index)])
+					),
+		  }
+		: s
+
+vi.stubGlobal('__', translateStub)
 
 import Lesson from '@/pages/Lesson.vue'
 
@@ -154,7 +169,7 @@ async function mountLesson(
 	const wrapper = mount(Lesson, {
 		props: { courseName: 'COURSE-1', ...props },
 		global: {
-			mocks: { __: (s: string) => s },
+			mocks: { __: translateStub },
 			provide: {
 				$user: { data: { name: 'student@example.com' } },
 				$socket: { on: socketOnMock, off: socketOffMock },
@@ -323,52 +338,70 @@ describe('Lesson.vue Next affordance follows canGoNext', () => {
 })
 
 describe('Lesson.vue locked lesson payload', () => {
-	it('replaces (not pushes) to redirect_to and renders the locked panel', async () => {
-		wrapper = await mountLesson()
-		findResource('lms.lms.utils.get_lesson').data = {
-			locked: 1,
-			title: 'Lesson 3',
-			course_title: 'Course 1',
-			redirect_to: '2-3',
-		}
-		await flushPromises()
+	it('shows the locked panel and counts down before navigating', async () => {
+		vi.useFakeTimers()
+		try {
+			wrapper = await mountLesson()
+			findResource('lms.lms.utils.get_lesson').data = {
+				locked: 1,
+				title: 'Lesson 3',
+				course_title: 'Course 1',
+				redirect_to: '2-3',
+			}
+			await flushPromises()
 
-		expect(replaceMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: 'Lesson',
-				params: {
-					courseName: 'COURSE-1',
-					chapterNumber: '2',
-					lessonNumber: '3',
-				},
-			})
-		)
-		expect(pushMock).not.toHaveBeenCalled()
-		expect(wrapper.text()).toContain('This lesson is locked')
-		expect(wrapper.text()).toContain('Go to my current lesson')
+			expect(wrapper.text()).toContain('This lesson is locked')
+			expect(wrapper.text()).toContain(
+				'Taking you to your current lesson in 3...'
+			)
+			expect(replaceMock).not.toHaveBeenCalled()
+
+			vi.advanceTimersByTime(1000)
+			await flushPromises()
+			expect(wrapper.text()).toContain(
+				'Taking you to your current lesson in 2...'
+			)
+			expect(replaceMock).not.toHaveBeenCalled()
+
+			vi.advanceTimersByTime(2000)
+			await flushPromises()
+			expect(replaceMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Lesson',
+					params: {
+						courseName: 'COURSE-1',
+						chapterNumber: '2',
+						lessonNumber: '3',
+					},
+				})
+			)
+			expect(pushMock).not.toHaveBeenCalled()
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 
-	it('goToCurrentLesson also replaces using the payload redirect_to', async () => {
-		wrapper = await mountLesson()
-		findResource('lms.lms.utils.get_lesson').data = {
-			locked: 1,
-			title: 'Lesson 3',
-			course_title: 'Course 1',
-			redirect_to: '2-3',
-		}
-		await flushPromises()
-		replaceMock.mockReset()
-		;(wrapper.vm as any).goToCurrentLesson()
+	it('stops the countdown when the page is left before it finishes', async () => {
+		vi.useFakeTimers()
+		try {
+			wrapper = await mountLesson()
+			findResource('lms.lms.utils.get_lesson').data = {
+				locked: 1,
+				title: 'Lesson 3',
+				course_title: 'Course 1',
+				redirect_to: '2-3',
+			}
+			await flushPromises()
 
-		expect(replaceMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				params: {
-					courseName: 'COURSE-1',
-					chapterNumber: '2',
-					lessonNumber: '3',
-				},
-			})
-		)
+			wrapper.unmount()
+			wrapper = null
+			vi.advanceTimersByTime(5000)
+			await flushPromises()
+
+			expect(replaceMock).not.toHaveBeenCalled()
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 })
 

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -278,6 +278,45 @@ describe('Lesson.vue Next affordance follows canGoNext', () => {
 		)
 		expect(replaceMock).not.toHaveBeenCalled()
 	})
+
+	it('falls back to Back to Course when a next lesson exists but is locked', async () => {
+		// A lesson can be uncompletable for good (quiz attempts exhausted, SCORM that
+		// never reports completion), and hiding the fallback along with Next left the
+		// footer with no forward affordance at all and no way out of the page.
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [
+					{ name: 'L1', number: '1-1', locked: 0 },
+					{ name: 'L2', number: '1-2', locked: 1 },
+				],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+
+		expect(wrapper.text()).not.toContain('Next')
+		expect(wrapper.text()).toContain('Back to Course')
+	})
+
+	it('falls back to Back to Course only when there truly is no next lesson', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [{ name: 'L1', number: '1-1', locked: 0 }],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			next: null,
+		}
+		await flushPromises()
+
+		expect(wrapper.text()).not.toContain('Next')
+		expect(wrapper.text()).toContain('Back to Course')
+	})
 })
 
 describe('Lesson.vue locked lesson payload', () => {

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -41,6 +41,9 @@ vi.mock('frappe-ui', async () => {
 				loading: false,
 				_config: config,
 				submit: vi.fn((_params: any, handlers: any) => {
+					// frappe-ui runs the resource-level onSuccess as well as the
+					// per-call one; the outline reload lives on the former.
+					config?.onSuccess?.(resource.data)
 					handlers?.onSuccess?.(resource.data)
 					return Promise.resolve()
 				}),
@@ -370,18 +373,94 @@ describe('Lesson.vue locked lesson payload', () => {
 })
 
 describe('Lesson.vue unlocks the next lesson without a reload', () => {
-	it('reloads the outline when progress lands for this course, and ignores other courses', async () => {
+	it('reloads the outline from this user own completion, not from the broadcast', async () => {
+		wrapper = await mountLesson()
+		const outline = findResource('lms.lms.utils.get_course_outline')
+		const progress = findResource(
+			'lms.lms.doctype.course_lesson.course_lesson.save_progress'
+		)
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			membership: { progress: 0 },
+		}
+		await flushPromises()
+		outline.reload.mockClear()
+		;(wrapper.vm as any).markProgress()
+		await flushPromises()
+
+		expect(progress.submit).toHaveBeenCalled()
+		expect(outline.reload).toHaveBeenCalledTimes(1)
+	})
+
+	it('leaves the outline alone when someone else completion is broadcast', async () => {
+		// update_lesson_progress goes to the site-wide website room, so reloading from
+		// it refetched the outline in every concurrent viewer of the course.
 		wrapper = await mountLesson()
 		const outline = findResource('lms.lms.utils.get_course_outline')
 		const handlerCall = socketOnMock.mock.calls.find(
 			(call: unknown[]) => call[0] === 'update_lesson_progress'
 		)
 		expect(handlerCall).toBeDefined()
-		const handler = handlerCall![1] as (data: { course: string }) => void
+		const handler = handlerCall![1] as (data: {
+			course: string
+			progress: number
+		}) => void
+		outline.reload.mockClear()
 
-		handler({ course: 'COURSE-1' })
-		handler({ course: 'OTHER-COURSE' })
+		handler({ course: 'COURSE-1', progress: 40 })
 
-		expect(outline.reload).toHaveBeenCalledTimes(1)
+		expect(outline.reload).not.toHaveBeenCalled()
+		expect((wrapper.vm as any).lessonProgress).toBe(40)
+	})
+})
+
+describe('Lesson.vue Next survives an outline that never resolves', () => {
+	it('shows Next from lesson.data.next while the outline is still unresolved', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+
+		expect(findResource('lms.lms.utils.get_course_outline').data).toBeNull()
+		expect((wrapper.vm as any).canGoNext).toBe(true)
+		expect(wrapper.text()).toContain('Next')
+	})
+
+	it('still offers Back to Course on the last lesson with no outline', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			next: null,
+		}
+		await flushPromises()
+
+		expect((wrapper.vm as any).canGoNext).toBe(false)
+		expect(wrapper.text()).toContain('Back to Course')
+	})
+
+	it('switchLesson navigates on the unresolved-outline fallback', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+		;(wrapper.vm as any).switchLesson('next')
+
+		expect(pushMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'Lesson',
+				params: {
+					courseName: 'COURSE-1',
+					chapterNumber: '1',
+					lessonNumber: '2',
+				},
+			})
+		)
+	})
+
+	it('goNext stays put while the outline is unresolved, since it has no index', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+		;(wrapper.vm as any).goNext()
+
+		expect(pushMock).not.toHaveBeenCalled()
 	})
 })

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -381,6 +381,27 @@ describe('Lesson.vue locked lesson payload', () => {
 		}
 	})
 
+	it('says the lesson does not exist rather than that it is locked', async () => {
+		// A lesson number that resolves to nothing comes back on the same redirecting
+		// payload, and the panel used to read "This lesson is locked / Finish the
+		// earlier lessons to unlock this one" under a "Lesson not found" breadcrumb.
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = {
+			locked: 1,
+			not_found: 1,
+			title: 'Lesson not found',
+			course_title: 'Course 1',
+			redirect_to: '1-1',
+		}
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Lesson not found')
+		expect(wrapper.text()).not.toContain('This lesson is locked')
+		expect(wrapper.text()).not.toContain(
+			'Finish the earlier lessons to unlock this one'
+		)
+	})
+
 	it('stops the countdown when the page is left before it finishes', async () => {
 		vi.useFakeTimers()
 		try {

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Lesson.vue is the heaviest page in the app (1300+ lines): a socket
+ * subscription, an EditorJS instance, plyr video tracking, two Pinia stores
+ * and a dozen child components. Every dependency below is stubbed so the
+ * mount exercises the REAL `canGoNext` computed, the REAL `goNext` /
+ * `switchLesson` / `setupLesson` / `goToLessonNumber` handlers, and the REAL
+ * socket callback registered in onMounted -- not a hand-rolled restatement of
+ * any of them.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+
+const pushMock = vi.hoisted(() => vi.fn())
+const replaceMock = vi.hoisted(() => vi.fn())
+const socketOnMock = vi.hoisted(() => vi.fn())
+const socketOffMock = vi.hoisted(() => vi.fn())
+const created = vi.hoisted(() => ({ list: [] as any[] }))
+const stub = vi.hoisted(() => (name: string) => ({
+	name,
+	template: `<div><slot /></div>`,
+}))
+
+vi.mock('vue-router', () => ({
+	useRoute: () => ({
+		params: { chapterNumber: '1', lessonNumber: '1' },
+		query: {},
+	}),
+	useRouter: () => ({ push: pushMock, replace: replaceMock }),
+}))
+
+vi.mock('frappe-ui', async () => {
+	const { reactive } = await import('vue')
+	const passthrough = (name: string) => ({
+		name,
+		template: `<div><slot name="prefix" /><slot name="icon" /><slot /><slot name="suffix" /></div>`,
+	})
+	return {
+		createResource: (config: any) => {
+			const resource: any = reactive({
+				data: null,
+				loading: false,
+				_config: config,
+				submit: vi.fn((_params: any, handlers: any) => {
+					handlers?.onSuccess?.(resource.data)
+					return Promise.resolve()
+				}),
+				reload: vi.fn(),
+				fetch: vi.fn(),
+			})
+			created.list.push(resource)
+			return resource
+		},
+		createListResource: () =>
+			reactive({
+				data: [],
+				loading: false,
+				update: vi.fn(),
+				reload: vi.fn(),
+				fetch: vi.fn(),
+			}),
+		call: vi.fn(() => Promise.resolve()),
+		usePageMeta: vi.fn(),
+		toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+		Badge: passthrough('Badge'),
+		Button: {
+			name: 'Button',
+			template: `<button><slot name="prefix" /><slot name="icon" /><slot /><slot name="suffix" /></button>`,
+		},
+		TabButtons: passthrough('TabButtons'),
+		Tooltip: { name: 'Tooltip', template: `<span><slot /></span>` },
+	}
+})
+
+vi.mock('@editorjs/editorjs', () => ({
+	default: class {
+		isReady = Promise.resolve()
+		destroy = vi.fn()
+	},
+}))
+
+vi.mock('@/utils', () => ({
+	getEditorTools: () => ({}),
+	enablePlyr: () => Promise.resolve([]),
+	highlightText: vi.fn(),
+	sanitizeEditorJs: (x: any) => x,
+}))
+
+vi.mock('@/stores/session', () => ({
+	sessionStore: () => ({ brand: {} }),
+}))
+vi.mock('@/stores/sidebar', () => ({
+	useSidebar: () => ({ isSidebarCollapsed: false }),
+}))
+vi.mock('@/stores/settings', () => ({
+	useSettings: () => ({
+		settings: { data: {}, promise: Promise.resolve() },
+	}),
+}))
+
+vi.mock('@/components/LessonContent.vue', () => ({
+	default: stub('LessonContent'),
+}))
+vi.mock('@/components/CourseInstructors.vue', () => ({
+	default: stub('CourseInstructors'),
+}))
+vi.mock('@/components/ProgressBar.vue', () => ({
+	default: stub('ProgressBar'),
+}))
+vi.mock('@/components/Discussions.vue', () => ({
+	default: stub('Discussions'),
+}))
+vi.mock('@/components/CertificationLinks.vue', () => ({
+	default: stub('CertificationLinks'),
+}))
+vi.mock('@/components/CourseOutline.vue', () => ({
+	default: stub('CourseOutline'),
+}))
+vi.mock('@/components/StudentLessonSidebar.vue', () => ({
+	default: stub('StudentLessonSidebar'),
+}))
+vi.mock('@/components/BottomSheet.vue', () => ({
+	default: stub('BottomSheet'),
+}))
+vi.mock('@/components/Layouts/PageHeader.vue', () => ({
+	default: stub('PageHeader'),
+}))
+vi.mock('@/components/HeaderButton.vue', () => ({
+	default: stub('HeaderButton'),
+}))
+vi.mock('@/components/UserAvatar.vue', () => ({
+	default: stub('UserAvatar'),
+}))
+vi.mock('@/components/Notes/Notes.vue', () => ({ default: stub('Notes') }))
+vi.mock('@/components/Notes/InlineLessonMenu.vue', () => ({
+	default: stub('InlineLessonMenu'),
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+import Lesson from '@/pages/Lesson.vue'
+
+const findResource = (url: string) =>
+	created.list.find((resource) => resource._config.url === url)
+
+async function mountLesson(
+	props: { chapterNumber: string; lessonNumber: string } = {
+		chapterNumber: '1',
+		lessonNumber: '1',
+	}
+) {
+	const wrapper = mount(Lesson, {
+		props: { courseName: 'COURSE-1', ...props },
+		global: {
+			mocks: { __: (s: string) => s },
+			provide: {
+				$user: { data: { name: 'student@example.com' } },
+				$socket: { on: socketOnMock, off: socketOffMock },
+			},
+			stubs: {
+				teleport: true,
+				'router-link': { template: '<a><slot /></a>' },
+			},
+		},
+	})
+	await flushPromises()
+	return wrapper
+}
+
+const baseLesson = {
+	name: 'L1',
+	title: 'Lesson 1',
+	course_title: 'Course 1',
+	chapter_title: 'Chapter 1',
+	prev: null,
+	next: '1.2',
+	instructors: [],
+}
+
+let wrapper: VueWrapper
+
+beforeEach(() => {
+	created.list.length = 0
+	pushMock.mockReset()
+	replaceMock.mockReset()
+	socketOnMock.mockReset()
+	socketOffMock.mockReset()
+})
+
+afterEach(() => {
+	wrapper?.unmount()
+})
+
+describe('Lesson.vue Next affordance follows canGoNext', () => {
+	it('hides the Next button when the following lesson is locked', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [
+					{ name: 'L1', number: '1-1', locked: 0 },
+					{ name: 'L2', number: '1-2', locked: 1 },
+				],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+
+		expect((wrapper.vm as any).canGoNext).toBe(false)
+		expect(wrapper.text()).not.toContain('Next')
+	})
+
+	it('shows the Next button when the following lesson is unlocked', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [
+					{ name: 'L1', number: '1-1', locked: 0 },
+					{ name: 'L2', number: '1-2', locked: 0 },
+				],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+
+		expect((wrapper.vm as any).canGoNext).toBe(true)
+		expect(wrapper.text()).toContain('Next')
+	})
+
+	it('hardens goNext and switchLesson so neither navigates when the template is bypassed', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [
+					{ name: 'L1', number: '1-1', locked: 0 },
+					{ name: 'L2', number: '1-2', locked: 1 },
+				],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = { ...baseLesson }
+		await flushPromises()
+		;(wrapper.vm as any).goNext()
+		;(wrapper.vm as any).switchLesson('next')
+
+		expect(pushMock).not.toHaveBeenCalled()
+	})
+
+	it('still pushes (not replaces) for an ordinary Previous navigation', async () => {
+		wrapper = await mountLesson({ chapterNumber: '1', lessonNumber: '2' })
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{
+				name: 'CH-1',
+				lessons: [
+					{ name: 'L1', number: '1-1', locked: 0 },
+					{ name: 'L2', number: '1-2', locked: 0 },
+				],
+			},
+		]
+		findResource('lms.lms.utils.get_lesson').data = {
+			...baseLesson,
+			name: 'L2',
+			prev: '1.1',
+			next: null,
+		}
+		await flushPromises()
+		;(wrapper.vm as any).goPrev()
+
+		expect(pushMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'Lesson',
+				params: {
+					courseName: 'COURSE-1',
+					chapterNumber: '1',
+					lessonNumber: '1',
+				},
+			})
+		)
+		expect(replaceMock).not.toHaveBeenCalled()
+	})
+})
+
+describe('Lesson.vue locked lesson payload', () => {
+	it('replaces (not pushes) to redirect_to and renders the locked panel', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = {
+			locked: 1,
+			title: 'Lesson 3',
+			course_title: 'Course 1',
+			redirect_to: '2-3',
+		}
+		await flushPromises()
+
+		expect(replaceMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'Lesson',
+				params: {
+					courseName: 'COURSE-1',
+					chapterNumber: '2',
+					lessonNumber: '3',
+				},
+			})
+		)
+		expect(pushMock).not.toHaveBeenCalled()
+		expect(wrapper.text()).toContain('This lesson is locked')
+		expect(wrapper.text()).toContain('Go to my current lesson')
+	})
+
+	it('goToCurrentLesson also replaces using the payload redirect_to', async () => {
+		wrapper = await mountLesson()
+		findResource('lms.lms.utils.get_lesson').data = {
+			locked: 1,
+			title: 'Lesson 3',
+			course_title: 'Course 1',
+			redirect_to: '2-3',
+		}
+		await flushPromises()
+		replaceMock.mockReset()
+		;(wrapper.vm as any).goToCurrentLesson()
+
+		expect(replaceMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				params: {
+					courseName: 'COURSE-1',
+					chapterNumber: '2',
+					lessonNumber: '3',
+				},
+			})
+		)
+	})
+})

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -329,3 +329,20 @@ describe('Lesson.vue locked lesson payload', () => {
 		)
 	})
 })
+
+describe('Lesson.vue unlocks the next lesson without a reload', () => {
+	it('reloads the outline when progress lands for this course, and ignores other courses', async () => {
+		wrapper = await mountLesson()
+		const outline = findResource('lms.lms.utils.get_course_outline')
+		const handlerCall = socketOnMock.mock.calls.find(
+			(call: unknown[]) => call[0] === 'update_lesson_progress'
+		)
+		expect(handlerCall).toBeDefined()
+		const handler = handlerCall![1] as (data: { course: string }) => void
+
+		handler({ course: 'COURSE-1' })
+		handler({ course: 'OTHER-COURSE' })
+
+		expect(outline.reload).toHaveBeenCalledTimes(1)
+	})
+})

--- a/frontend/src/tests/lessonLocking.test.ts
+++ b/frontend/src/tests/lessonLocking.test.ts
@@ -352,14 +352,14 @@ describe('Lesson.vue locked lesson payload', () => {
 
 			expect(wrapper.text()).toContain('This lesson is locked')
 			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 3...'
+				'Taking you to your current lesson in 3s'
 			)
 			expect(replaceMock).not.toHaveBeenCalled()
 
 			vi.advanceTimersByTime(1000)
 			await flushPromises()
 			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 2...'
+				'Taking you to your current lesson in 2s'
 			)
 			expect(replaceMock).not.toHaveBeenCalled()
 

--- a/frontend/src/tests/lessonYoutubeTracking.test.ts
+++ b/frontend/src/tests/lessonYoutubeTracking.test.ts
@@ -1,11 +1,23 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Plyr is mocked the same way as plyr.test.ts: this suite only cares that
-// enablePlyr finds the markup LessonContent renders, not what the player does.
+// Plyr's YouTube provider REPLACES the element it is given —
+// `player.media = replaceElement(container, player.media)` (plyr.mjs:5901), i.e.
+// `oldChild.parentNode.replaceChild(newChild, oldChild)`, and the replacement
+// carries no `video-player` class. The fake must do the same or the mock hides
+// the class of bug where Vue keeps patching a node Plyr already detached.
 const plyrCtor = vi.hoisted(() =>
-	vi.fn(function FakePlyr(this: { on: () => void }) {
+	vi.fn(function FakePlyr(this: { on: () => void }, el: Element) {
 		this.on = () => {}
+		if (el?.parentNode) {
+			const container = document.createElement('div')
+			container.id = 'plyr-youtube-fake'
+			container.setAttribute(
+				'data-replaced-embed-id',
+				el.getAttribute('data-plyr-embed-id') || ''
+			)
+			el.parentNode.replaceChild(container, el)
+		}
 	})
 )
 vi.mock('plyr', () => ({ default: plyrCtor }))
@@ -146,5 +158,37 @@ describe('enforce_video_completion gates youtube-field lessons', () => {
 				enforceVideo: 1,
 			})
 		).toBe(true)
+	})
+
+	// Lesson.vue reuses LessonContent across lessons (no :key on it) and resets
+	// plyrSources before re-running enablePlyr. Since Plyr detaches the node it
+	// initialises, an unkeyed player element leaves Vue patching a node that is
+	// no longer in the document: the next lesson keeps showing the previous
+	// video AND enablePlyr finds nothing, so the dwell timer is not suppressed
+	// and the lesson auto-completes — the exact bug this component was changed
+	// to fix.
+	it('tracks the next lesson after navigating between two youtube-field lessons', async () => {
+		const wrapper = mountContent({
+			content: 'Lesson A',
+			youtube: 'https://www.youtube.com/watch?v=AAAAAAAAAAA',
+		})
+
+		expect(await enablePlyr()).toHaveLength(1)
+
+		await wrapper.setProps({
+			content: 'Lesson B',
+			youtube: 'https://www.youtube.com/watch?v=BBBBBBBBBBB',
+		})
+
+		const plyrSources = await enablePlyr()
+
+		expect(document.body.innerHTML).not.toContain('AAAAAAAAAAA')
+		expect(plyrSources).toHaveLength(1)
+		expect(
+			shouldStartDwellTimer({
+				hasVideo: hasVideoListener(plyrSources),
+				enforceVideo: 1,
+			})
+		).toBe(false)
 	})
 })

--- a/frontend/src/tests/lessonYoutubeTracking.test.ts
+++ b/frontend/src/tests/lessonYoutubeTracking.test.ts
@@ -1,0 +1,150 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Plyr is mocked the same way as plyr.test.ts: this suite only cares that
+// enablePlyr finds the markup LessonContent renders, not what the player does.
+const plyrCtor = vi.hoisted(() =>
+	vi.fn(function FakePlyr(this: { on: () => void }) {
+		this.on = () => {}
+	})
+)
+vi.mock('plyr', () => ({ default: plyrCtor }))
+vi.mock('plyr/dist/plyr.css', () => ({}))
+vi.mock('@/stores/settings', () => ({
+	useSettings: () => ({ settings: { data: {} } }),
+}))
+vi.mock('@/components/QuizBlock.vue', () => ({
+	default: { props: ['quiz'], template: '<div class="quiz-stub" />' },
+}))
+vi.mock('@/components/PdfBlock.vue', () => ({
+	default: { props: ['file'], template: '<div class="pdf-stub" />' },
+}))
+
+import LessonContent from '@/components/LessonContent.vue'
+import { enablePlyr } from '@/utils/plyr'
+import { shouldStartDwellTimer } from '@/utils/lessonProgress'
+
+vi.stubGlobal('__', (s: string) => s)
+
+const mountContent = (props: { content: string; youtube?: string }) =>
+	mount(LessonContent, { props, attachTo: document.body })
+
+describe('LessonContent renders tracked Plyr markup for YouTube', () => {
+	beforeEach(() => {
+		plyrCtor.mockClear()
+		document.body.innerHTML = ''
+	})
+
+	it('renders the youtube field as a .video-player, not a bare iframe', () => {
+		const wrapper = mountContent({
+			content: 'Some intro text',
+			youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		})
+
+		const player = wrapper.get('.video-player')
+		expect(player.attributes('data-plyr-provider')).toBe('youtube')
+		expect(player.attributes('data-plyr-embed-id')).toBe('dQw4w9WgXcQ')
+		expect(wrapper.find('iframe.youtube-video').exists()).toBe(false)
+	})
+
+	it.each([
+		['https://www.youtube.com/watch?v=abc123XYZ_-', 'abc123XYZ_-'],
+		['https://youtu.be/abc123XYZ_-', 'abc123XYZ_-'],
+		['https://www.youtube.com/embed/abc123XYZ_-', 'abc123XYZ_-'],
+		['https://www.youtube.com/watch?v=abc123XYZ_-&t=42s', 'abc123XYZ_-'],
+		['abc123XYZ_-', 'abc123XYZ_-'],
+	])('extracts the embed id from %s', (url, expected) => {
+		const wrapper = mountContent({ content: 'text', youtube: url })
+		expect(wrapper.get('.video-player').attributes('data-plyr-embed-id')).toBe(
+			expected
+		)
+	})
+
+	it('renders a {{ YouTubeVideo }} block as the same tracked markup', () => {
+		const wrapper = mountContent({
+			content: '{{ YouTubeVideo("https://www.youtube.com/watch?v=vid12345") }}',
+		})
+
+		const player = wrapper.get('.video-player')
+		expect(player.attributes('data-plyr-provider')).toBe('youtube')
+		expect(player.attributes('data-plyr-embed-id')).toBe('vid12345')
+		expect(wrapper.find('iframe.youtube-video').exists()).toBe(false)
+	})
+
+	it('accepts a bare video id in the macro argument', () => {
+		const wrapper = mountContent({ content: '{{ YouTubeVideo("vid12345") }}' })
+		expect(wrapper.get('.video-player').attributes('data-plyr-embed-id')).toBe(
+			'vid12345'
+		)
+	})
+
+	it('renders nothing for a malformed macro rather than an empty player', () => {
+		// An empty-id player would still count as a video and suppress the dwell
+		// timer, leaving the lesson uncompletable.
+		const wrapper = mountContent({ content: '{{ YouTubeVideo() }}' })
+		expect(wrapper.find('.video-player').exists()).toBe(false)
+	})
+
+	it('renders no player when the lesson has no youtube field', () => {
+		const wrapper = mountContent({ content: 'Just some prose.' })
+		expect(wrapper.find('.video-player').exists()).toBe(false)
+	})
+})
+
+describe('enforce_video_completion gates youtube-field lessons', () => {
+	beforeEach(() => {
+		plyrCtor.mockClear()
+		document.body.innerHTML = ''
+	})
+
+	// Mirrors Lesson.vue: hasVideoListener = plyr instances || a <video> element.
+	const hasVideoListener = (plyrSources: unknown[]) =>
+		plyrSources.length > 0 || !!document.querySelector('video')
+
+	it('suppresses the dwell timer for a youtube-field lesson', async () => {
+		mountContent({
+			content: 'Watch this.',
+			youtube: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		})
+
+		const plyrSources = await enablePlyr()
+
+		expect(plyrSources).toHaveLength(1)
+		expect(
+			shouldStartDwellTimer({
+				hasVideo: hasVideoListener(plyrSources),
+				enforceVideo: 1,
+			})
+		).toBe(false)
+	})
+
+	it('suppresses the dwell timer for a {{ YouTubeVideo }} lesson', async () => {
+		mountContent({
+			content: '{{ YouTubeVideo("https://www.youtube.com/watch?v=vid12345") }}',
+		})
+
+		const plyrSources = await enablePlyr()
+
+		expect(plyrSources).toHaveLength(1)
+		expect(
+			shouldStartDwellTimer({
+				hasVideo: hasVideoListener(plyrSources),
+				enforceVideo: 1,
+			})
+		).toBe(false)
+	})
+
+	it('still runs the dwell timer for a lesson with no video at all', async () => {
+		mountContent({ content: 'Just some prose.' })
+
+		const plyrSources = await enablePlyr()
+
+		expect(plyrSources).toHaveLength(0)
+		expect(
+			shouldStartDwellTimer({
+				hasVideo: hasVideoListener(plyrSources),
+				enforceVideo: 1,
+			})
+		).toBe(true)
+	})
+})

--- a/frontend/src/tests/lockedLessonNotice.test.ts
+++ b/frontend/src/tests/lockedLessonNotice.test.ts
@@ -103,6 +103,20 @@ describe('LockedLessonNotice', () => {
 		expect(wrapper.get('[role="status"]').text()).toBe('')
 	})
 
+	it('does not blame the lock for a lesson that does not exist', async () => {
+		const wrapper = mountNotice({ notFound: true })
+
+		expect(wrapper.text()).toContain('Lesson not found')
+		expect(wrapper.text()).toContain('There is no such lesson in this course.')
+		expect(wrapper.text()).not.toContain('This lesson is locked')
+
+		vi.advanceTimersByTime(100)
+		await nextTick()
+		expect(wrapper.get('[role="status"]').text()).toBe(
+			'Lesson not found. Taking you to your current lesson in 3 seconds.'
+		)
+	})
+
 	it('reports the configured duration in the announcement', async () => {
 		const wrapper = mountNotice({ seconds: 10 })
 

--- a/frontend/src/tests/lockedLessonNotice.test.ts
+++ b/frontend/src/tests/lockedLessonNotice.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import LockedLessonNotice from '@/components/LockedLessonNotice.vue'
+
+// Mirrors src/translation.js: a message carrying {0}-style placeholders returns
+// a { format } object, not a string, and takes no replacement argument. A plain
+// passthrough stub would let a real `__(...).format is not a function` crash
+// through.
+const __ = (message: string) => {
+	if (!/{\d+}/.test(message)) return message
+	return {
+		format: (...args: unknown[]) =>
+			message.replace(/{(\d+)}/g, (match, number) =>
+				typeof args[number] !== 'undefined' ? String(args[number]) : match
+			),
+	}
+}
+
+const mountNotice = (props = {}) =>
+	mount(LockedLessonNotice, {
+		props,
+		global: { mocks: { __ } },
+	})
+
+beforeEach(() => {
+	vi.stubGlobal('__', __)
+	vi.useFakeTimers()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('LockedLessonNotice', () => {
+	it('hides the ticking counter from assistive technology', () => {
+		const wrapper = mountNotice()
+		const counter = wrapper.get('.tabular-nums')
+
+		expect(counter.attributes('aria-hidden')).toBe('true')
+		expect(counter.attributes('role')).toBeUndefined()
+		expect(counter.attributes('aria-live')).toBeUndefined()
+		expect(counter.text()).toContain('3')
+	})
+
+	it('announces the reason once, not once per second', async () => {
+		const wrapper = mountNotice()
+		const status = wrapper.get('[role="status"]')
+
+		expect(status.classes()).toContain('sr-only')
+		expect(status.text()).toBe('')
+
+		await nextTick()
+		const announced = status.text()
+		expect(announced).toBe(
+			'This lesson is locked. Taking you to your current lesson in 3 seconds.'
+		)
+
+		vi.advanceTimersByTime(2000)
+		await nextTick()
+		expect(status.text()).toBe(announced)
+	})
+
+	it('carries exactly one live region', () => {
+		const wrapper = mountNotice()
+
+		expect(wrapper.findAll('[role="status"]')).toHaveLength(1)
+		expect(wrapper.findAll('[aria-live]')).toHaveLength(0)
+	})
+
+	it('emits done when the countdown reaches zero', async () => {
+		const wrapper = mountNotice()
+
+		vi.advanceTimersByTime(2000)
+		expect(wrapper.emitted('done')).toBeUndefined()
+
+		vi.advanceTimersByTime(1000)
+		expect(wrapper.emitted('done')).toHaveLength(1)
+	})
+
+	it('renders no countdown and no live region when redirect is off', () => {
+		const wrapper = mountNotice({ redirect: false })
+
+		expect(wrapper.find('.tabular-nums').exists()).toBe(false)
+		expect(wrapper.find('[role="status"]').exists()).toBe(false)
+		expect(wrapper.text()).toContain('This lesson is locked')
+	})
+
+	it('reports the configured duration in the announcement', async () => {
+		const wrapper = mountNotice({ seconds: 10 })
+
+		await nextTick()
+		expect(wrapper.get('[role="status"]').text()).toContain('in 10 seconds')
+	})
+})

--- a/frontend/src/tests/lockedLessonNotice.test.ts
+++ b/frontend/src/tests/lockedLessonNotice.test.ts
@@ -43,18 +43,32 @@ describe('LockedLessonNotice', () => {
 		expect(counter.text()).toContain('3')
 	})
 
-	it('announces the reason once, not once per second', async () => {
+	// The region must already be in the accessibility tree before it gets text:
+	// content set in the same frame as the region's own insertion reads as initial
+	// content, which most screen readers do not announce at all.
+	it('renders the live region empty, then fills it a frame later', async () => {
 		const wrapper = mountNotice()
 		const status = wrapper.get('[role="status"]')
 
 		expect(status.classes()).toContain('sr-only')
-		expect(status.text()).toBe('')
 
 		await nextTick()
-		const announced = status.text()
-		expect(announced).toBe(
+		expect(status.text()).toBe('')
+
+		vi.advanceTimersByTime(100)
+		await nextTick()
+		expect(status.text()).toBe(
 			'This lesson is locked. Taking you to your current lesson in 3 seconds.'
 		)
+	})
+
+	it('announces the reason once, not once per second', async () => {
+		const wrapper = mountNotice()
+		const status = wrapper.get('[role="status"]')
+
+		vi.advanceTimersByTime(100)
+		await nextTick()
+		const announced = status.text()
 
 		vi.advanceTimersByTime(2000)
 		await nextTick()
@@ -78,17 +92,21 @@ describe('LockedLessonNotice', () => {
 		expect(wrapper.emitted('done')).toHaveLength(1)
 	})
 
-	it('renders no countdown and no live region when redirect is off', () => {
+	it('renders no countdown and announces nothing when redirect is off', async () => {
 		const wrapper = mountNotice({ redirect: false })
 
 		expect(wrapper.find('.tabular-nums').exists()).toBe(false)
-		expect(wrapper.find('[role="status"]').exists()).toBe(false)
 		expect(wrapper.text()).toContain('This lesson is locked')
+
+		vi.advanceTimersByTime(1000)
+		await nextTick()
+		expect(wrapper.get('[role="status"]').text()).toBe('')
 	})
 
 	it('reports the configured duration in the announcement', async () => {
 		const wrapper = mountNotice({ seconds: 10 })
 
+		vi.advanceTimersByTime(100)
 		await nextTick()
 		expect(wrapper.get('[role="status"]').text()).toContain('in 10 seconds')
 	})

--- a/frontend/src/tests/lockedLessonNotice.test.ts
+++ b/frontend/src/tests/lockedLessonNotice.test.ts
@@ -107,7 +107,9 @@ describe('LockedLessonNotice', () => {
 		const wrapper = mountNotice({ notFound: true })
 
 		expect(wrapper.text()).toContain('Lesson not found')
-		expect(wrapper.text()).toContain('There is no such lesson in this course.')
+		expect(wrapper.text()).toContain(
+			'There is no lesson at this address in this course.'
+		)
 		expect(wrapper.text()).not.toContain('This lesson is locked')
 
 		vi.advanceTimersByTime(100)
@@ -115,6 +117,24 @@ describe('LockedLessonNotice', () => {
 		expect(wrapper.get('[role="status"]').text()).toBe(
 			'Lesson not found. Taking you to your current lesson in 3 seconds.'
 		)
+	})
+
+	it('skips the wait when the student asks to go now', async () => {
+		const wrapper = mountNotice()
+
+		await wrapper.get('button').trigger('click')
+		expect(wrapper.emitted('done')).toHaveLength(1)
+
+		// The interval has to die with it, or it fires again on a page the student
+		// has already left.
+		vi.advanceTimersByTime(5000)
+		expect(wrapper.emitted('done')).toHaveLength(1)
+	})
+
+	it('offers no way out when there is nowhere to send the student', () => {
+		const wrapper = mountNotice({ redirect: false })
+
+		expect(wrapper.find('button').exists()).toBe(false)
 	})
 
 	it('reports the configured duration in the announcement', async () => {

--- a/frontend/src/tests/scormChapterLocking.test.ts
+++ b/frontend/src/tests/scormChapterLocking.test.ts
@@ -78,7 +78,22 @@ vi.mock('@/components/Layouts/PageHeader.vue', () => ({
 	default: { name: 'PageHeader', template: '<div><slot /></div>' },
 }))
 
-vi.stubGlobal('__', (s: string) => s)
+// Mirrors src/translation.js: a message with {0}-style placeholders returns a
+// formatter object, not a string. A stub that always returns the string hides a
+// real "__(...).format is not a function" crash.
+const translateStub = (s: string) =>
+	/{\d+}/.test(s)
+		? {
+				format: (...args: unknown[]) =>
+					s.replace(/{(\d+)}/g, (match, index) =>
+						args[Number(index)] === undefined
+							? match
+							: String(args[Number(index)])
+					),
+		  }
+		: s
+
+vi.stubGlobal('__', translateStub)
 
 import SCORMChapter from '@/pages/SCORMChapter.vue'
 
@@ -89,7 +104,7 @@ async function mountChapter() {
 	const wrapper = mount(SCORMChapter, {
 		props: { courseName: 'COURSE-1', chapterName: 'CH-SCORM' },
 		global: {
-			mocks: { __: (s: string) => s },
+			mocks: { __: translateStub },
 			provide: { $user: { data: { name: 'student@example.com' } } },
 		},
 	})
@@ -155,24 +170,34 @@ describe('SCORMChapter.vue refuses a gated chapter', () => {
 		expect(wrapper.find('iframe').exists()).toBe(false)
 	})
 
-	it('offers the way back to the lesson the student may actually open', async () => {
-		wrapper = await mountChapter()
-		findResource('lms.lms.utils.get_course_outline').data = gatedOutline
-		await resolveChapter()
+	it('counts down and then sends the student to the lesson they may open', async () => {
+		vi.useFakeTimers()
+		try {
+			wrapper = await mountChapter()
+			findResource('lms.lms.utils.get_course_outline').data = gatedOutline
+			await resolveChapter()
 
-		expect(wrapper.text()).toContain('Go to my current lesson')
-		await wrapper.find('button').trigger('click')
+			expect(wrapper.text()).toContain(
+				'Taking you to your current lesson in 3...'
+			)
+			expect(replaceMock).not.toHaveBeenCalled()
 
-		expect(replaceMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: 'Lesson',
-				params: {
-					courseName: 'COURSE-1',
-					chapterNumber: '1',
-					lessonNumber: '1',
-				},
-			})
-		)
+			vi.advanceTimersByTime(3000)
+			await flushPromises()
+
+			expect(replaceMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Lesson',
+					params: {
+						courseName: 'COURSE-1',
+						chapterNumber: '1',
+						lessonNumber: '1',
+					},
+				})
+			)
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 
 	it('renders the package once the chapter is unlocked', async () => {

--- a/frontend/src/tests/scormChapterLocking.test.ts
+++ b/frontend/src/tests/scormChapterLocking.test.ts
@@ -178,7 +178,7 @@ describe('SCORMChapter.vue refuses a gated chapter', () => {
 			await resolveChapter()
 
 			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 3...'
+				'Taking you to your current lesson in 3s'
 			)
 			expect(replaceMock).not.toHaveBeenCalled()
 

--- a/frontend/src/tests/scormChapterLocking.test.ts
+++ b/frontend/src/tests/scormChapterLocking.test.ts
@@ -1,0 +1,219 @@
+/**
+ * SCORMChapter.vue is reached by its own route and never calls get_lesson: it
+ * reads the Course Chapter doc directly and iframes its launch file. These
+ * mounts exercise the REAL `isLocked` / `currentLessonNumber` computeds and the
+ * REAL `goToCurrentLesson` handler against the course outline payload.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+
+const replaceMock = vi.hoisted(() => vi.fn())
+const created = vi.hoisted(() => ({ list: [] as any[], docs: [] as any[] }))
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+}))
+
+vi.mock('frappe-ui', async () => {
+	const { reactive } = await import('vue')
+	return {
+		createResource: (config: any) => {
+			const resource: any = reactive({
+				data: null,
+				error: null,
+				loading: false,
+				_config: config,
+				submit: vi.fn((_params: any, handlers: any) => {
+					config?.onSuccess?.(resource.data)
+					handlers?.onSuccess?.(resource.data)
+					return Promise.resolve()
+				}),
+				reload: vi.fn(),
+				fetch: vi.fn(),
+			})
+			created.list.push(resource)
+			return resource
+		},
+		createDocumentResource: (config: any) => {
+			const resource: any = reactive({
+				doc: {
+					name: 'CH-SCORM',
+					title: 'SCORM Chapter',
+					course: 'COURSE-1',
+					course_title: 'Course 1',
+					launch_file: '/private/scorm/COURSE-1/SCORM%20Chapter/index.html',
+					lessons: [{ lesson: 'L-SCORM' }],
+				},
+				_config: config,
+			})
+			created.docs.push(resource)
+			return resource
+		},
+		createListResource: () => {
+			const resource: any = reactive({
+				data: [{ member: 'student@example.com', course: 'COURSE-1' }],
+				loading: false,
+				insert: { submit: vi.fn() },
+				reload: vi.fn(),
+				fetch: vi.fn(),
+			})
+			return resource
+		},
+		call: vi.fn(() => Promise.resolve()),
+		usePageMeta: vi.fn(),
+		Button: {
+			name: 'Button',
+			template: `<button><slot name="prefix" /><slot name="icon" /><slot /></button>`,
+		},
+	}
+})
+
+vi.mock('@/stores/session', () => ({
+	sessionStore: () => ({ brand: {} }),
+}))
+vi.mock('@/stores/sidebar', () => ({
+	useSidebar: () => ({ isSidebarCollapsed: false }),
+}))
+vi.mock('@/components/Layouts/PageHeader.vue', () => ({
+	default: { name: 'PageHeader', template: '<div><slot /></div>' },
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+import SCORMChapter from '@/pages/SCORMChapter.vue'
+
+const findResource = (url: string) =>
+	created.list.find((resource) => resource._config.url === url)
+
+async function mountChapter() {
+	const wrapper = mount(SCORMChapter, {
+		props: { courseName: 'COURSE-1', chapterName: 'CH-SCORM' },
+		global: {
+			mocks: { __: (s: string) => s },
+			provide: { $user: { data: { name: 'student@example.com' } } },
+		},
+	})
+	await flushPromises()
+	return wrapper
+}
+
+// Chapter 1 is an ordinary incomplete lesson, chapter 2 is the SCORM package.
+const gatedOutline = [
+	{
+		name: 'CH-1',
+		lessons: [
+			{ name: 'L1', number: '1-1', locked: 0, is_complete: 0 },
+			{ name: 'L2', number: '1-2', locked: 1, is_complete: 0 },
+		],
+	},
+	{
+		name: 'CH-SCORM',
+		launch_file: null,
+		lessons: [{ name: 'L-SCORM', number: '2-1', locked: 1, is_complete: 0 }],
+	},
+]
+
+const openOutline = [
+	{
+		name: 'CH-1',
+		lessons: [{ name: 'L1', number: '1-1', locked: 0, is_complete: 1 }],
+	},
+	{
+		name: 'CH-SCORM',
+		launch_file: '/private/scorm/COURSE-1/SCORM%20Chapter/index.html',
+		lessons: [{ name: 'L-SCORM', number: '2-1', locked: 0, is_complete: 0 }],
+	},
+]
+
+let wrapper: VueWrapper
+
+beforeEach(() => {
+	created.list.length = 0
+	created.docs.length = 0
+	replaceMock.mockReset()
+})
+
+afterEach(() => {
+	wrapper?.unmount()
+})
+
+// readyToRender only flips once the chapter doc resolves and the progress lookup
+// comes back, which is the sequence the page itself wires up.
+async function resolveChapter() {
+	created.docs[0]._config.onSuccess?.(created.docs[0].doc)
+	await flushPromises()
+}
+
+describe('SCORMChapter.vue refuses a gated chapter', () => {
+	it('renders the locked panel instead of the package iframe', async () => {
+		wrapper = await mountChapter()
+		findResource('lms.lms.utils.get_course_outline').data = gatedOutline
+		await resolveChapter()
+
+		expect((wrapper.vm as any).isLocked).toBe(true)
+		expect(wrapper.text()).toContain('This lesson is locked')
+		expect(wrapper.find('iframe').exists()).toBe(false)
+	})
+
+	it('offers the way back to the lesson the student may actually open', async () => {
+		wrapper = await mountChapter()
+		findResource('lms.lms.utils.get_course_outline').data = gatedOutline
+		await resolveChapter()
+
+		expect(wrapper.text()).toContain('Go to my current lesson')
+		await wrapper.find('button').trigger('click')
+
+		expect(replaceMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'Lesson',
+				params: {
+					courseName: 'COURSE-1',
+					chapterNumber: '1',
+					lessonNumber: '1',
+				},
+			})
+		)
+	})
+
+	it('renders the package once the chapter is unlocked', async () => {
+		wrapper = await mountChapter()
+		findResource('lms.lms.utils.get_course_outline').data = openOutline
+		await resolveChapter()
+
+		expect((wrapper.vm as any).isLocked).toBe(false)
+		expect(wrapper.find('iframe').exists()).toBe(true)
+	})
+
+	it('does not lock a course whose outline carries no lock flags at all', async () => {
+		wrapper = await mountChapter()
+		findResource('lms.lms.utils.get_course_outline').data = [
+			{ name: 'CH-SCORM', lessons: [{ name: 'L-SCORM', number: '1-1' }] },
+		]
+		await resolveChapter()
+
+		expect((wrapper.vm as any).isLocked).toBe(false)
+		expect(wrapper.find('iframe').exists()).toBe(true)
+	})
+
+	it('holds the iframe back while the outline is still unresolved', async () => {
+		// The chapter doc and its progress resolve on their own chain, so the iframe
+		// could mount before the lock was known -- and the student read the server's
+		// 403 page for the package before the locked notice replaced it.
+		wrapper = await mountChapter()
+		await resolveChapter()
+
+		expect((wrapper.vm as any).isLocked).toBe(false)
+		expect(wrapper.find('iframe').exists()).toBe(false)
+	})
+
+	it('renders the package anyway when the outline request fails', async () => {
+		// Waiting forever on an outline that will never arrive would leave a blank
+		// page; the bytes are refused server side either way.
+		wrapper = await mountChapter()
+		findResource('lms.lms.utils.get_course_outline').error = new Error('boom')
+		await resolveChapter()
+
+		expect((wrapper.vm as any).isLocked).toBe(false)
+		expect(wrapper.find('iframe').exists()).toBe(true)
+	})
+})

--- a/frontend/src/tests/scormChapterLocking.test.ts
+++ b/frontend/src/tests/scormChapterLocking.test.ts
@@ -177,9 +177,7 @@ describe('SCORMChapter.vue refuses a gated chapter', () => {
 			findResource('lms.lms.utils.get_course_outline').data = gatedOutline
 			await resolveChapter()
 
-			expect(wrapper.text()).toContain(
-				'Taking you to your current lesson in 3s'
-			)
+			expect(wrapper.text()).toContain('3s')
 			expect(replaceMock).not.toHaveBeenCalled()
 
 			vi.advanceTimersByTime(3000)

--- a/frontend/src/tests/studentLessonSidebar.test.ts
+++ b/frontend/src/tests/studentLessonSidebar.test.ts
@@ -1,0 +1,93 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import StudentLessonSidebar from '@/components/StudentLessonSidebar.vue'
+
+const outline = vi.hoisted(() => [
+	{
+		name: 'CH-1',
+		title: 'Chapter 1',
+		idx: 1,
+		lessons: [
+			{
+				name: 'L1',
+				title: 'Lesson 1',
+				number: '1-1',
+				is_complete: 1,
+				locked: 0,
+			},
+			{
+				name: 'L2',
+				title: 'Lesson 2',
+				number: '1-2',
+				is_complete: 0,
+				locked: 0,
+			},
+			{
+				name: 'L3',
+				title: 'Lesson 3',
+				number: '1-3',
+				is_complete: 0,
+				locked: 1,
+			},
+		],
+	},
+])
+
+vi.mock('vue-router', () => ({
+	useRoute: () => ({ params: {}, query: {} }),
+	useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('frappe-ui', () => ({
+	createResource: () => ({ data: outline, reload: vi.fn() }),
+}))
+
+vi.stubGlobal('__', (s: string) => s)
+
+const mountSidebar = () =>
+	mount(StudentLessonSidebar, {
+		props: {
+			courseName: 'COURSE-1',
+			courseTitle: 'Course 1',
+			progress: 33,
+			selectedLessonNumber: '1-2',
+		},
+		global: {
+			mocks: { __: (s: string) => s },
+			stubs: {
+				'router-link': {
+					props: ['to'],
+					template: '<a><slot /></a>',
+				},
+			},
+		},
+	})
+
+describe('StudentLessonSidebar locked lesson', () => {
+	it('renders a lock for a locked lesson and no link', () => {
+		const wrapper = mountSidebar()
+		const rows = wrapper.findAll('li li')
+
+		expect(rows).toHaveLength(3)
+		expect(rows[2].find('a').exists()).toBe(false)
+		expect(rows[2].attributes('aria-disabled')).toBeUndefined()
+		expect(rows[2].find('[aria-disabled="true"]').exists()).toBe(true)
+	})
+
+	it('still links unlocked lessons', () => {
+		const wrapper = mountSidebar()
+		const rows = wrapper.findAll('li li')
+
+		expect(rows[0].find('a').exists()).toBe(true)
+		expect(rows[1].find('a').exists()).toBe(true)
+	})
+
+	it('does not emit select-lesson when a locked row is clicked', async () => {
+		const wrapper = mountSidebar()
+		const rows = wrapper.findAll('li li')
+
+		await rows[2].find('[aria-disabled="true"]').trigger('click')
+
+		expect(wrapper.emitted('select-lesson')).toBeUndefined()
+	})
+})

--- a/frontend/src/tests/studentLessonSidebar.test.ts
+++ b/frontend/src/tests/studentLessonSidebar.test.ts
@@ -70,8 +70,10 @@ describe('StudentLessonSidebar locked lesson', () => {
 
 		expect(rows).toHaveLength(3)
 		expect(rows[2].find('a').exists()).toBe(false)
-		expect(rows[2].attributes('aria-disabled')).toBeUndefined()
-		expect(rows[2].find('[aria-disabled="true"]').exists()).toBe(true)
+		expect(rows[2].find('.cursor-not-allowed').exists()).toBe(true)
+		expect(rows[2].find('.sr-only').text()).toBe('Locked')
+		expect(rows[2].find('[aria-label]').exists()).toBe(false)
+		expect(rows[2].find('[aria-disabled]').exists()).toBe(false)
 	})
 
 	it('still links unlocked lessons', () => {
@@ -86,7 +88,7 @@ describe('StudentLessonSidebar locked lesson', () => {
 		const wrapper = mountSidebar()
 		const rows = wrapper.findAll('li li')
 
-		await rows[2].find('[aria-disabled="true"]').trigger('click')
+		await rows[2].find('.cursor-not-allowed').trigger('click')
 
 		expect(wrapper.emitted('select-lesson')).toBeUndefined()
 	})

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -84,6 +84,7 @@ export interface OutlineLesson {
 	number: string
 	icon?: string
 	is_complete?: boolean
+	locked?: 0 | 1
 }
 
 export interface OutlineChapter {

--- a/frontend/src/types/lms/LMSCourse.ts
+++ b/frontend/src/types/lms/LMSCourse.ts
@@ -25,6 +25,8 @@ export interface LMSCourse {
 	short_introduction: string
 	/**	Disable Self Learning : Check	*/
 	disable_self_learning?: 0 | 1
+	/**	Enforce Lesson Completion : Check	*/
+	enforce_lesson_completion?: 0 | 1
 	/**	Preview Image : Attach Image	*/
 	image?: string
 	/**	Tags : Data	*/

--- a/lms/lms/course_import_export.py
+++ b/lms/lms/course_import_export.py
@@ -477,6 +477,7 @@ def get_course_fields():
 		"upcoming",
 		"featured",
 		"disable_self_learning",
+		"enforce_lesson_completion",
 		"published_on",
 		"category",
 		"evaluator",

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -10,7 +10,6 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.functions import Locate
 from frappe.rate_limiter import rate_limit
-from frappe.realtime import get_website_room
 from frappe.utils import add_to_date, now_datetime
 from frappe.utils.response import send_private_file
 from frappe.utils.telemetry import capture
@@ -421,9 +420,14 @@ def _save_progress(lesson: str, course: str, scorm_details: dict = None):
 	# replaces fired no on_update, which is the webhook regression being fixed.
 	update_enrollment(membership, {"current_lesson": next_lesson or lesson, "progress": progress})
 
+	# Addressed to the member who completed the lesson, not the whole website room.
+	# Everything in this payload is theirs alone — `progress` is their course progress,
+	# which every other viewer of the course was assigning to their own progress bar —
+	# and it is the signal their outline reloads on, so a site-wide room made one
+	# student's completion refetch the outline in every concurrent viewer's browser.
 	frappe.publish_realtime(
 		event="update_lesson_progress",
-		room=get_website_room(),
+		user=frappe.session.user,
 		message={"course": course, "lesson": lesson, "progress": progress},
 		after_commit=True,
 	)

--- a/lms/lms/doctype/course_lesson/course_lesson.py
+++ b/lms/lms/doctype/course_lesson/course_lesson.py
@@ -19,7 +19,7 @@ from lms.lms.doctype.lms_enrollment.lms_enrollment import (
 	batched_enrollment_updates,
 	update_enrollment,
 )
-from lms.lms.permissions import INSTRUCTOR_FIELDS, can_access_lesson
+from lms.lms.permissions import INSTRUCTOR_FIELDS, can_access_lesson, get_locked_lessons
 from lms.lms.utils import (
 	get_course_progress,
 	get_editorjs_blocks,
@@ -325,6 +325,16 @@ def _save_progress(lesson: str, course: str, scorm_details: dict = None):
 	membership = frappe.db.exists("LMS Enrollment", {"course": course, "member": frappe.session.user})
 	if not membership:
 		return 0
+
+	# On a sequential course this endpoint writes the gate's own unlock state, so an
+	# enrolled student could otherwise complete every lesson name the outline publishes
+	# and open the whole course. The lesson a student is legitimately on is the first
+	# incomplete one, which is never locked, so the normal path never reaches this.
+	if lesson in get_locked_lessons(course):
+		frappe.throw(
+			_("Complete the previous lesson before marking this one as done."),
+			frappe.PermissionError,
+		)
 
 	progress_already_exists = frappe.db.exists(
 		"LMS Course Progress", {"lesson": lesson, "member": frappe.session.user}

--- a/lms/lms/doctype/lms_course/lms_course.json
+++ b/lms/lms/doctype/lms_course/lms_course.json
@@ -98,7 +98,7 @@
   },
   {
    "default": "0",
-   "description": "Students must complete each lesson before the next one becomes available.",
+   "description": "Students must complete each lesson before the next one becomes available. A lesson a student cannot complete (quiz attempts exhausted, or a SCORM package that never reports completion) will block every lesson after it.",
    "fieldname": "enforce_lesson_completion",
    "fieldtype": "Check",
    "label": "Enforce Lesson Completion"

--- a/lms/lms/doctype/lms_course/lms_course.json
+++ b/lms/lms/doctype/lms_course/lms_course.json
@@ -24,6 +24,7 @@
   "upcoming",
   "featured",
   "disable_self_learning",
+  "enforce_lesson_completion",
   "section_break_18",
   "short_introduction",
   "column_break_viqw",
@@ -94,6 +95,13 @@
    "fieldname": "disable_self_learning",
    "fieldtype": "Check",
    "label": "Disable Self Learning"
+  },
+  {
+   "default": "0",
+   "description": "Students must complete each lesson before the next one becomes available.",
+   "fieldname": "enforce_lesson_completion",
+   "fieldtype": "Check",
+   "label": "Enforce Lesson Completion"
   },
   {
    "fieldname": "image",

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -338,6 +338,18 @@ def save_progress_after_quiz(quiz_details: dict, percentage: float):
 
 	if quiz_details.passing_percentage and percentage < quiz_details.passing_percentage:
 		return
+
+	# save_progress refuses a locked lesson by raising, which would roll back the
+	# submission create_submission() has already written. A quiz can be reached
+	# without its lesson being open — can_access_quiz also grants through an
+	# LMS Assessment on a batch — so skip the progress write instead of failing the
+	# submit. The throw stays in _save_progress, which is the boundary for the
+	# direct-call bypass.
+	from lms.lms.permissions import get_locked_lessons
+
+	if quiz_details.lesson in get_locked_lessons(quiz_details.course):
+		return
+
 	save_progress(quiz_details.lesson, quiz_details.course)
 
 

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -135,6 +135,37 @@ def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
 		frappe.session.user = original_user
 
 
+def enforces_lesson_completion(course: str) -> bool:
+	"""Whether the sequential lesson gate applies to the current user on this course.
+
+	Course authors and moderators are exempt (they have no enrollment, so gating would
+	park them on the first lesson), and so is anyone who is not enrolled — sequencing
+	is meaningless without progress, and their access is already decided by
+	include_in_preview.
+	"""
+	if not isinstance(course, str) or not course:
+		return False
+	if not frappe.db.get_value("LMS Course", course, "enforce_lesson_completion"):
+		return False
+	if can_modify_course(course):
+		return False
+	return bool(get_membership(course))
+
+
+def get_locked_lessons(course: str) -> set:
+	"""Lesson names the current user may not open yet. Empty when the gate does not apply."""
+	if not enforces_lesson_completion(course):
+		return set()
+
+	# Local import: utils imports from permissions at call time, so importing utils at
+	# module load would create a cycle (same reason get_lesson imports this lazily).
+	from lms.lms.utils import compute_locked_lessons, get_completed_lessons, get_ordered_lesson_rows
+
+	rows = get_ordered_lesson_rows(course)
+	completed = get_completed_lessons(course, rows)
+	return compute_locked_lessons([row.name for row in rows], completed)
+
+
 def file_has_permission(doc, ptype="read", user=None):
 	"""File has_permission hook: deny-only tightening for instructor-only lesson files.
 

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -94,7 +94,7 @@ def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
 	if not isinstance(quiz, str) or not quiz:
 		return False
 
-	quiz_row = frappe.db.get_value("LMS Quiz", quiz, ["course", "owner"], as_dict=True)
+	quiz_row = frappe.db.get_value("LMS Quiz", quiz, ["course", "lesson", "owner"], as_dict=True)
 	if not quiz_row:
 		return False
 
@@ -109,13 +109,32 @@ def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
 			return True
 
 		# Courses the quiz belongs to: the authoritative LMS Quiz.course link plus any
-		# lesson that references it via the manually-set quiz_id field.
-		courses = set()
+		# lesson that references it via the manually-set quiz_id field. The owning
+		# lesson travels with the course so a sequential course can gate the quiz on
+		# the same rule as the lesson that embeds it — the quiz id is a bearer handle,
+		# so withholding it from the outline would not revoke it from a student who
+		# already saw it while the setting was off.
+		placements = set()
 		if quiz_row.course:
-			courses.add(quiz_row.course)
-		courses.update(frappe.get_all("Course Lesson", filters={"quiz_id": quiz}, pluck="course"))
-		for course in courses:
-			if course and (can_modify_course(course) or get_membership(course, user)):
+			placements.add((quiz_row.course, quiz_row.lesson))
+		for row in frappe.get_all("Course Lesson", filters={"quiz_id": quiz}, fields=["course", "name"]):
+			placements.add((row.course, row.name))
+		for course, lesson in placements:
+			if not course:
+				continue
+			if can_modify_course(course):
+				return True
+			if not get_membership(course, user):
+				continue
+			locked = get_locked_lessons(course)
+			if not locked:
+				return True
+			# Under the gate a placement with no owning lesson cannot be checked against
+			# the lock set at all: cleanup_lesson_backreferences clears LMS Quiz.lesson
+			# and leaves .course standing, and `None not in locked` is true of every
+			# course, so such a placement used to grant any enrolled member access to a
+			# quiz whose lesson is still locked. It grants nothing now.
+			if lesson and lesson not in locked:
 				return True
 
 		assessment_batches = frappe.get_all(

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -171,6 +171,25 @@ def enforces_lesson_completion(course: str) -> bool:
 	return bool(get_membership(course))
 
 
+def _lock_state(course: str) -> tuple[set, list, set]:
+	"""``(locked names, every name in course order, completed names)``.
+
+	Reads no enrollment pointer: SCORMRenderer runs the lock check on every asset
+	request of a package, and only needs the lock set.
+	"""
+	if not enforces_lesson_completion(course):
+		return set(), [], set()
+
+	# Local import: utils imports from permissions at call time, so importing utils at
+	# module load would create a cycle (same reason get_lesson imports this lazily).
+	from lms.lms.utils import compute_locked_lessons, get_completed_lessons, get_ordered_lesson_rows
+
+	rows = get_ordered_lesson_rows(course)
+	completed = get_completed_lessons(course, rows)
+	names = [row.name for row in rows]
+	return compute_locked_lessons(names, completed), names, completed
+
+
 def get_lesson_gate(course: str) -> tuple[set, str | None]:
 	"""``(locked lesson names, the lesson to resume at)`` for the current user.
 
@@ -183,17 +202,9 @@ def get_lesson_gate(course: str) -> tuple[set, str | None]:
 
 	Both values are empty/None when the gate does not apply to this user.
 	"""
-	if not enforces_lesson_completion(course):
-		return set(), None
-
-	# Local import: utils imports from permissions at call time, so importing utils at
-	# module load would create a cycle (same reason get_lesson imports this lazily).
-	from lms.lms.utils import compute_locked_lessons, get_completed_lessons, get_ordered_lesson_rows
-
-	rows = get_ordered_lesson_rows(course)
-	completed = get_completed_lessons(course, rows)
-	names = [row.name for row in rows]
-	locked = compute_locked_lessons(names, completed)
+	locked, names, completed = _lock_state(course)
+	if not names:
+		return locked, None
 
 	resume = None
 	for name in names:
@@ -202,7 +213,7 @@ def get_lesson_gate(course: str) -> tuple[set, str | None]:
 			break
 	# Every lesson is complete, so nothing is locked and the first lesson is as good a
 	# landing spot as any.
-	if resume is None and names:
+	if resume is None:
 		resume = names[0]
 
 	pointer = frappe.db.get_value(
@@ -216,7 +227,7 @@ def get_lesson_gate(course: str) -> tuple[set, str | None]:
 
 def get_locked_lessons(course: str) -> set:
 	"""Lesson names the current user may not open yet. Empty when the gate does not apply."""
-	return get_lesson_gate(course)[0]
+	return _lock_state(course)[0]
 
 
 def file_has_permission(doc, ptype="read", user=None):

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -152,10 +152,20 @@ def enforces_lesson_completion(course: str) -> bool:
 	return bool(get_membership(course))
 
 
-def get_locked_lessons(course: str) -> set:
-	"""Lesson names the current user may not open yet. Empty when the gate does not apply."""
+def get_lesson_gate(course: str) -> tuple[set, str | None]:
+	"""``(locked lesson names, the lesson to resume at)`` for the current user.
+
+	The resume lesson is derived from the same ordered list that produced the lock set:
+	the first incomplete lesson, which the rule leaves open by construction. The
+	LMS Enrollment pointer is only a hint and is used only when it is itself unlocked —
+	save_progress wrote it under whatever rules applied at the time (the setting may
+	have been off, the chapters may have been reordered since), so trusting it blindly
+	can redirect a student to a lesson that is locked, which is a dead end.
+
+	Both values are empty/None when the gate does not apply to this user.
+	"""
 	if not enforces_lesson_completion(course):
-		return set()
+		return set(), None
 
 	# Local import: utils imports from permissions at call time, so importing utils at
 	# module load would create a cycle (same reason get_lesson imports this lazily).
@@ -163,7 +173,31 @@ def get_locked_lessons(course: str) -> set:
 
 	rows = get_ordered_lesson_rows(course)
 	completed = get_completed_lessons(course, rows)
-	return compute_locked_lessons([row.name for row in rows], completed)
+	names = [row.name for row in rows]
+	locked = compute_locked_lessons(names, completed)
+
+	resume = None
+	for name in names:
+		if name not in completed:
+			resume = name
+			break
+	# Every lesson is complete, so nothing is locked and the first lesson is as good a
+	# landing spot as any.
+	if resume is None and names:
+		resume = names[0]
+
+	pointer = frappe.db.get_value(
+		"LMS Enrollment", {"course": course, "member": frappe.session.user}, "current_lesson"
+	)
+	if pointer and pointer not in locked:
+		resume = pointer
+
+	return locked, resume
+
+
+def get_locked_lessons(course: str) -> set:
+	"""Lesson names the current user may not open yet. Empty when the gate does not apply."""
+	return get_lesson_gate(course)[0]
 
 
 def file_has_permission(doc, ptype="read", user=None):

--- a/lms/lms/permissions.py
+++ b/lms/lms/permissions.py
@@ -114,14 +114,17 @@ def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
 		# the same rule as the lesson that embeds it — the quiz id is a bearer handle,
 		# so withholding it from the outline would not revoke it from a student who
 		# already saw it while the setting was off.
-		placements = set()
+		# Grouped by course, not held as flat (course, lesson) pairs: every check below
+		# except the last is course-level, and a quiz embedded in several lessons of one
+		# course would otherwise repeat the membership read and the whole lock chain per
+		# lesson for a set that cannot differ between them.
+		placements = {}
 		if quiz_row.course:
-			placements.add((quiz_row.course, quiz_row.lesson))
+			placements.setdefault(quiz_row.course, set()).add(quiz_row.lesson)
 		for row in frappe.get_all("Course Lesson", filters={"quiz_id": quiz}, fields=["course", "name"]):
-			placements.add((row.course, row.name))
-		for course, lesson in placements:
-			if not course:
-				continue
+			if row.course:
+				placements.setdefault(row.course, set()).add(row.name)
+		for course, lessons in placements.items():
 			if can_modify_course(course):
 				return True
 			if not get_membership(course, user):
@@ -134,7 +137,7 @@ def can_access_quiz(quiz: str, *, user: str | None = None) -> bool:
 			# and leaves .course standing, and `None not in locked` is true of every
 			# course, so such a placement used to grant any enrolled member access to a
 			# quiz whose lesson is still locked. It grants nothing now.
-			if lesson and lesson not in locked:
+			if any(lesson and lesson not in locked for lesson in lessons):
 				return True
 
 		assessment_batches = frappe.get_all(

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -340,16 +340,6 @@ def get_lesson_index(lesson_name: str) -> str:
 	return f"{chapter.idx}-{lesson.idx}"
 
 
-def get_current_lesson_number(course: str) -> str:
-	"""The {chapter}-{lesson} number of the lesson this user is currently on."""
-	current_lesson = frappe.db.get_value(
-		"LMS Enrollment", {"course": course, "member": frappe.session.user}, "current_lesson"
-	)
-	if not current_lesson:
-		return "1-1"
-	return get_lesson_index(current_lesson)
-
-
 def get_lesson_url(course: str, lesson_number: str):
 	if not lesson_number:
 		return
@@ -1171,7 +1161,13 @@ def get_course_details(course: str):
 		course_details.is_instructor = False
 
 	if course_details.membership and course_details.membership.current_lesson:
-		course_details.current_lesson = get_lesson_index(course_details.membership.current_lesson)
+		# "Continue Learning" must not point at a locked lesson. get_lesson_gate keeps
+		# the enrollment pointer when it is unlocked and substitutes the lesson the
+		# student may actually open otherwise; it returns None when no gate applies.
+		from lms.lms.permissions import get_lesson_gate
+
+		_locked, resume = get_lesson_gate(course)
+		course_details.current_lesson = get_lesson_index(resume or course_details.membership.current_lesson)
 
 	return course_details
 
@@ -1381,6 +1377,7 @@ def build_outline(
 
 	outline = []
 	for c in chapters:
+		lessons = lessons_by_chapter.get(c.name, [])
 		chapter = frappe._dict(
 			name=c.name,
 			title=c.title,
@@ -1388,9 +1385,15 @@ def build_outline(
 			launch_file=c.launch_file,
 			scorm_package=c.scorm_package,
 			idx=c.idx,
-			lessons=lessons_by_chapter.get(c.name, []),
+			lessons=lessons,
 		)
-		if c.is_scorm_package and c.scorm_package and c.scorm_package in files_by_name:
+		# launch_file is the SCORM entry URL and scorm_package resolves to the package
+		# file. Handing either out for a chapter the student cannot open yet would let
+		# the outline itself route around the gate, so withhold both.
+		if lessons and all(lesson.get("locked") for lesson in lessons):
+			chapter.launch_file = None
+			chapter.scorm_package = None
+		elif c.is_scorm_package and c.scorm_package and c.scorm_package in files_by_name:
 			chapter.scorm_package = files_by_name[c.scorm_package]
 		outline.append(chapter)
 	return outline
@@ -1451,14 +1454,15 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 
 	# Local import: permissions imports from utils at module load, so importing it
 	# at the top of utils would create a cycle.
-	from lms.lms.permissions import get_locked_lessons
+	from lms.lms.permissions import get_lesson_gate
 
-	if lesson_name in get_locked_lessons(course):
+	locked, resume = get_lesson_gate(course)
+	if lesson_name in locked:
 		return {
 			"locked": 1,
 			"title": lesson_details.title,
 			"course_title": frappe.db.get_value("LMS Course", course, "title"),
-			"redirect_to": get_current_lesson_number(course),
+			"redirect_to": get_lesson_index(resume) if resume else "1-1",
 		}
 
 	if lesson_details.is_scorm_package:

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1216,7 +1216,11 @@ def get_course_outline(course: str, progress: bool = False) -> list:
 	files_by_name = get_scorm_files(chapters)
 	completed = get_completed_lessons(course, lesson_rows) if progress else set()
 
-	return build_outline(chapters, lesson_rows, files_by_name, completed, progress)
+	from lms.lms.permissions import enforces_lesson_completion
+
+	enforce = enforces_lesson_completion(course) if progress else False
+
+	return build_outline(chapters, lesson_rows, files_by_name, completed, progress, enforce)
 
 
 def get_outline_chapter(course: str) -> list:
@@ -1331,7 +1335,12 @@ def get_ordered_lesson_rows(course: str) -> list:
 
 
 def build_outline(
-	chapters: list, lesson_rows: list, files_by_name: dict, completed: set, progress: bool
+	chapters: list,
+	lesson_rows: list,
+	files_by_name: dict,
+	completed: set,
+	progress: bool,
+	enforce_completion: bool = False,
 ) -> list:
 	chapter_idx_by_name = {c.name: c.idx for c in chapters}
 	lessons_by_chapter = {}
@@ -1352,6 +1361,13 @@ def build_outline(
 		if progress:
 			lesson.is_complete = lr.name in completed
 		lessons_by_chapter.setdefault(lr.chapter_name, []).append(lesson)
+
+	if progress and enforce_completion:
+		ordered_names = [lesson.name for c in chapters for lesson in lessons_by_chapter.get(c.name, [])]
+		locked = compute_locked_lessons(ordered_names, completed)
+		for lessons in lessons_by_chapter.values():
+			for lesson in lessons:
+				lesson.locked = 1 if lesson.name in locked else 0
 
 	outline = []
 	for c in chapters:

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -340,6 +340,16 @@ def get_lesson_index(lesson_name: str) -> str:
 	return f"{chapter.idx}-{lesson.idx}"
 
 
+def get_current_lesson_number(course: str) -> str:
+	"""The {chapter}-{lesson} number of the lesson this user is currently on."""
+	current_lesson = frappe.db.get_value(
+		"LMS Enrollment", {"course": course, "member": frappe.session.user}, "current_lesson"
+	)
+	if not current_lesson:
+		return "1-1"
+	return get_lesson_index(current_lesson)
+
+
 def get_lesson_url(course: str, lesson_number: str):
 	if not lesson_number:
 		return
@@ -1438,6 +1448,18 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 
 	if not lesson_details:
 		return {}
+
+	# Local import: permissions imports from utils at module load, so importing it
+	# at the top of utils would create a cycle.
+	from lms.lms.permissions import get_locked_lessons
+
+	if lesson_name in get_locked_lessons(course):
+		return {
+			"locked": 1,
+			"title": lesson_details.title,
+			"course_title": frappe.db.get_value("LMS Course", course, "title"),
+			"redirect_to": get_current_lesson_number(course),
+		}
 
 	if lesson_details.is_scorm_package:
 		return {

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1123,7 +1123,7 @@ def get_course_fields():
 	]
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @rate_limit(limit=500, seconds=60 * 60)
 def get_course_details(course: str):
 	if not guest_access_allowed():
@@ -1207,7 +1207,7 @@ def get_categorized_courses(courses: list) -> dict:
 	}
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_course_outline(course: str, progress: bool = False) -> list:
 	"""Returns the course outline."""
 
@@ -1457,7 +1457,7 @@ def _gate_redirect(course: str) -> dict:
 	}
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @rate_limit(limit=500, seconds=60 * 60)
 def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 	if not guest_access_allowed():

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1402,6 +1402,9 @@ def build_outline(
 		for lessons in lessons_by_chapter.values():
 			for lesson in lessons:
 				lesson.locked = 1 if lesson.name in locked else 0
+				if lesson.locked:
+					# The quiz is part of the gated lesson, not a separate resource.
+					lesson.quiz_id = None
 
 	outline = []
 	for c in chapters:

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1430,6 +1430,33 @@ def build_outline(
 	return outline
 
 
+def _gate_redirect(course: str) -> dict:
+	"""The locked payload for a lesson number that resolves to nothing.
+
+	Typing a lesson number that does not exist is the same URL tampering the gate is
+	there to catch, so on a gated course it lands the student back on their current
+	lesson rather than on the course page. Off a gated course the caller keeps the
+	existing empty response.
+
+	`not_found` travels with `locked` so the page can say which of the two happened:
+	the lesson does not exist, and telling the student to finish the earlier lessons to
+	unlock it would be a lie.
+	"""
+	from lms.lms.permissions import get_lesson_gate
+
+	_locked, resume = get_lesson_gate(course)
+	if not resume:
+		return {}
+
+	return {
+		"locked": 1,
+		"not_found": 1,
+		"title": _("Lesson not found"),
+		"course_title": frappe.db.get_value("LMS Course", course, "title"),
+		"redirect_to": get_lesson_index(resume),
+	}
+
+
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=500, seconds=60 * 60)
 def get_lesson(course: str, chapter: int, lesson: int) -> dict:
@@ -1449,14 +1476,14 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 		.limit(1)
 	).run(as_dict=1)
 	if not chapter_row:
-		return {}
+		return _gate_redirect(course)
 
 	chapter_name = chapter_row[0].name
 	chapter_title = chapter_row[0].title
 
 	lesson_name = frappe.db.get_value("Lesson Reference", {"parent": chapter_name, "idx": lesson}, "lesson")
 	if not lesson_name:
-		return {}
+		return _gate_redirect(course)
 
 	lesson_details = frappe.db.get_value(
 		"Course Lesson",
@@ -1481,7 +1508,7 @@ def get_lesson(course: str, chapter: int, lesson: int) -> dict:
 	)
 
 	if not lesson_details:
-		return {}
+		return _gate_redirect(course)
 
 	# Local import: permissions imports from utils at module load, so importing it
 	# at the top of utils would create a cycle.

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1311,10 +1311,19 @@ def compute_locked_lessons(ordered_lesson_names: list, completed: set) -> set:
 	A lesson is open when it is at or before the first incomplete lesson, or when the
 	student already completed it (so enabling the setting mid-cohort never revokes
 	access to work already done).
+
+	Names are deduped on first occurrence: a lesson reachable from two chapters would
+	otherwise be locked by its later occurrence and, since the return value is a set of
+	names, lock its earlier one too — with lesson one locked, even the redirect target
+	is locked and the course is a dead end.
 	"""
 	locked = set()
+	seen = set()
 	past_first_incomplete = False
 	for name in ordered_lesson_names:
+		if name in seen:
+			continue
+		seen.add(name)
 		if name in completed:
 			continue
 		if past_first_incomplete:
@@ -1325,19 +1334,38 @@ def compute_locked_lessons(ordered_lesson_names: list, completed: set) -> set:
 
 
 def get_ordered_lesson_rows(course: str) -> list:
-	"""Outline lesson rows for a course, in (chapter idx, lesson idx) order."""
-	chapters = get_outline_chapter(course)
-	if not chapters:
-		return []
+	"""Lesson identity rows for a course, in (chapter idx, lesson idx) order.
 
-	rows_by_chapter = {}
-	for row in get_outline_lessons([c.name for c in chapters]):
-		rows_by_chapter.setdefault(row.chapter_name, []).append(row)
+	Deliberately narrow. The lock rule needs nothing but names and order, so this must
+	not reuse get_outline_lessons: that selects body and content, the two largest text
+	columns, and every gated lesson view would then transfer the whole course.
 
-	ordered = []
-	for chapter in chapters:
-		ordered.extend(sorted(rows_by_chapter.get(chapter.name, []), key=lambda r: r.lesson_idx))
-	return ordered
+	The joins mirror get_outline_chapter / get_outline_lessons exactly (both reference
+	tables inner-joined to their target doctype) so this list and the one build_outline
+	derives its locks from can never diverge over a dangling reference row.
+	"""
+	ChapterReference = frappe.qb.DocType("Chapter Reference")
+	CourseChapter = frappe.qb.DocType("Course Chapter")
+	LessonReference = frappe.qb.DocType("Lesson Reference")
+	CourseLesson = frappe.qb.DocType("Course Lesson")
+	return (
+		frappe.qb.from_(ChapterReference)
+		.join(CourseChapter)
+		.on(CourseChapter.name == ChapterReference.chapter)
+		.join(LessonReference)
+		.on(LessonReference.parent == CourseChapter.name)
+		.join(CourseLesson)
+		.on(CourseLesson.name == LessonReference.lesson)
+		.select(
+			CourseLesson.name.as_("name"),
+			ChapterReference.chapter.as_("chapter_name"),
+			ChapterReference.idx.as_("chapter_idx"),
+			LessonReference.idx.as_("lesson_idx"),
+		)
+		.where(ChapterReference.parent == course)
+		.orderby(ChapterReference.idx)
+		.orderby(LessonReference.idx)
+	).run(as_dict=True)
 
 
 def build_outline(

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1295,6 +1295,41 @@ def get_completed_lessons(course: str, lesson_rows: list) -> set:
 	)
 
 
+def compute_locked_lessons(ordered_lesson_names: list, completed: set) -> set:
+	"""Lesson names a student may not open yet, given the course order and what they finished.
+
+	A lesson is open when it is at or before the first incomplete lesson, or when the
+	student already completed it (so enabling the setting mid-cohort never revokes
+	access to work already done).
+	"""
+	locked = set()
+	past_first_incomplete = False
+	for name in ordered_lesson_names:
+		if name in completed:
+			continue
+		if past_first_incomplete:
+			locked.add(name)
+		else:
+			past_first_incomplete = True
+	return locked
+
+
+def get_ordered_lesson_rows(course: str) -> list:
+	"""Outline lesson rows for a course, in (chapter idx, lesson idx) order."""
+	chapters = get_outline_chapter(course)
+	if not chapters:
+		return []
+
+	rows_by_chapter = {}
+	for row in get_outline_lessons([c.name for c in chapters]):
+		rows_by_chapter.setdefault(row.chapter_name, []).append(row)
+
+	ordered = []
+	for chapter in chapters:
+		ordered.extend(sorted(rows_by_chapter.get(chapter.name, []), key=lambda r: r.lesson_idx))
+	return ordered
+
+
 def build_outline(
 	chapters: list, lesson_rows: list, files_by_name: dict, completed: set, progress: bool
 ) -> list:

--- a/lms/page_renderers.py
+++ b/lms/page_renderers.py
@@ -28,7 +28,7 @@ class SCORMRenderer(BaseRenderer):
 	_DISK_ROOTS = ("private", "public")
 
 	def _check_permission(self):
-		from lms.lms.permissions import can_access_lesson
+		from lms.lms.permissions import can_access_lesson, get_locked_lessons
 
 		parts = self.path.strip("/").split("/")
 		# scorm/<course>/<title>/...
@@ -47,7 +47,10 @@ class SCORMRenderer(BaseRenderer):
 		# SCORM chapters are created with exactly one lesson (upsert_chapter invariant
 		# in api.py). order_by keeps the access check deterministic if that ever changes.
 		lesson = frappe.db.get_value("Lesson Reference", {"parent": chapter}, "lesson", order_by="idx asc")
-		if not lesson or not can_access_lesson(lesson):
+		# can_access_lesson answers "is this course yours or are you enrolled", which is
+		# lock-unaware. Sequential courses gate the bytes too, otherwise the SCORM page
+		# is a route around the gate that never touches get_lesson.
+		if not lesson or not can_access_lesson(lesson) or lesson in get_locked_lessons(course):
 			frappe.logger("lms.security").warning(
 				"SCORM resource access denied: user=%s path=%s",
 				frappe.session.user,

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -198,6 +198,37 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		self.assertNotIn("content", payload)
 		self.assertNotIn("body", payload)
 
+	def test_get_lesson_sends_a_nonexistent_lesson_number_back_to_the_current_one(self):
+		"""Typing a lesson number that does not exist is the same URL tampering the gate
+		catches, so a gated course lands the student on their current lesson rather than
+		bouncing them to the course page."""
+		self._enable()
+		from lms.lms.utils import get_lesson
+
+		# Chapter 1 has three lessons and there is no chapter 9.
+		for chapter, lesson in ((1, 99), (9, 1)):
+			with self.subTest(chapter=chapter, lesson=lesson):
+				payload = get_lesson(self.course.name, chapter, lesson)
+				self.assertEqual(payload.get("locked"), 1)
+				self.assertEqual(payload.get("not_found"), 1)
+				self.assertEqual(payload.get("redirect_to"), "1-1")
+
+	def test_a_lesson_that_exists_but_is_locked_is_not_flagged_not_found(self):
+		# Both payloads redirect, so the page tells them apart on this flag alone:
+		# "finish the earlier lessons to unlock this one" is false of a lesson that
+		# does not exist.
+		self._enable()
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 1, 2)
+		self.assertEqual(payload.get("locked"), 1)
+		self.assertIsNone(payload.get("not_found"))
+
+	def test_a_nonexistent_lesson_number_is_still_empty_without_the_gate(self):
+		from lms.lms.utils import get_lesson
+
+		self.assertEqual(get_lesson(self.course.name, 9, 1), {})
+
 	def test_get_lesson_serves_the_current_lesson(self):
 		self._enable()
 		from lms.lms.utils import get_lesson

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -493,6 +493,18 @@ class TestLessonLockingIntegration(BaseTestUtils):
 			)
 		)
 
+	def test_the_lock_check_does_not_read_the_enrollment_pointer(self):
+		# SCORMRenderer runs this on every asset request of a package.
+		self._enable()
+		with patch("frappe.db.get_value", wraps=frappe.db.get_value) as get_value:
+			get_locked_lessons(self.course.name)
+
+		pointer_reads = [
+			call
+			for call in get_value.call_args_list
+			if call.args and call.args[0] == "LMS Enrollment" and "current_lesson" in call.args
+		]
+		self.assertEqual(pointer_reads, [])
 
 
 class TestLessonLockingImportExport(FrappeTestCase):

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, FOSS United and Contributors
 # See license.txt
 
+import json
 from unittest.mock import patch
 
 import frappe
@@ -519,7 +520,18 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		# submission counts as a pass and the flow actually reaches the progress
 		# write, which is where the rollback happened.
 		frappe.db.set_value("LMS Quiz", quiz.name, "passing_percentage", 0)
-		batch = self._create_batch(self.course.name, instructor=self.author.email, title="Locking Batch")
+		# _create_batch links its courses row to a Course Evaluator, and that in turn
+		# links a User. Both helpers default to frappe@example.com, which nothing in
+		# this suite seeds — a site carrying either from an earlier run hides that,
+		# CI's fresh one does not. Build both off this suite's own author instead, so
+		# the test depends on nothing outside its own setUp.
+		self._create_evaluator(self.author.email)
+		batch = self._create_batch(
+			self.course.name,
+			instructor=self.author.email,
+			title="Locking Batch",
+			evaluator=self.author.email,
+		)
 		batch_doc = frappe.get_doc("LMS Batch", batch.name)
 		batch_doc.append("assessment", {"assessment_type": "LMS Quiz", "assessment_name": quiz.name})
 		batch_doc.save()
@@ -529,7 +541,10 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		from lms.lms.doctype.lms_quiz.lms_quiz import submit_quiz
 
 		self.assertIn(self.lessons[2].name, get_locked_lessons(self.course.name))
-		result = submit_quiz(quiz.name, [])
+		# A JSON string, not a list: submit_quiz is whitelisted and `results` is typed
+		# `str | None`, so frappe coerces the argument through pydantic exactly as it
+		# would over HTTP. Every other caller in the suite passes json.dumps(...).
+		result = submit_quiz(quiz.name, json.dumps([]))
 
 		self.assertTrue(frappe.db.exists("LMS Quiz Submission", result["submission"]))
 		# The lesson stays locked: skipping the write must not become a way past the gate.

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -108,6 +108,21 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		frappe.set_user(user)
 		return chapter, lesson
 
+	def _create_lesson_quiz(self, lesson_name, title="Locking Lesson Quiz"):
+		user = frappe.session.user
+		frappe.set_user("Administrator")
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": title,
+				"course": self.course.name,
+				"lesson": lesson_name,
+				"passing_percentage": 70,
+			}
+		).insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Quiz", quiz.name))
+		frappe.set_user(user)
+		return quiz
 
 	def test_flag_off_locks_nothing(self):
 		self.assertFalse(enforces_lesson_completion(self.course.name))
@@ -360,3 +375,66 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		outline = get_course_outline(self.course.name, progress=True)
 		scorm = next(c for c in outline if c.name == chapter.name)
 		self.assertEqual(scorm.launch_file, "index.html")
+
+	def test_locked_lesson_quiz_is_not_readable(self):
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+
+		from lms.lms.permissions import can_access_quiz
+
+		self.assertFalse(can_access_quiz(quiz.name))
+
+	def test_the_current_lessons_quiz_stays_readable(self):
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[0].name)
+
+		from lms.lms.permissions import can_access_quiz
+
+		self.assertTrue(can_access_quiz(quiz.name))
+
+	def test_a_quiz_orphaned_from_its_lesson_is_refused_under_the_gate(self):
+		# cleanup_lesson_backreferences clears LMS Quiz.lesson on the lesson's deletion
+		# and leaves LMS Quiz.course standing, so the placement carries no lesson to
+		# check. `None not in locked` holds for every course, which granted any enrolled
+		# member the questions of a quiz still embedded in a locked lesson.
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+		frappe.db.set_value("LMS Quiz", quiz.name, "lesson", None)
+
+		from lms.lms.permissions import can_access_quiz
+
+		self.assertFalse(can_access_quiz(quiz.name))
+
+	def test_a_quiz_orphaned_from_its_lesson_stays_readable_without_the_gate(self):
+		# The refusal above is the gate talking, not a blanket rule: an ungated course
+		# still hands its enrolled members a quiz whose lesson link was cleared.
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+		frappe.db.set_value("LMS Quiz", quiz.name, "lesson", None)
+
+		from lms.lms.permissions import can_access_quiz
+
+		self.assertTrue(can_access_quiz(quiz.name))
+
+	def test_an_orphaned_quiz_reopens_once_the_course_is_finished(self):
+		# Gate on, nothing left locked: there is no lesson the quiz could be gated by.
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+		frappe.db.set_value("LMS Quiz", quiz.name, "lesson", None)
+		for lesson in self.lessons:
+			self._complete(lesson.name)
+
+		from lms.lms.permissions import can_access_quiz
+
+		self.assertEqual(get_locked_lessons(self.course.name), set())
+		self.assertTrue(can_access_quiz(quiz.name))
+
+	def test_outline_does_not_publish_the_quiz_of_a_locked_lesson(self):
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+		frappe.db.set_value("Course Lesson", self.lessons[2].name, "quiz_id", quiz.name)
+
+		from lms.lms.utils import get_course_outline
+
+		outline = get_course_outline(self.course.name, progress=True)
+		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
+		self.assertIsNone(lessons[2].quiz_id)

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -30,6 +30,12 @@ class TestComputeLockedLessons(FrappeTestCase):
 	def test_empty_course_locks_nothing(self):
 		self.assertEqual(compute_locked_lessons([], set()), set())
 
+	def test_a_repeated_lesson_does_not_lock_its_own_first_occurrence(self):
+		# A lesson referenced from two chapters used to be locked by its later
+		# occurrence, which — the return value being a set of names — locked the first
+		# one too. With lesson one locked there is nowhere left to redirect to.
+		locked = compute_locked_lessons(["L1", "L2", "L1"], set())
+		self.assertEqual(locked, {"L2"})
 
 
 class TestLessonLockingIntegration(BaseTestUtils):
@@ -258,6 +264,16 @@ class TestLessonLockingIntegration(BaseTestUtils):
 
 		self.assertEqual(get_course_details(self.course.name).current_lesson, "1-2")
 
+	def test_ordered_lesson_rows_carry_no_lesson_bodies(self):
+		# The lock rule needs names and order only; body/content would put the whole
+		# course text on the wire for every gated lesson view.
+		from lms.lms.utils import get_ordered_lesson_rows
+
+		rows = get_ordered_lesson_rows(self.course.name)
+		self.assertEqual([row.name for row in rows], [lesson.name for lesson in self.lessons])
+		for row in rows:
+			self.assertNotIn("body", row)
+			self.assertNotIn("content", row)
 
 	def test_save_progress_refuses_a_locked_lesson(self):
 		self._enable()

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2026, FOSS United and Contributors
 # See license.txt
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from lms.lms.permissions import enforces_lesson_completion, get_locked_lessons
+from lms.lms.test_helpers import BaseTestUtils
 from lms.lms.utils import compute_locked_lessons
 
 
@@ -26,3 +29,88 @@ class TestComputeLockedLessons(FrappeTestCase):
 
 	def test_empty_course_locks_nothing(self):
 		self.assertEqual(compute_locked_lessons([], set()), set())
+
+
+class TestLessonLockingIntegration(BaseTestUtils):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# The worktree's field reaches the test site's schema only via reload_doctype;
+		# bench migrate cannot see this worktree.
+		frappe.reload_doctype("LMS Course")
+
+	def setUp(self):
+		super().setUp()
+		self.student = self._create_user("locking-student@example.com", "Lock", "Student", ["LMS Student"])
+		self.author = self._create_user(
+			"locking-author@example.com", "Lock", "Author", ["Course Creator", "Moderator"]
+		)
+		self.course = self._create_course(title="Locking Course", instructor=self.author.email)
+		self.chapter = self._create_chapter("Locking Chapter", self.course.name)
+		self._create_chapter_reference(self.course.name, self.chapter.name, idx=1)
+
+		self.lessons = []
+		for idx in range(1, 4):
+			lesson = self._create_lesson(f"Locking Lesson {idx}", self.chapter.name, self.course.name)
+			self.lessons.append(lesson)
+
+		chapter_doc = frappe.get_doc("Course Chapter", self.chapter.name)
+		for lesson in self.lessons:
+			chapter_doc.append("lessons", {"lesson": lesson.name})
+		chapter_doc.save()
+
+		self._create_enrollment(self.student.email, self.course.name)
+		frappe.set_user(self.student.email)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def _enable(self):
+		frappe.db.set_value("LMS Course", self.course.name, "enforce_lesson_completion", 1)
+
+	def test_flag_off_locks_nothing(self):
+		self.assertFalse(enforces_lesson_completion(self.course.name))
+		self.assertEqual(get_locked_lessons(self.course.name), set())
+
+	def test_flag_on_locks_everything_past_the_first_lesson(self):
+		self._enable()
+		self.assertTrue(enforces_lesson_completion(self.course.name))
+		self.assertEqual(
+			get_locked_lessons(self.course.name),
+			{self.lessons[1].name, self.lessons[2].name},
+		)
+
+	def test_completing_the_first_lesson_unlocks_the_second(self):
+		self._enable()
+		frappe.set_user("Administrator")
+		progress = self._create_progress(self.student.email, self.course.name, self.lessons[0].name)
+		frappe.db.set_value("LMS Course Progress", progress.name, "status", "Complete")
+		frappe.set_user(self.student.email)
+		self.assertEqual(get_locked_lessons(self.course.name), {self.lessons[2].name})
+
+	def test_partially_complete_does_not_unlock(self):
+		self._enable()
+		frappe.set_user("Administrator")
+		progress = self._create_progress(self.student.email, self.course.name, self.lessons[0].name)
+		frappe.db.set_value("LMS Course Progress", progress.name, "status", "Partially Complete")
+		frappe.set_user(self.student.email)
+		self.assertEqual(
+			get_locked_lessons(self.course.name),
+			{self.lessons[1].name, self.lessons[2].name},
+		)
+
+	def test_course_author_is_exempt(self):
+		self._enable()
+		frappe.set_user(self.author.email)
+		self.assertFalse(enforces_lesson_completion(self.course.name))
+		self.assertEqual(get_locked_lessons(self.course.name), set())
+
+	def test_unenrolled_user_is_not_gated_by_sequencing(self):
+		self._enable()
+		frappe.set_user("Guest")
+		self.assertFalse(enforces_lesson_completion(self.course.name))
+
+	def test_malformed_course_argument_locks_nothing(self):
+		self.assertEqual(get_locked_lessons(None), set())
+		self.assertEqual(get_locked_lessons(["!=", ""]), set())

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -438,3 +438,10 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		outline = get_course_outline(self.course.name, progress=True)
 		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
 		self.assertIsNone(lessons[2].quiz_id)
+
+
+class TestLessonLockingImportExport(FrappeTestCase):
+	def test_export_carries_the_setting(self):
+		from lms.lms.course_import_export import get_course_fields
+
+		self.assertIn("enforce_lesson_completion", get_course_fields())

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -130,3 +130,65 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		outline = get_course_outline(self.course.name, progress=False)
 		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
 		self.assertFalse(any("locked" in lesson for lesson in lessons))
+
+	def test_get_lesson_refuses_a_locked_lesson(self):
+		self._enable()
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 1, 2)
+		self.assertEqual(payload.get("locked"), 1)
+		self.assertEqual(payload.get("redirect_to"), "1-1")
+		self.assertNotIn("content", payload)
+		self.assertNotIn("body", payload)
+
+	def test_get_lesson_serves_the_current_lesson(self):
+		self._enable()
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 1, 1)
+		self.assertFalse(payload.get("locked"))
+		self.assertEqual(payload.get("title"), "Locking Lesson 1")
+
+	def test_redirect_target_follows_the_enrollment_pointer(self):
+		self._enable()
+		frappe.set_user("Administrator")
+		progress = self._create_progress(self.student.email, self.course.name, self.lessons[0].name)
+		frappe.db.set_value("LMS Course Progress", progress.name, "status", "Complete")
+		enrollment = frappe.db.get_value(
+			"LMS Enrollment", {"course": self.course.name, "member": self.student.email}
+		)
+		frappe.db.set_value("LMS Enrollment", enrollment, "current_lesson", self.lessons[1].name)
+		frappe.set_user(self.student.email)
+
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 1, 3)
+		self.assertEqual(payload.get("locked"), 1)
+		self.assertEqual(payload.get("redirect_to"), "1-2")
+
+	def test_get_lesson_refuses_a_locked_scorm_lesson(self):
+		self._enable()
+		frappe.set_user("Administrator")
+		scorm_chapter = self._create_chapter("Locking SCORM Chapter", self.course.name)
+		self._create_chapter_reference(self.course.name, scorm_chapter.name, idx=2)
+		frappe.db.set_value(
+			"Course Chapter", scorm_chapter.name, {"is_scorm_package": 1, "launch_file": "index.html"}
+		)
+		scorm_lesson = self._create_lesson("SCORM Lesson", scorm_chapter.name, self.course.name)
+		self._create_lesson_reference(scorm_chapter.name, scorm_lesson.name)
+		frappe.set_user(self.student.email)
+
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 2, 1)
+		self.assertEqual(payload.get("locked"), 1)
+		self.assertNotIn("is_scorm_package", payload)
+
+	def test_course_author_still_gets_a_locked_lesson(self):
+		self._enable()
+		frappe.set_user(self.author.email)
+		from lms.lms.utils import get_lesson
+
+		payload = get_lesson(self.course.name, 1, 3)
+		self.assertFalse(payload.get("locked"))
+		self.assertEqual(payload.get("title"), "Locking Lesson 3")

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -31,6 +31,7 @@ class TestComputeLockedLessons(FrappeTestCase):
 		self.assertEqual(compute_locked_lessons([], set()), set())
 
 
+
 class TestLessonLockingIntegration(BaseTestUtils):
 	@classmethod
 	def setUpClass(cls):
@@ -68,6 +69,39 @@ class TestLessonLockingIntegration(BaseTestUtils):
 
 	def _enable(self):
 		frappe.db.set_value("LMS Course", self.course.name, "enforce_lesson_completion", 1)
+
+	def _complete(self, lesson_name):
+		"""Mark a lesson complete for the student, as the system would."""
+		user = frappe.session.user
+		frappe.set_user("Administrator")
+		progress = self._create_progress(self.student.email, self.course.name, lesson_name)
+		frappe.db.set_value("LMS Course Progress", progress.name, "status", "Complete")
+		frappe.set_user(user)
+		return progress
+
+	def _set_pointer(self, lesson_name):
+		user = frappe.session.user
+		frappe.set_user("Administrator")
+		enrollment = frappe.db.get_value(
+			"LMS Enrollment", {"course": self.course.name, "member": self.student.email}
+		)
+		frappe.db.set_value("LMS Enrollment", enrollment, "current_lesson", lesson_name)
+		frappe.set_user(user)
+
+	def _add_scorm_chapter(self, title="Locking SCORM Chapter"):
+		"""A SCORM chapter after the plain ones, so it is locked until they are done."""
+		user = frappe.session.user
+		frappe.set_user("Administrator")
+		chapter = self._create_chapter(title, self.course.name)
+		self._create_chapter_reference(self.course.name, chapter.name, idx=2)
+		frappe.db.set_value(
+			"Course Chapter", chapter.name, {"is_scorm_package": 1, "launch_file": "index.html"}
+		)
+		lesson = self._create_lesson("SCORM Lesson", chapter.name, self.course.name)
+		self._create_lesson_reference(chapter.name, lesson.name)
+		frappe.set_user(user)
+		return chapter, lesson
+
 
 	def test_flag_off_locks_nothing(self):
 		self.assertFalse(enforces_lesson_completion(self.course.name))
@@ -168,15 +202,7 @@ class TestLessonLockingIntegration(BaseTestUtils):
 
 	def test_get_lesson_refuses_a_locked_scorm_lesson(self):
 		self._enable()
-		frappe.set_user("Administrator")
-		scorm_chapter = self._create_chapter("Locking SCORM Chapter", self.course.name)
-		self._create_chapter_reference(self.course.name, scorm_chapter.name, idx=2)
-		frappe.db.set_value(
-			"Course Chapter", scorm_chapter.name, {"is_scorm_package": 1, "launch_file": "index.html"}
-		)
-		scorm_lesson = self._create_lesson("SCORM Lesson", scorm_chapter.name, self.course.name)
-		self._create_lesson_reference(scorm_chapter.name, scorm_lesson.name)
-		frappe.set_user(self.student.email)
+		self._add_scorm_chapter()
 
 		from lms.lms.utils import get_lesson
 
@@ -192,3 +218,129 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		payload = get_lesson(self.course.name, 1, 3)
 		self.assertFalse(payload.get("locked"))
 		self.assertEqual(payload.get("title"), "Locking Lesson 3")
+
+	def test_redirect_target_is_never_locked_when_the_pointer_is_stale(self):
+		# The pointer can name a locked lesson: save_progress wrote it while the setting
+		# was off, or the chapters were reordered afterwards. Redirecting there is a dead
+		# end — the router replaces the route it is already on and nothing happens.
+		self._enable()
+		self._complete(self.lessons[0].name)
+		self._set_pointer(self.lessons[2].name)
+
+		from lms.lms.utils import get_lesson
+
+		locked = get_locked_lessons(self.course.name)
+		self.assertIn(self.lessons[2].name, locked)
+
+		payload = get_lesson(self.course.name, 1, 3)
+		self.assertEqual(payload.get("locked"), 1)
+		self.assertEqual(payload.get("redirect_to"), "1-2")
+
+		from lms.lms.utils import get_lesson_index
+
+		self.assertNotIn(payload["redirect_to"], {get_lesson_index(name) for name in locked})
+
+	def test_continue_learning_never_points_at_a_locked_lesson(self):
+		self._enable()
+		self._complete(self.lessons[0].name)
+		self._set_pointer(self.lessons[2].name)
+
+		from lms.lms.utils import get_course_details
+
+		self.assertEqual(get_course_details(self.course.name).current_lesson, "1-2")
+
+	def test_continue_learning_keeps_the_pointer_when_it_is_open(self):
+		self._enable()
+		self._complete(self.lessons[0].name)
+		self._set_pointer(self.lessons[1].name)
+
+		from lms.lms.utils import get_course_details
+
+		self.assertEqual(get_course_details(self.course.name).current_lesson, "1-2")
+
+
+	def test_save_progress_refuses_a_locked_lesson(self):
+		self._enable()
+		from lms.lms.doctype.course_lesson.course_lesson import save_progress
+
+		with self.assertRaises(frappe.PermissionError):
+			save_progress(self.lessons[2].name, self.course.name)
+		self.assertFalse(
+			frappe.db.exists(
+				"LMS Course Progress", {"lesson": self.lessons[2].name, "member": self.student.email}
+			)
+		)
+
+	def test_save_progress_cannot_unlock_the_whole_course(self):
+		# The bypass: call save_progress once per lesson name the outline publishes and
+		# every lesson gets a Complete row, emptying the lock set.
+		self._enable()
+		from lms.lms.doctype.course_lesson.course_lesson import save_progress
+
+		for lesson in self.lessons[1:]:
+			with self.assertRaises(frappe.PermissionError):
+				save_progress(lesson.name, self.course.name)
+
+		self.assertEqual(
+			get_locked_lessons(self.course.name),
+			{self.lessons[1].name, self.lessons[2].name},
+		)
+
+	def test_save_progress_still_completes_the_lesson_the_student_is_on(self):
+		self._enable()
+		from lms.lms.doctype.course_lesson.course_lesson import save_progress
+
+		save_progress(self.lessons[0].name, self.course.name)
+		self.assertTrue(
+			frappe.db.exists(
+				"LMS Course Progress",
+				{"lesson": self.lessons[0].name, "member": self.student.email, "status": "Complete"},
+			)
+		)
+		self.assertEqual(get_locked_lessons(self.course.name), {self.lessons[2].name})
+
+	def test_scorm_renderer_refuses_bytes_for_a_locked_chapter(self):
+		# SCORMChapter.vue never calls get_lesson, so this is the authoritative gate for
+		# a student who opens /learn/<scorm-chapter> directly.
+		self._enable()
+		chapter, _lesson = self._add_scorm_chapter()
+
+		from lms.page_renderers import SCORMRenderer
+
+		renderer = SCORMRenderer(path=f"scorm/{self.course.name}/{chapter.title}/index.html")
+		with self.assertRaises(frappe.PermissionError):
+			renderer._check_permission()
+
+	def test_scorm_renderer_serves_bytes_once_the_chapter_is_unlocked(self):
+		self._enable()
+		chapter, _lesson = self._add_scorm_chapter()
+		for lesson in self.lessons:
+			self._complete(lesson.name)
+
+		from lms.page_renderers import SCORMRenderer
+
+		renderer = SCORMRenderer(path=f"scorm/{self.course.name}/{chapter.title}/index.html")
+		self.assertIsNone(renderer._check_permission())
+
+	def test_outline_withholds_the_launch_file_of_a_locked_scorm_chapter(self):
+		self._enable()
+		chapter, _lesson = self._add_scorm_chapter()
+
+		from lms.lms.utils import get_course_outline
+
+		outline = get_course_outline(self.course.name, progress=True)
+		scorm = next(c for c in outline if c.name == chapter.name)
+		self.assertIsNone(scorm.launch_file)
+		self.assertIsNone(scorm.scorm_package)
+
+	def test_outline_serves_the_launch_file_once_the_chapter_is_unlocked(self):
+		self._enable()
+		chapter, _lesson = self._add_scorm_chapter()
+		for lesson in self.lessons:
+			self._complete(lesson.name)
+
+		from lms.lms.utils import get_course_outline
+
+		outline = get_course_outline(self.course.name, progress=True)
+		scorm = next(c for c in outline if c.name == chapter.name)
+		self.assertEqual(scorm.launch_file, "index.html")

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, FOSS United and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -438,6 +440,25 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		outline = get_course_outline(self.course.name, progress=True)
 		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
 		self.assertIsNone(lessons[2].quiz_id)
+
+	def test_progress_is_published_to_the_completing_member_alone(self):
+		# The outline reload for a quiz or assignment completion rides on this event,
+		# so it has to reach the student who completed the lesson - and only them.
+		self._enable()
+		from lms.lms.doctype.course_lesson.course_lesson import save_progress
+
+		with patch("frappe.publish_realtime") as publish:
+			save_progress(self.lessons[0].name, self.course.name)
+
+		published = [
+			call for call in publish.call_args_list if call.kwargs.get("event") == "update_lesson_progress"
+		]
+		self.assertEqual(len(published), 1)
+		self.assertEqual(published[0].kwargs.get("user"), self.student.email)
+		self.assertIsNone(published[0].kwargs.get("room"))
+		self.assertEqual(published[0].kwargs["message"]["lesson"], self.lessons[0].name)
+
+
 
 
 class TestLessonLockingImportExport(FrappeTestCase):

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, FOSS United and Contributors
+# See license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+from lms.lms.utils import compute_locked_lessons
+
+
+class TestComputeLockedLessons(FrappeTestCase):
+	def test_nothing_complete_leaves_only_the_first_lesson_open(self):
+		locked = compute_locked_lessons(["L1", "L2", "L3"], set())
+		self.assertEqual(locked, {"L2", "L3"})
+
+	def test_completing_the_first_opens_the_second(self):
+		locked = compute_locked_lessons(["L1", "L2", "L3"], {"L1"})
+		self.assertEqual(locked, {"L3"})
+
+	def test_all_complete_locks_nothing(self):
+		locked = compute_locked_lessons(["L1", "L2"], {"L1", "L2"})
+		self.assertEqual(locked, set())
+
+	def test_a_lesson_completed_out_of_order_stays_open(self):
+		# Flag switched on mid-cohort: L3 was already finished, so it must not lock.
+		locked = compute_locked_lessons(["L1", "L2", "L3", "L4"], {"L3"})
+		self.assertEqual(locked, {"L2", "L4"})
+
+	def test_empty_course_locks_nothing(self):
+		self.assertEqual(compute_locked_lessons([], set()), set())

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -458,6 +458,40 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		self.assertIsNone(published[0].kwargs.get("room"))
 		self.assertEqual(published[0].kwargs["message"]["lesson"], self.lessons[0].name)
 
+	def test_a_quiz_on_a_locked_lesson_keeps_its_submission(self):
+		# can_access_quiz grants through an LMS Assessment on a batch, so a quiz can be
+		# submitted while its lesson is locked. save_progress refuses a locked lesson by
+		# raising, which would roll back the submission already written in the same
+		# request.
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+
+		frappe.set_user("Administrator")
+		# submit_quiz reads the row, not the doc. A questionless quiz has its passing
+		# percentage forced to 100 by calculate_total_marks; drop it to 0 so the
+		# submission counts as a pass and the flow actually reaches the progress
+		# write, which is where the rollback happened.
+		frappe.db.set_value("LMS Quiz", quiz.name, "passing_percentage", 0)
+		batch = self._create_batch(self.course.name, instructor=self.author.email, title="Locking Batch")
+		batch_doc = frappe.get_doc("LMS Batch", batch.name)
+		batch_doc.append("assessment", {"assessment_type": "LMS Quiz", "assessment_name": quiz.name})
+		batch_doc.save()
+		self._create_batch_enrollment(self.student.email, batch.name)
+		frappe.set_user(self.student.email)
+
+		from lms.lms.doctype.lms_quiz.lms_quiz import submit_quiz
+
+		self.assertIn(self.lessons[2].name, get_locked_lessons(self.course.name))
+		result = submit_quiz(quiz.name, [])
+
+		self.assertTrue(frappe.db.exists("LMS Quiz Submission", result["submission"]))
+		# The lesson stays locked: skipping the write must not become a way past the gate.
+		self.assertIn(self.lessons[2].name, get_locked_lessons(self.course.name))
+		self.assertFalse(
+			frappe.db.exists(
+				"LMS Course Progress", {"lesson": self.lessons[2].name, "member": self.student.email}
+			)
+		)
 
 
 

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -114,3 +114,19 @@ class TestLessonLockingIntegration(BaseTestUtils):
 	def test_malformed_course_argument_locks_nothing(self):
 		self.assertEqual(get_locked_lessons(None), set())
 		self.assertEqual(get_locked_lessons(["!=", ""]), set())
+
+	def test_outline_stamps_locked_when_the_gate_applies(self):
+		self._enable()
+		from lms.lms.utils import get_course_outline
+
+		outline = get_course_outline(self.course.name, progress=True)
+		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
+		self.assertEqual([lesson.locked for lesson in lessons], [0, 1, 1])
+
+	def test_outline_without_progress_does_not_stamp_locked(self):
+		self._enable()
+		from lms.lms.utils import get_course_outline
+
+		outline = get_course_outline(self.course.name, progress=False)
+		lessons = [lesson for chapter in outline for lesson in chapter.lessons]
+		self.assertFalse(any("locked" in lesson for lesson in lessons))

--- a/lms/tests/test_lesson_locking.py
+++ b/lms/tests/test_lesson_locking.py
@@ -461,6 +461,22 @@ class TestLessonLockingIntegration(BaseTestUtils):
 		self.assertEqual(get_locked_lessons(self.course.name), set())
 		self.assertTrue(can_access_quiz(quiz.name))
 
+	def test_two_placements_in_one_course_compute_the_lock_state_once(self):
+		# A quiz reachable from more than one lesson of the same course walked the whole
+		# lock chain per placement: get_membership plus the ordered rows and the progress
+		# read, repeated for a set that cannot differ between them.
+		self._enable()
+		quiz = self._create_lesson_quiz(self.lessons[2].name)
+		frappe.db.set_value("Course Lesson", self.lessons[1].name, "quiz_id", quiz.name)
+
+		from lms.lms import permissions
+		from lms.lms.permissions import can_access_quiz
+
+		with patch.object(permissions, "_lock_state", wraps=permissions._lock_state) as lock_state:
+			self.assertFalse(can_access_quiz(quiz.name))
+
+		self.assertEqual(lock_state.call_count, 1)
+
 	def test_outline_does_not_publish_the_quiz_of_a_locked_lesson(self):
 		self._enable()
 		quiz = self._create_lesson_quiz(self.lessons[2].name)


### PR DESCRIPTION
## Summary

- Adds a per-course `Enforce Lesson Completion` setting. When it is off, a student can only open a lesson once every lesson before it in the course outline is complete. Off by default, so existing courses are unaffected. 
- The gate is enforced server-side at every route that can reach lesson content, rather than hidden in the UI.

## Screenshots

### Locked Lessons on Sidebar
<img width="2798" height="1679" alt="Screenshot From 2026-08-19 11-22-23" src="https://github.com/user-attachments/assets/bbf11162-ee2f-4562-82e2-29ed9c3a036b" />

### Locked Lessons in the Course Outline
<img width="2806" height="1684" alt="image" src="https://github.com/user-attachments/assets/84a4c459-afd6-4f85-9dcb-72de4bc192d9" />

### The Locked Lesson Banner
<img width="2806" height="1684" alt="image" src="https://github.com/user-attachments/assets/bbfd7a6b-b8ab-4199-b1fa-258372f781af" />

### A Lesson That Does Not Exist
<img width="2806" height="1684" alt="image" src="https://github.com/user-attachments/assets/770de986-63ed-44d3-97bb-1724af7207e7" />

### The Course Setting
<img width="2806" height="1684" alt="image" src="https://github.com/user-attachments/assets/689fe748-a33b-499f-9eb2-64e09704cc9a" />

## How

**The rule is one pure function.**

-  `utils.compute_locked_lessons(ordered_lesson_names, completed) -> set` takes the flattened outline and the set of completed lessons and returns the locked ones. 
- No DB access, no request state — it is directly unit-testable, and every enforcement point derives from it
- `permissions.py` wraps it for callers:

| function | returns |
|---|---|
| `enforces_lesson_completion(course)` | is the setting on for this course |
| `get_locked_lessons(course)` | the locked set for the current user |
| `get_lesson_gate(course)` | the locked set **and** the lesson to send the student to |

`get_lesson_gate` derives the redirect target from the same ordered list as the lock set, and only honours `LMS Enrollment.current_lesson` when that pointer is itself unlocked — a stale pointer can otherwise aim the student at a locked lesson and dead-end the course.

**Four enforcement points, each with a bypass test:**

- `get_lesson` — returns a `locked` payload instead of lesson content
- `SCORMRenderer._check_permission` — the SCORM page is its own route and never calls `get_lesson`, so it needs its own check
- `save_progress` — it writes the very rows that unlock the gate
- `can_access_quiz` — a lesson's quiz is reachable by its own id

`build_outline` also stamps per-lesson `locked` so both outline components can render the lock and stop navigating, and it withholds a locked SCORM chapter's launch file.

**Frontend.** `LockedLessonNotice.vue` replaces the lesson body with a banner explaining why, plus a counter and a `Go now` button back to the lesson the student is actually on. `ChapterRow.vue` and `StudentLessonSidebar.vue` render locked rows as non-navigating, named with `sr-only` text.

## Issues
- Closes #2178