### PR TITLE
fix(courses): give the Chapters bar the tab strip's height

### DIFF
--- a/frontend/src/pages/Courses/CourseDetail.vue
+++ b/frontend/src/pages/Courses/CourseDetail.vue
@@ -194,7 +194,7 @@
 				<div
 					class="pointer-events-auto flex w-[30%] items-center justify-between gap-x-2 border-s border-b bg-surface-base p-1 px-5"
 				>
-					<div class="py-2.5 text-base-medium text-ink-gray-9">
+					<div class="py-2.5 text-p-base-medium text-ink-gray-9">
 						{{ __('Chapters') }}
 					</div>
 					<Button size="sm" @click="courseEditorRef?.openAddChapter()">


### PR DESCRIPTION
The bar floats over the tab strip and masks the 30% of it that sits above the outline, so the two have to be exactly as tall as each other: the bar's own bottom border stands in for the strip's there, and the outline's start border runs down from it.

They matched until the page shell gave the tab buttons `text-p-base` (line-height 1.5) while the bar's label kept `text-base-medium` (1.15). Same 14px, but 4.9px less box, so the bar's border landed short of the strip's and the start border broke between the two.