### PR TITLE
fix:  enrollment update

### DIFF
--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -136,10 +136,11 @@ def update_program_progress(member):
 
 
 def _update_course_enrollments(course, increment=True):
-	frappe.db.sql(
-		"UPDATE `tabLMS Course` SET enrollments = enrollments + %s WHERE name = %s",
-		(1 if increment else -1, course),
-	)
+	LMSCourse = frappe.qb.DocType("LMS Course")
+	value = 1 if increment else -1
+	frappe.qb.update(LMSCourse).set(LMSCourse.enrollments, LMSCourse.enrollments + value).where(
+		LMSCourse.name == course
+	).run()
 
 
 @contextmanager

--- a/lms/lms/doctype/lms_enrollment/lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/lms_enrollment.py
@@ -38,6 +38,14 @@ class LMSEnrollment(Document):
 	def on_update(self):
 		update_program_progress(self.member)
 
+	def after_insert(self):
+		if self.member_type == "Student":
+			_update_course_enrollments(self.course, increment=True)
+
+	def after_delete(self):
+		if self.member_type == "Student":
+			_update_course_enrollments(self.course, increment=False)
+
 	def validate_duplicate_enrollment(self):
 		# Lock the course row first: see the note in
 		# lms_batch_enrollment.validate_duplicate_members. Two concurrent
@@ -125,6 +133,13 @@ def update_program_progress(member):
 
 		average_progress = ceil(total_progress / len(courses))
 		frappe.db.set_value("LMS Program Member", program.name, "progress", average_progress)
+
+
+def _update_course_enrollments(course, increment=True):
+	frappe.db.sql(
+		"UPDATE `tabLMS Course` SET enrollments = enrollments + %s WHERE name = %s",
+		(1 if increment else -1, course),
+	)
 
 
 @contextmanager

--- a/lms/lms/doctype/lms_enrollment/test_lms_enrollment.py
+++ b/lms/lms/doctype/lms_enrollment/test_lms_enrollment.py
@@ -1,10 +1,34 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
-
 import unittest
 
 import frappe
 
+from lms.lms.test_helpers import BaseTestUtils
 
-class TestLMSEnrollment(unittest.TestCase):
-	pass
+
+class TestLMSEnrollment(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		hash = frappe.generate_hash(length=6)
+		self.instructor = self._create_user(
+			f"instr-{hash}@example.com", "Instr", "Test", ["Course Creator", "Moderator"]
+		)
+		self.course = self._create_course(title=f"Test Course {hash}", instructor=self.instructor.email)
+		self.student = self._create_user(f"student-{hash}@example.com", "Student", "Test", ["LMS Student"])
+
+	def test_enrollment_count_increments_on_insert(self):
+		initial = frappe.db.get_value("LMS Course", self.course.name, "enrollments") or 0
+		self._create_enrollment(self.student.email, self.course.name)
+		after = frappe.db.get_value("LMS Course", self.course.name, "enrollments")
+		self.assertEqual(after, initial + 1)
+
+	def test_enrollment_count_decrements_on_delete(self):
+		enrollment = self._create_enrollment(self.student.email, self.course.name)
+		after_insert = frappe.db.get_value("LMS Course", self.course.name, "enrollments")
+		frappe.delete_doc("LMS Enrollment", enrollment.name, force=True)
+		self.cleanup_items = [
+			item for item in self.cleanup_items if item != ("LMS Enrollment", enrollment.name)
+		]
+		after_delete = frappe.db.get_value("LMS Course", self.course.name, "enrollments")
+		self.assertEqual(after_delete, after_insert - 1)


### PR DESCRIPTION
fixes #2430 
- Move enrollment count update out of `on_update` into `after_insert` and `after_delete` hooks so it only fires when a row is actually created or deleted
- Use `after_delete` instead of `on_trash` so the count is recalculated after the row is removed from the database
- Use atomic SQL `UPDATE ... SET enrollments = enrollments + %s` to avoid race conditions on concurrent enrollments
- Move helper `_update_course_enrollments` into `lms_enrollment.py` as an internal function