### PR TITLE
fix(profile): treat an unset profile field as empty, not as a change

### DIFF
--- a/frontend/src/pages/Forms/ProfileEditForm.vue
+++ b/frontend/src/pages/Forms/ProfileEditForm.vue
@@ -131,6 +131,7 @@ const profile = reactive({
 	first_name: '',
 	last_name: '',
 	headline: '',
+	language: '',
 	bio: '',
 	image: '',
 	open_to: '',
@@ -139,10 +140,11 @@ const profile = reactive({
 	twitter: '',
 })
 
-// Normalised to '' on both sides: `language` is nullable on User, so an unset
-// language would otherwise read as a change on every save.
+// Every key above is a User fieldname except `image`, which edits `user_image`.
+const serverField = (key) => (key === 'image' ? 'user_image' : key)
+
 const hasLanguageChanged = computed(
-	() => (profile.language ?? '') !== (profileData.value?.language ?? '')
+	() => profile.language !== (profileData.value?.language ?? '')
 )
 
 const updateProfile = createResource({
@@ -210,17 +212,12 @@ const saveProfile = () => {
 
 watch(
 	profile,
-	(newVal) => {
+	() => {
 		const data = profileData.value
 		if (!data) return
-		const keys = Object.keys(newVal).filter((key) => key !== 'image')
-		for (const key of keys) {
-			if (newVal[key] !== data[key]) {
-				isDirty.value = true
-				return
-			}
-		}
-		isDirty.value = profile.image !== data.user_image
+		isDirty.value = Object.keys(profile).some(
+			(key) => profile[key] !== (data[serverField(key)] ?? '')
+		)
 	},
 	{ deep: true }
 )
@@ -232,16 +229,9 @@ watch(
 	profileData,
 	(data) => {
 		if (!data) return
-		profile.first_name = data.first_name
-		profile.last_name = data.last_name
-		profile.headline = data.headline
-		profile.language = data.language
-		profile.bio = data.bio
-		profile.open_to = data.open_to
-		profile.linkedin = data.linkedin
-		profile.github = data.github
-		profile.twitter = data.twitter
-		profile.image = data.user_image
+		for (const key of Object.keys(profile)) {
+			profile[key] = data[serverField(key)] ?? ''
+		}
 		isDirty.value = false
 	},
 	{ immediate: true }

--- a/frontend/src/pages/Forms/ProfileEditForm.vue
+++ b/frontend/src/pages/Forms/ProfileEditForm.vue
@@ -38,7 +38,7 @@
 					<FormControl
 						v-model="profile.open_to"
 						type="select"
-						:options="[' ', 'Work', 'Hiring']"
+						:options="[{ label: '', value: '' }, 'Work', 'Hiring']"
 						:label="__('Open to')"
 						:placeholder="__('Looking for new work or hiring talent?')"
 					/>

--- a/frontend/src/tests/profileEditRoute.test.ts
+++ b/frontend/src/tests/profileEditRoute.test.ts
@@ -44,10 +44,12 @@ vi.mock('frappe-ui', () => ({
 		inheritAttrs: false,
 		template: `<button v-bind="$attrs"><slot name="icon" /><slot /></button>`,
 	},
+	// Emits for real: clearing a field is the only way to reach the form's
+	// empty-vs-null comparison. `data-label` lets a test address one field.
 	FormControl: {
 		props: ['modelValue', 'label', 'type', 'required'],
 		emits: ['update:modelValue'],
-		template: `<label>{{ label }}<input :value="modelValue" /></label>`,
+		template: `<label>{{ label }}<input :data-label="label" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" /></label>`,
 	},
 	Badge: passthrough,
 	TabButtons: passthrough,
@@ -134,14 +136,22 @@ describe('the profile edit route', () => {
 			writable: true,
 			configurable: true,
 		})
+		// get_profile_details is a bare frappe.db.get_value, so a field the user
+		// never filled in arrives as null, not ''. `headline: ''` is the third
+		// case: what a field holds after one save through this form.
 		profileResource.data = {
 			name: 'john@example.com',
 			username: USERNAME,
 			first_name: 'John',
 			last_name: 'Doe',
 			user_image: '/files/john.png',
-			headline: 'Learner',
+			headline: '',
+			bio: null,
 			language: 'en',
+			open_to: '',
+			linkedin: null,
+			github: null,
+			twitter: null,
 		}
 		profileResource.reload.mockClear()
 	})

--- a/frontend/src/tests/profileEditRoute.test.ts
+++ b/frontend/src/tests/profileEditRoute.test.ts
@@ -278,4 +278,39 @@ describe('the profile edit route', () => {
 
 		expect(router.currentRoute.value.name).toBe('ProfileAbout')
 	})
+
+	// Guards the seeding loop: it walks the draft's keys, so a key it misses is
+	// silently left blank rather than failing loudly.
+	it('seeds every field from the profile it was handed', async () => {
+		const router = makeRouter()
+		await router.push(`/user/${USERNAME}/edit`)
+		const wrapper = mountForm(router, USERNAME)
+		await flushPromises()
+
+		const valueOf = (label: string) =>
+			(wrapper.find(`input[data-label="${label}"]`).element as HTMLInputElement)
+				.value
+
+		expect(valueOf('First Name')).toBe('John')
+		expect(valueOf('Last Name')).toBe('Doe')
+		expect(valueOf('LinkedIn ID')).toBe('')
+		expect(wrapper.text()).not.toContain('Not Saved')
+	})
+
+	// An unfilled field arrives as null, an input can only return '', so clearing
+	// one used to latch "Not Saved" with no way off it but saving.
+	it('stays pristine when a null-backed field is cleared', async () => {
+		const router = makeRouter()
+		await router.push(`/user/${USERNAME}/edit`)
+		const wrapper = mountForm(router, USERNAME)
+		await flushPromises()
+
+		const linkedin = wrapper.find('input[data-label="LinkedIn ID"]')
+		await linkedin.setValue('a')
+		expect(wrapper.text()).toContain('Not Saved')
+
+		await linkedin.setValue('')
+		await flushPromises()
+		expect(wrapper.text()).not.toContain('Not Saved')
+	})
 })

--- a/frontend/src/tests/profileEditRoute.test.ts
+++ b/frontend/src/tests/profileEditRoute.test.ts
@@ -317,6 +317,29 @@ describe('the profile edit route', () => {
 		])
 	})
 
+	// The blank is only worth offering if choosing it lands back where the field
+	// started. Read off the option rather than written as '' so the value the row
+	// carries and the value the dirty-check accepts cannot drift apart. Driven
+	// through the control's v-model, not an input event: a select has no keystroke.
+	it('returns to pristine when Open to goes back to blank', async () => {
+		const router = makeRouter()
+		await router.push(`/user/${USERNAME}/edit`)
+		const wrapper = mountForm(router, USERNAME)
+		await flushPromises()
+
+		const openTo = wrapper
+			.findAllComponents({ name: 'FormControl' })
+			.find((control) => control.props('label') === 'Open to')
+
+		await openTo?.setValue('Work')
+		expect(wrapper.text()).toContain('Not Saved')
+
+		const blank = (openTo?.props('options') as { value: string }[])[0].value
+		await openTo?.setValue(blank)
+		await flushPromises()
+		expect(wrapper.text()).not.toContain('Not Saved')
+	})
+
 	// An unfilled field arrives as null, an input can only return '', so clearing
 	// one used to latch "Not Saved" with no way off it but saving.
 	it('stays pristine when a null-backed field is cleared', async () => {

--- a/frontend/src/tests/profileEditRoute.test.ts
+++ b/frontend/src/tests/profileEditRoute.test.ts
@@ -47,7 +47,8 @@ vi.mock('frappe-ui', () => ({
 	// Emits for real: clearing a field is the only way to reach the form's
 	// empty-vs-null comparison. `data-label` lets a test address one field.
 	FormControl: {
-		props: ['modelValue', 'label', 'type', 'required'],
+		name: 'FormControl',
+		props: ['modelValue', 'label', 'type', 'required', 'options'],
 		emits: ['update:modelValue'],
 		template: `<label>{{ label }}<input :data-label="label" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" /></label>`,
 	},
@@ -295,6 +296,25 @@ describe('the profile edit route', () => {
 		expect(valueOf('Last Name')).toBe('Doe')
 		expect(valueOf('LinkedIn ID')).toBe('')
 		expect(wrapper.text()).not.toContain('Not Saved')
+	})
+
+	// '' is the only empty the field's options accept, in object form because
+	// Select drops a falsy option and the blank row would vanish with it.
+	it('offers the Open to blank as the value the field allows', async () => {
+		const router = makeRouter()
+		await router.push(`/user/${USERNAME}/edit`)
+		const wrapper = mountForm(router, USERNAME)
+		await flushPromises()
+
+		const openTo = wrapper
+			.findAllComponents({ name: 'FormControl' })
+			.find((control) => control.props('label') === 'Open to')
+
+		expect(openTo?.props('options')).toEqual([
+			{ label: '', value: '' },
+			'Work',
+			'Hiring',
+		])
 	})
 
 	// An unfilled field arrives as null, an input can only return '', so clearing


### PR DESCRIPTION
Clearing a profile field that was never filled in latches the "Not Saved" badge on, and the only way off it is to save.


https://github.com/user-attachments/assets/ba2e4da7-dfbe-4c8c-a6f9-b746bd2695cf


### What happens

1. Open `/lms/user/<username>/edit`. No badge — the form is clean.
2. Type a character into **Headline** (or LinkedIn / GitHub / Twitter). The badge appears, correctly.
3. Delete it. The field is empty again, exactly as it loaded — **and the badge stays.**

Nothing clears it. Tabbing away, clearing other fields, re-typing and re-clearing: the form insists there is unsaved work when nothing has changed. The user's only exit is to press Save and write to their own record to make a false warning go away.

Choosing the blank row in **Open to** latches it the same way, and additionally posts a value the server never stores.

### Why

`get_profile_details` reads its columns with a bare `frappe.db.get_value`, so a field the user has never filled in comes back as `null`. A DOM input's value is a `DOMString` and can only ever come back as `''`. The draft held one and the dirty-check compared it against the other, so `'' !== null` and the form was permanently dirty.

The bug is self-concealing, which is probably why it has survived: saving writes `''` into that column, so the field never reproduces again for that user. But `null` is the state of most optional profile fields on a live site, and **every newly registered user has all of them** — so this is what a new user meets the first time they open the form, on every field they touch.

`Open to` is a separate instance of the same mismatch: the blank option's value was a literal space, but the `open_to` custom field's options are `"\nWork\nHiring"`, so the only empty it accepts is `''`. Selecting blank left the draft holding `' '`, which never matched the server copy. Saving posted `' '`, and Frappe's `_validate_selects` strips it back to `''` on the way in — leaving the client holding a value that was never stored.

### The fix

Seeding normalises `null` to `''` on the way in, and the dirty-check normalises the server side to match, so both sides speak one empty.

The two halves have to move together. Normalising only the seed leaves an `''` draft against a `null` server copy, and whether the badge shows up on load then depends on which of the two watchers Vue happens to flush first.

Two smaller things fall out of it:

- `language` joins the draft's declared shape. It was bound, compared and assigned, but never declared.
- `serverField` names the one key whose fieldname differs (`image` → `user_image`), so seeding and comparing share a single mapping instead of two copies that can drift.

For `Open to`, the blank option has to be the object form. `Select`'s `normalizeOption` rejects falsy options in order to skip holes in the array, so a bare `''` string is dropped and the blank row disappears entirely. `{ label: '', value: '' }` clears that guard, gets a synthetic internal value because Reka reserves `''` for "no selection", and renders as the placeholder since both its label and value are blank.

### Tests

`frontend/src/tests/profileEditRoute.test.ts`:

- The fixture now matches what the API actually returns. It previously set one field and omitted the rest, leaving them `undefined` — a user shape the database cannot produce. All three real cases are covered: `null` (never filled in), `''` (saved once through this form), and a filled value.
- The `FormControl` stub now emits on input. It declared `update:modelValue` and never fired it, so no test could clear a field — which is the only way to reach the comparison at all.
- Three new cases: every field seeds from the profile handed in; a null-backed field that is cleared stays pristine; `Open to` offers the blank the field's options actually allow.

Verified red against the unfixed component before the fix landed. Full suite green: 1426 tests, 148 files.
