### PR TITLE
fix: assign the course owner as instructor in memory

### DIFF
--- a/lms/lms/doctype/lms_course/lms_course.py
+++ b/lms/lms/doctype/lms_course/lms_course.py
@@ -40,15 +40,7 @@ class LMSCourse(Document):
 
 	def validate_instructors(self):
 		if self.is_new() and not self.instructors:
-			frappe.get_doc(
-				{
-					"doctype": "Course Instructor",
-					"instructor": self.owner,
-					"parent": self.name,
-					"parentfield": "instructors",
-					"parenttype": "LMS Course",
-				}
-			).save(ignore_permissions=True)
+			self.append("instructors", {"instructor": self.owner})
 
 	def validate_video_link(self):
 		# Store video_link exactly as entered: a YouTube/Vimeo link or an uploaded

--- a/lms/lms/doctype/lms_course/test_lms_course.py
+++ b/lms/lms/doctype/lms_course/test_lms_course.py
@@ -22,6 +22,29 @@ class TestLMSCourse(BaseTestUtils):
 		self.assertEqual(course.title, course_name)
 		self.assertTrue(frappe.db.exists("LMS Course", course.name))
 
+	def test_course_without_instructors_is_assigned_its_owner(self):
+		# `instructors` is mandatory on LMS Course and validate_instructors() is
+		# meant to fill it in with the owner when none is given. Every other test
+		# here supplies instructors explicitly (BaseTestUtils._create_course does),
+		# so this path had no coverage — and it is the path the course ZIP importer
+		# takes, since create_course_doc() only appends what the archive declares.
+		course = frappe.new_doc("LMS Course")
+		course.update(
+			{
+				"title": f"Test Course {frappe.generate_hash()}",
+				"short_introduction": "Created without an instructor",
+				"description": "The owner must be assigned as instructor automatically.",
+			}
+		)
+		course.insert(ignore_permissions=True)
+		self.cleanup_items.append(("LMS Course", course.name))
+
+		self.assertEqual([row.instructor for row in course.instructors], [course.owner])
+
+		# and it must be persisted, not only present on the in-memory document
+		course.reload()
+		self.assertEqual([row.instructor for row in course.instructors], [course.owner])
+
 	def test_video_link_stored_as_entered(self):
 		course = self._create_course(f"Test Course {frappe.generate_hash()}")
 


### PR DESCRIPTION
### Problem

Any `LMS Course` inserted without an explicit instructor fails:

```
frappe.exceptions.MandatoryError: [LMS Course, <name>]: instructors
"Error: Data missing in table Instructors"
```

The course ZIP importer is the common way in — `create_course_doc()` only appends the instructors the archive's `course.json` declares, so importing an archive that declares none always fails. That is what surfaced it for us: "Import Course from ZIP" never completed.

### Root cause

`instructors` is a mandatory Table MultiSelect on `LMS Course`, and `validate_instructors()` is meant to fill it in with the owner when a course is created without one. It did so by inserting a **detached** `Course Instructor` child row straight into the database (`parent=self.name`) instead of appending to the in-memory child table:

```python
def validate_instructors(self):
    if self.is_new() and not self.instructors:
        frappe.get_doc({
            "doctype": "Course Instructor",
            "instructor": self.owner,
            "parent": self.name,
            ...
        }).save(ignore_permissions=True)
```

`Document.insert()` runs `run_before_save_methods()` before `_validate()`, so by the time `_validate_mandatory()` looks at `self.instructors` the list is still empty — `self.get(df.fieldname) in (None, [])` — and the insert aborts. The detached row then rolls back with the transaction, so the auto-assign never takes effect at all.

### Fix

Append to the child table and let the parent's normal insert flow write the row, which satisfies the mandatory check:

```python
def validate_instructors(self):
    if self.is_new() and not self.instructors:
        self.append("instructors", {"instructor": self.owner})
```

Explicit instructors are untouched — the branch is guarded by `not self.instructors` — and the `is_new()` guard keeps later saves from re-adding a row.

### Why it went unnoticed

The path has no coverage: `BaseTestUtils._create_course` always supplies `"instructors": [{"instructor": instructor}]`, so every existing test takes the other branch. This PR adds a regression test that creates a course without instructors and asserts the owner is assigned **and persisted** (`reload()`), not merely present on the in-memory document.

### Verification

- The regression test fails on `develop` (the insert raises `MandatoryError`) and passes with the fix.
- Checked end to end on a stand (lms v2.58.1 / frappe v16): before the change, importing a course archive whose `course.json` has `"instructors": []` returns HTTP 417 `MandatoryError`; after it, HTTP 200 and the course is complete — 4 chapters, 10 lessons, 25 linked quiz questions, owner listed as instructor.
- Re-saving an existing course does not add a duplicate row, and a course created with an explicit instructor keeps it.

The code is identical on `develop` and v2.58.1.
