### PR TITLE
fix: show the server's message when a course import fails

### DIFF
--- a/frontend/src/pages/Forms/CourseImportForm.vue
+++ b/frontend/src/pages/Forms/CourseImportForm.vue
@@ -103,6 +103,7 @@ import { useFormRoute } from '@/composables/useFormRoute'
 // as composables/useKeyboardShortcuts.ts:3. Without this the import raises a
 // fresh TS7016 and pushes vue-tsc past its baseline.
 import { canCreateCourse } from '@/utils'
+import { resourceErrorMessage } from '@/utils/resource'
 
 const fileInput = ref<HTMLInputElement | null>(null)
 const zip = ref<any | null>(null)
@@ -210,8 +211,17 @@ const importZip = () => {
 			// server's own messages in error.messages. Reporting the former shows
 			// "...import_course_from_zip ValidationError" and hides the reason the
 			// archive was rejected, which is the only actionable part.
+			//
+			// Via resourceErrorMessage rather than messages[0] directly: call()
+			// never leaves `messages` empty — with nothing from the server it
+			// substitutes the untranslated "Internal Server Error" — so a plain
+			// nullish check would treat that placeholder as a real message and
+			// make this fallback unreachable.
 			toast.error(
-				error.messages?.[0] ?? __('Error importing course') + ': ' + error.message
+				resourceErrorMessage(
+					error,
+					__('Error importing course') + ': ' + error.message
+				)
 			)
 			console.error('Error importing course:', error)
 		})

--- a/frontend/src/pages/Forms/CourseImportForm.vue
+++ b/frontend/src/pages/Forms/CourseImportForm.vue
@@ -206,7 +206,13 @@ const importZip = () => {
 			})
 		})
 		.catch((error: any) => {
-			toast.error('Error importing course: ' + error.message)
+			// call() builds error.message as "<method> <exc_type>" and puts the
+			// server's own messages in error.messages. Reporting the former shows
+			// "...import_course_from_zip ValidationError" and hides the reason the
+			// archive was rejected, which is the only actionable part.
+			toast.error(
+				error.messages?.[0] ?? __('Error importing course') + ': ' + error.message
+			)
 			console.error('Error importing course:', error)
 		})
 }

--- a/frontend/src/tests/courseImportForm.test.ts
+++ b/frontend/src/tests/courseImportForm.test.ts
@@ -216,15 +216,20 @@ describe('CourseImportForm as a route', () => {
 		)
 	})
 
-	it('reports the server message when the import is rejected', async () => {
-		// call() throws an Error whose message is "<method> <exc_type>" and carries
-		// the server's own messages separately. Reporting the message alone told the
-		// user "...import_course_from_zip ValidationError" and dropped the reason.
-		const error: Error & { messages?: string[] } = new Error(
-			'lms.lms.api.import_course_from_zip ValidationError'
+	// Both cases build the error the way call() does: `message` is
+	// "<method> <exc_type>" and the server's own text lives in `messages` — which
+	// call() never leaves empty, substituting 'Internal Server Error' when the
+	// response carried nothing.
+	const importError = (messages: string[]) => {
+		const error: Error & { messages: string[] } = Object.assign(
+			new Error('lms.lms.api.import_course_from_zip ValidationError'),
+			{ messages }
 		)
-		error.messages = ['Invalid course ZIP: Missing course.json']
-		callMock.mockRejectedValue(error)
+		return error
+	}
+
+	const rejectImportWith = async (messages: string[]) => {
+		callMock.mockRejectedValue(importError(messages))
 		const router = makeRouter()
 		await router.push({ name: 'CourseImport' })
 		const wrapper = await mountForm(router)
@@ -232,21 +237,24 @@ describe('CourseImportForm as a route', () => {
 		await attachZip(wrapper)
 		await wrapper.find('[data-testid="course-import-submit"]').trigger('click')
 		await flushPromises()
+	}
+
+	it('reports the server message when the import is rejected', async () => {
+		// Reporting error.message alone told the user
+		// "...import_course_from_zip ValidationError" and dropped the reason.
+		await rejectImportWith(['Invalid course ZIP: Missing course.json'])
 
 		expect(toast.error).toHaveBeenCalledWith('Invalid course ZIP: Missing course.json')
 	})
 
 	it('falls back to the raw error when the server sent no message', async () => {
-		callMock.mockRejectedValue(new Error('boom'))
-		const router = makeRouter()
-		await router.push({ name: 'CourseImport' })
-		const wrapper = await mountForm(router)
+		// call()'s placeholder is not a message anyone can act on, so it must not
+		// win over the fallback — which still names the method and exception.
+		await rejectImportWith(['Internal Server Error'])
 
-		await attachZip(wrapper)
-		await wrapper.find('[data-testid="course-import-submit"]').trigger('click')
-		await flushPromises()
-
-		expect(toast.error).toHaveBeenCalledWith('Error importing course: boom')
+		expect(toast.error).toHaveBeenCalledWith(
+			'Error importing course: lms.lms.api.import_course_from_zip ValidationError'
+		)
 	})
 
 	it('replaces rather than pushes on import, so Back reaches the list', async () => {

--- a/frontend/src/tests/courseImportForm.test.ts
+++ b/frontend/src/tests/courseImportForm.test.ts
@@ -7,6 +7,7 @@ import {
 	type Router,
 } from 'vue-router'
 import { defineComponent, h } from 'vue'
+import { toast } from 'frappe-ui'
 
 vi.stubGlobal('__', (text: string) => text)
 enableAutoUnmount(afterEach)
@@ -148,6 +149,7 @@ describe('CourseImportForm as a route', () => {
 	beforeEach(() => {
 		callMock.mockReset()
 		uploadMock.mockReset()
+		vi.mocked(toast.error).mockClear()
 		uploadMock.mockResolvedValue({
 			file_url: '/files/course.zip',
 			file_name: 'course.zip',
@@ -212,6 +214,39 @@ describe('CourseImportForm as a route', () => {
 				zip_file_path: '/files/course.zip',
 			}
 		)
+	})
+
+	it('reports the server message when the import is rejected', async () => {
+		// call() throws an Error whose message is "<method> <exc_type>" and carries
+		// the server's own messages separately. Reporting the message alone told the
+		// user "...import_course_from_zip ValidationError" and dropped the reason.
+		const error: Error & { messages?: string[] } = new Error(
+			'lms.lms.api.import_course_from_zip ValidationError'
+		)
+		error.messages = ['Invalid course ZIP: Missing course.json']
+		callMock.mockRejectedValue(error)
+		const router = makeRouter()
+		await router.push({ name: 'CourseImport' })
+		const wrapper = await mountForm(router)
+
+		await attachZip(wrapper)
+		await wrapper.find('[data-testid="course-import-submit"]').trigger('click')
+		await flushPromises()
+
+		expect(toast.error).toHaveBeenCalledWith('Invalid course ZIP: Missing course.json')
+	})
+
+	it('falls back to the raw error when the server sent no message', async () => {
+		callMock.mockRejectedValue(new Error('boom'))
+		const router = makeRouter()
+		await router.push({ name: 'CourseImport' })
+		const wrapper = await mountForm(router)
+
+		await attachZip(wrapper)
+		await wrapper.find('[data-testid="course-import-submit"]').trigger('click')
+		await flushPromises()
+
+		expect(toast.error).toHaveBeenCalledWith('Error importing course: boom')
 	})
 
 	it('replaces rather than pushes on import, so Back reaches the list', async () => {


### PR DESCRIPTION
### Problem

When a course import is rejected, the toast shows the exception class and drops the reason:

```
Error importing course: lms.lms.api.import_course_from_zip ValidationError
```

`call()` builds the thrown `Error` with `message = "<method> <exc_type>"` and puts the server's own messages in `error.messages`. `CourseImportForm.vue` reports `error.message`, so every reason the importer can give is invisible:

- `Invalid ZIP file`
- `Invalid course ZIP: Missing course.json`
- `Minimum two options are required for multiple choice questions.`
- `Invalid Quiz ID in content`
- the mandatory-field list

All of these are actionable — they tell the author what to fix in the archive — and none of them reach the user. Diagnosing a failed import currently means reading the server log or the raw response.

### Fix

Report `messages[0]` when the server sent one, and fall back to the previous text otherwise:

```js
toast.error(
    error.messages?.[0] ?? __('Error importing course') + ': ' + error.message
)
```

### Tests

Two cases added to `frontend/src/tests/courseImportForm.test.ts`:

- the server's message is what reaches `toast.error` when `messages` is present;
- the previous text is still used when it is not, so the fallback cannot be dropped silently.

```
$ vitest run src/tests/courseImportForm.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Reverting only the source change fails exactly the first of the two:

```
× reports the server message when the import is rejected
Tests  1 failed | 9 passed (10)
```

### Note

This is what made frappe/lms#2688 hard to find — the underlying `MandatoryError` was never shown, only the exception class. The two changes are independent; either can land alone.
