### PR TITLE
fix(signup): keep the signup form independent of frappe develop

### DIFF
--- a/lms/templates/signup-form.html
+++ b/lms/templates/signup-form.html
@@ -1,4 +1,14 @@
-{% from "templates/includes/login/macros.html" import alert_banner %}
+{%- macro alert_banner(type, text="") -%}
+{%- set is_error = type == "error" -%}
+<div class="login-{{ type }}-banner es-alert hidden" role="alert" data-theme="{{ 'red' if is_error else 'green' }}">
+    <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <use href="#icon-{{ 'circle-alert' if is_error else 'circle-check' }}"></use>
+    </svg>
+    <div class="es-alert__content">
+        <span class="es-alert__title">{{ text }}</span>
+    </div>
+</div>
+{%- endmacro -%}
 {% set custom_signup_content = frappe.db.get_single_value("LMS Settings", "custom_signup_content") %}
 {% set user_category = frappe.db.get_single_value("LMS Settings", "user_category") %}
 {% set login_link = '<a href="#login">' ~ _("Login") ~ '</a>' %}
@@ -207,16 +217,24 @@
                 const section = $("section:visible");
 
                 if (cint(code) === 0) {
-                    login.hide_loading();
+                    hide_signup_loading();
                     section.find(".login-success-banner").addClass("hidden");
                     show_signup_error(message);
                 } else {
                     login.set_status({{ _("Success") | tojson }}, "green");
                     section.find(".login-error-banner").addClass("hidden");
-                    login.show_success_banner(message);
+                    show_signup_success(message);
                 }
             }
         });
+    }
+
+    const hide_signup_loading = () => {
+        $(".signup-form .btn-signup").removeAttr("aria-busy").text(signup_button_label);
+    }
+
+    const show_signup_success = (message) => {
+        $("section:visible .login-success-banner").removeClass("hidden").find(".es-alert__title").text(message);
     }
 
     const show_signup_error = (message) => {

--- a/lms/tests/test_signup_form.py
+++ b/lms/tests/test_signup_form.py
@@ -1,16 +1,22 @@
 # Copyright (c) 2021, FOSS United and Contributors
 # See license.txt
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import frappe
+from frappe import _
 from frappe.tests import UnitTestCase
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
+
+import lms
 
 SIGNUP_FORM = "lms/templates/signup-form.html"
 
 
 class TestSignupForm(UnitTestCase):
-	def render(self, **lms_settings):
+	def patched_settings(self, lms_settings):
 		original = frappe.db.get_single_value
 
 		def get_single_value(doctype, fieldname, *args, **kwargs):
@@ -18,8 +24,28 @@ class TestSignupForm(UnitTestCase):
 				return lms_settings.get(fieldname)
 			return original(doctype, fieldname, *args, **kwargs)
 
-		with patch.object(frappe.db, "get_single_value", side_effect=get_single_value):
+		return patch.object(frappe.db, "get_single_value", side_effect=get_single_value)
+
+	def render(self, **lms_settings):
+		with self.patched_settings(lms_settings):
 			return frappe.get_template(SIGNUP_FORM).render({})
+
+	def render_without_framework_templates(self, **lms_settings):
+		"""Render with only LMS's own templates on the loader path, the way a site
+		on a released frappe sees it."""
+		lms_package = os.path.dirname(lms.__file__)
+		env = Environment(
+			loader=ChoiceLoader(
+				[
+					PrefixLoader({"lms": FileSystemLoader(lms_package)}),
+					FileSystemLoader(lms_package),
+				]
+			)
+		)
+		env.globals.update(frappe=frappe, _=_)
+
+		with self.patched_settings(lms_settings):
+			return env.get_template(SIGNUP_FORM).render({})
 
 	def test_renders_the_result_banners(self):
 		html = self.render()
@@ -50,3 +76,15 @@ class TestSignupForm(UnitTestCase):
 		self.assertIn('id="signup-terms"', html)
 		self.assertIn("I agree to the terms", html)
 		self.assertIn("icon-chevrons-up-down", html)
+
+	def test_renders_without_the_frameworks_login_templates(self):
+		"""/login renders this template, so an include the running frappe does not
+		ship takes the whole login page down with a 500."""
+		html = self.render_without_framework_templates()
+		self.assertIn("login-error-banner", html)
+		self.assertIn("login-success-banner", html)
+
+	def test_does_not_call_login_helpers_missing_from_released_frappe(self):
+		source = Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
+		self.assertNotIn("login.show_success_banner", source)
+		self.assertNotIn("login.hide_loading", source)


### PR DESCRIPTION
The signup form imported `templates/includes/login/macros.html`, which only exists on frappe develop. frappe's /login renders this template through the `signup_form_template` hook, so on a released frappe the missing include raises TemplateNotFound and takes the whole login page down with a 500 for every logged-out visitor. Already logged-in users are unaffected, which is why it read as a login-only outage.

Define the banner macro locally, and replace `login.hide_loading` and `login.show_success_banner` (also develop-only) with local equivalents, so the form no longer depends on the frappe version the site runs. The rendered banner markup is unchanged on develop.