### PR TITLE
fix: show volume slider on lesson video player

### DIFF
--- a/frontend/src/components/Modals/VideoStatistics.vue
+++ b/frontend/src/components/Modals/VideoStatistics.vue
@@ -247,10 +247,6 @@ const tabs = computed(() => {
 })
 </script>
 <style>
-.plyr__volume input[type='range'] {
-	display: none;
-}
-
 .plyr__control--overlaid {
 	background: radial-gradient(
 		circle,

--- a/frontend/src/pages/Lesson.vue
+++ b/frontend/src/pages/Lesson.vue
@@ -1404,10 +1404,6 @@ usePageMeta(() => {
 	border-inline-start: 1px solid #e8e8eb;
 }
 
-.plyr__volume input[type='range'] {
-	display: none;
-}
-
 .plyr__control--overlaid {
 	background: radial-gradient(
 		circle,

--- a/frontend/src/styles/blockEditor.css
+++ b/frontend/src/styles/blockEditor.css
@@ -183,10 +183,6 @@ iframe {
 	display: none !important;
 }
 
-.plyr__volume input[type='range'] {
-	display: none;
-}
-
 .plyr__control--overlaid {
 	background: radial-gradient(
 		circle,


### PR DESCRIPTION
The volume-level slider was hidden on the lesson video player, leaving only a mute button, so this restores it on both embedded and uploaded videos.


<img width="1470" height="641" alt="image" src="https://github.com/user-attachments/assets/0eaa92f8-30af-4018-a98a-a88c7d697302" />
