### PR TITLE
fix: align sidebar icon spacing with CRM and Helpdesk

### DIFF
--- a/frontend/src/components/Sidebar/SidebarLink.vue
+++ b/frontend/src/components/Sidebar/SidebarLink.vue
@@ -18,7 +18,7 @@
 				:disabled="!isCollapsed"
 			>
 				<slot name="icon">
-					<span class="grid h-5 w-6 flex-shrink-0 place-items-center">
+					<span class="grid size-4 flex-shrink-0 place-items-center">
 						<component
 							:is="typeof link.icon === 'string' ? icons[link.icon] : link.icon"
 							class="h-4 w-4 stroke-1.5 text-ink-gray-8"


### PR DESCRIPTION
The sidebar icons used a wider box than the shared frappe-ui sidebar, so their spacing looked different from CRM and Helpdesk; this matches the standard icon size so the alignment is consistent across apps.