### PR TITLE
 Resolve attributeError in count_matching

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -952,9 +952,18 @@ def get_course_count(filters: dict = None) -> int:
 
 
 def count_matching(doctype: str, filters: dict | list, or_filters: dict = None) -> int:
-	"""Row count for filters that include or_filters, which db.count cannot take."""
-	query = frappe.get_all(doctype, filters=filters, or_filters=or_filters, fields=["name"], run=False)
-	return frappe.db.sql(f"SELECT COUNT(*) FROM ({query}) AS _total")[0][0]
+	"""Return row count for filters, including OR filters."""
+	if not or_filters:
+		return frappe.db.count(doctype, filters)
+	return len(
+		frappe.get_all(
+			doctype,
+			filters=filters,
+			or_filters=or_filters,
+			fields=["name"],
+			limit_page_length=0,
+		)
+	)
 
 
 def as_filter_conditions(filters: dict) -> list:

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -953,8 +953,8 @@ def get_course_count(filters: dict = None) -> int:
 
 def count_matching(doctype: str, filters: dict | list, or_filters: dict = None) -> int:
 	"""Row count for filters that include or_filters, which db.count cannot take."""
-	rows = frappe.get_all(doctype, filters=filters, or_filters=or_filters, fields=[{"COUNT": "*"}])
-	return cint(next(iter(rows[0].values()))) if rows else 0
+	query = frappe.get_all(doctype, filters=filters, or_filters=or_filters, fields=["name"], run=False)
+	return frappe.db.sql(f"SELECT COUNT(*) FROM ({query}) AS _total")[0][0]
 
 
 def as_filter_conditions(filters: dict) -> list:


### PR DESCRIPTION
When opening the Batches page, the footer was supposed to show 
how many batches match the current filters (like "8 of 24"). 
Instead it was throwing an error and nothing would load.

The issue was in how we were counting the batches behind the 
scenes. We were using an older way of doing it that no longer 
works with the current version of Frappe. 

Updated the count_matching function in utils.py to use a 
different approach that works correctly,  it now builds the 
filtered query first and runs a count on top of it, so the 
footer shows the right number every time without crashing.
