### PR TITLE
Improve text contrast in programming exercise submission

### DIFF
--- a/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
+++ b/frontend/src/pages/ProgrammingExercises/ProgrammingExerciseSubmission.vue
@@ -46,7 +46,6 @@
 						@click="submitCode"
 						:loading="running"
 						:disabled="running"
-						class="text-ink-gray-9"
 					>
 						<template #prefix>
 							<span class="lucide-play size-3" />
@@ -70,7 +69,7 @@
 						v-if="error"
 						v-model="errorMessage"
 						:aria-label="__('Compiler Message')"
-						class="font-mono text-ink-red-3 bg-surface-gray-1 border-none text-sm h-32 leading-6"
+						class="font-mono text-ink-red-6 bg-surface-gray-1 border-none text-sm h-32 leading-6"
 						readonly
 					/>
 				</div>


### PR DESCRIPTION
Two small visual fixes on the Programming Exercise Submission page.

**1. Run button** : removed a hardcoded gray text color that was 
overriding the button's default white label.

**2. Compiler error message** : the error text was too light to read 
comfortably. Increased the red shade so it stands out more clearly 
when something goes wrong.


### Before:
<img width="1913" height="862" alt="image" src="https://github.com/user-attachments/assets/86614de8-df01-4376-8cbe-6c73b553630a" />

<img width="1912" height="866" alt="image" src="https://github.com/user-attachments/assets/63e718a2-2e41-47bf-af19-9700d42c5b67" />

### After:
<img width="1915" height="860" alt="image" src="https://github.com/user-attachments/assets/facea39c-a3eb-4e6b-b84c-d360742f896f" />

<img width="1912" height="857" alt="image" src="https://github.com/user-attachments/assets/1f782fbe-227a-445c-9f21-4b04e790112f" />


