### PR TITLE
feat: embed PeerTube videos in lessons

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -250,6 +250,16 @@ export function getEditorTools(
 							window.innerWidth < 640 ? '15rem' : '30rem'
 						};" frameborder="0" allowfullscreen></iframe>`,
 					},
+					peertube: {
+						// Generic PeerTube support: any instance, watch URLs /w/<id> or /videos/watch/<id>.
+						// The embed is built on the same host, so no third-party domain is introduced.
+						regex: /^https:\/\/([a-z0-9.-]+)\/(?:w|videos\/watch)\/([a-zA-Z0-9-]+)(?:\?[^\s]*)?$/,
+						embedUrl: 'https://<%= remote_id %>',
+						html: `<iframe style="width:100%; height: ${
+							window.innerWidth < 640 ? '15rem' : '30rem'
+						};" frameborder="0" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>`,
+						id: ([host, id]) => `${host}/videos/embed/${id}?title=0&warningTitle=0&peertubeLink=0`,
+					},
 					codepen: true,
 					aparat: {
 						regex: /^(?:http[s]?:\/\/)?(?:www.)?aparat\.com\/v\/([^\/\?\&]+)\/?$/,


### PR DESCRIPTION
## What

Adds a `peertube` service to the lesson editor's embed tool (`frontend/src/utils/index.js`), next to YouTube, Vimeo, Cloudflare Stream and Bunny Stream.

Pasting a watch URL of any PeerTube instance

- `https://<host>/w/<shortId>` or
- `https://<host>/videos/watch/<uuid>`

renders the instance's own player via `https://<host>/videos/embed/<id>?title=0&warningTitle=0&peertubeLink=0` (same host as the pasted URL, so no third-party domain is introduced). Same iframe height/sandbox handling as the existing services; the read-only lesson view uses the same tool config, so playback works for learners.

## Why

Teams that keep training videos on a self-hosted PeerTube server (adaptive HLS, private/unlisted videos, no external platform) currently cannot embed them in lessons. The only alternative is uploading the file, which is a progressive download without streaming (see docs: "Video Integration").

## Tested

- Frappe 16.33 / LMS develop (`0cd844e`), self-hosted PeerTube 8.2.4 (unlisted video): lesson shows the PeerTube iframe in edit and learner view, playback works (HLS).
- Existing services unchanged.

## Notes

If maintainers prefer an allow-list of hosts instead of the generic host match, I am happy to adapt (e.g. a setting in LMS Settings).