### PR TITLE
fix(settings): link self-hosted sites to the Payments repo, not the marketplace

### DIFF
--- a/lms/lms/doctype/lms_settings/lms_settings.js
+++ b/lms/lms/doctype/lms_settings/lms_settings.js
@@ -17,10 +17,15 @@ frappe.ui.form.on("LMS Settings", {
 	},
 
 	set_no_payments_app_html(frm) {
+		// The marketplace can only install into a Frappe Cloud site; a self-hosted
+		// admin following that link has no way to act on it. Point them at the repo.
+		const install_url = frappe.boot.is_fc_site
+			? "https://frappecloud.com/marketplace/apps/payments"
+			: "https://github.com/frappe/payments";
 		frm.get_field("payments_app_is_not_installed").html(`
 				<div class="alert alert-warning">
 					Please install the
-					<a target="_blank" style="text-decoration: underline; color: var(--alert-text-warning); background: var(--alert-bg-warning);" href="https://frappecloud.com/marketplace/apps/payments">Payments app</a>
+					<a target="_blank" style="text-decoration: underline; color: var(--alert-text-warning); background: var(--alert-bg-warning);" href="${install_url}">Payments app</a>
 					 to enable payment gateway. Refer to the
 					 <a target="_blank" style="text-decoration: underline; color: var(--alert-text-warning); background: var(--alert-bg-warning);" href="https://docs.frappe.io/learning/setting-up-payment-gateway">Documentation</a>
 					 for more information.


### PR DESCRIPTION
In **LMS Settings**, the warning shown when the Payments app is missing always links to the Frappe Cloud marketplace:

```
https://frappecloud.com/marketplace/apps/payments
```

The marketplace can only install into a Frappe Cloud site, so a self-hosted admin who follows that link lands on a page they can't act on — while the alert is telling them to install the app.

This keeps the existing link on Frappe Cloud (`frappe.boot.is_fc_site`) and points everyone else at `github.com/frappe/payments`, which is installable on any deployment. The documentation link is unchanged.

One file, six lines.