### PR TITLE
fix(lms): deduplicate course filters for created and enrolled courses

### DIFF
--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1025,14 +1025,14 @@ def update_course_filters(filters: dict) -> tuple:
 
 	if filters.get("enrolled"):
 		enrolled_courses = frappe.get_all("LMS Enrollment", {"member": frappe.session.user}, pluck="course")
-		filters.update({"name": ["in", enrolled_courses]})
+		filters.update({"name": ["in", list(set(enrolled_courses))]})
 		del filters["enrolled"]
 
 	if filters.get("created"):
 		created_courses = frappe.get_all(
 			"Course Instructor", {"instructor": frappe.session.user}, pluck="parent"
 		)
-		filters.update({"name": ["in", created_courses]})
+		filters.update({"name": ["in", list(set(created_courses))]})
 		del filters["created"]
 
 	if filters.get("live"):

--- a/lms/tests/test_utils.py
+++ b/lms/tests/test_utils.py
@@ -518,6 +518,12 @@ class TestListEndpointPaging(BaseTestUtils):
 	def test_the_count_includes_the_featured_courses(self):
 		self.assertEqual(get_course_count(filters=self._filters()), 4)
 
+	def test_created_courses_filter_deduplication(self):
+		"""Ensure multiple instructor entries for the same course return unique course entries."""
+		courses = get_courses(filters={"created": 1})
+		course_names = [c.name for c in courses]
+		self.assertEqual(len(course_names), len(set(course_names)))
+
 	def test_the_batch_count_agrees_with_the_batch_list(self):
 		filters = {"published": 1}
 		listed = get_batches(filters=filters.copy(), start=0, limit_page_length=MAX_PAGE_LENGTH)


### PR DESCRIPTION
Fixes #2476. Ensures created and enrolled course lists use unique course names when building the filter query to prevent duplicate course cards from rendering for instructors/moderators with multiple batch assignments.