### PR TITLE
fix: reveal the signup result banners on released frappe

### DIFF
--- a/lms/templates/signup-form.html
+++ b/lms/templates/signup-form.html
@@ -1,7 +1,7 @@
 {%- macro alert_banner(type, text="") -%}
 {%- set is_error = type == "error" -%}
 <div class="login-{{ type }}-banner es-alert hidden" role="alert" data-theme="{{ 'red' if is_error else 'green' }}">
-    <svg fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <svg width="16" height="16" style="fill: none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <use href="#icon-{{ 'circle-alert' if is_error else 'circle-check' }}"></use>
     </svg>
     <div class="es-alert__content">
@@ -233,8 +233,12 @@
         $(".signup-form .btn-signup").removeAttr("aria-busy").text(signup_button_label);
     }
 
+    const reveal_banner = (banner) => banner.css("display", "flex").removeClass("hidden");
+
     const show_signup_success = (message) => {
-        $("section:visible .login-success-banner").removeClass("hidden").find(".es-alert__title").text(message);
+        const banner = $("section:visible .login-success-banner");
+        banner.find(".es-alert__title").text(message);
+        reveal_banner(banner);
     }
 
     const show_signup_error = (message) => {
@@ -247,6 +251,6 @@
             title.text(message);
         }
 
-        banner.removeClass("hidden");
+        reveal_banner(banner);
     }
 </script>

--- a/lms/tests/test_signup_form.py
+++ b/lms/tests/test_signup_form.py
@@ -2,10 +2,12 @@
 # See license.txt
 
 import os
+import re
 from pathlib import Path
 from unittest.mock import patch
 
 import frappe
+from bs4 import BeautifulSoup
 from frappe import _
 from frappe.tests import UnitTestCase
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
@@ -13,6 +15,11 @@ from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PrefixLoader
 import lms
 
 SIGNUP_FORM = "lms/templates/signup-form.html"
+
+# The `login.*` helpers a released frappe actually ships. This template is rendered
+# into frappe's own login page, so it may lean on these and nothing else: #2691 was a
+# 500 on /login caused by reaching for one that exists only on develop.
+RELEASED_LOGIN_HELPERS = {"login_handlers", "set_status", "show_field_error"}
 
 
 class TestSignupForm(UnitTestCase):
@@ -46,6 +53,9 @@ class TestSignupForm(UnitTestCase):
 
 		with self.patched_settings(lms_settings):
 			return env.get_template(SIGNUP_FORM).render({})
+
+	def source(self):
+		return Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
 
 	def test_renders_the_result_banners(self):
 		html = self.render()
@@ -84,21 +94,34 @@ class TestSignupForm(UnitTestCase):
 		self.assertIn("login-error-banner", html)
 		self.assertIn("login-success-banner", html)
 
-	def test_does_not_call_login_helpers_missing_from_released_frappe(self):
-		source = Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
-		self.assertNotIn("login.show_success_banner", source)
-		self.assertNotIn("login.hide_loading", source)
+	def test_only_calls_login_helpers_released_frappe_ships(self):
+		"""An allowlist rather than a denylist, so a newly added `login.*` call has to
+		be checked against a released frappe before it can land."""
+		used = set(re.findall(r"\blogin\.(\w+)", self.source()))
+		self.assertEqual(used - RELEASED_LOGIN_HELPERS, set())
 
-	def test_reveals_banners_with_an_explicit_display(self):
-		"""Released frappe ships these banners as `display: none` and frappe's own
-		login.js re-hides them inline on every keystroke, so dropping the `hidden`
-		class is not enough to make one visible."""
-		source = Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
-		self.assertIn('css("display", "flex")', source)
+	def test_both_result_handlers_go_through_the_reveal_helper(self):
+		"""Released frappe ships these banners as `display: none`, and its own login.js
+		re-hides them inline on every keystroke, so dropping the `hidden` class is not
+		enough to make one visible. Nothing in python runs this script, so this pins the
+		wiring rather than the visibility it buys, which needs a released frappe in a
+		browser."""
+		source = self.source()
+		self.assertIn('const reveal_banner = (banner) => banner.css("display", "flex")', source)
 
-	def test_banner_icon_is_sized_and_unfilled_inline(self):
-		"""Released frappe's `.login-*-banner svg` rule sets a fill and no size; a
-		presentation attribute loses to it, which renders the stroked glyph as a blob."""
-		html = self.render_without_framework_templates()
-		self.assertIn('style="fill: none"', html)
-		self.assertIn('width="16" height="16"', html)
+		for handler in ("show_signup_success", "show_signup_error"):
+			body = source.split(f"const {handler} = ")[1].split("\n    }")[0]
+			self.assertIn("reveal_banner(banner)", body)
+
+	def test_banner_icons_carry_their_size_and_an_inline_fill(self):
+		"""Released frappe's `.login-*-banner svg` rule sets a fill and no size. A
+		`fill` presentation attribute loses to that rule, which paints the stroked
+		lucide glyph as a solid dot, and nothing anywhere sizes the icon."""
+		soup = BeautifulSoup(self.render_without_framework_templates(), "html.parser")
+		icons = soup.select(".login-error-banner svg, .login-success-banner svg")
+
+		self.assertEqual(len(icons), 2)
+		for icon in icons:
+			self.assertEqual((icon["width"], icon["height"]), ("16", "16"))
+			self.assertIsNone(icon.get("fill"))
+			self.assertIn("fill: none", icon["style"])

--- a/lms/tests/test_signup_form.py
+++ b/lms/tests/test_signup_form.py
@@ -88,3 +88,17 @@ class TestSignupForm(UnitTestCase):
 		source = Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
 		self.assertNotIn("login.show_success_banner", source)
 		self.assertNotIn("login.hide_loading", source)
+
+	def test_reveals_banners_with_an_explicit_display(self):
+		"""Released frappe ships these banners as `display: none` and frappe's own
+		login.js re-hides them inline on every keystroke, so dropping the `hidden`
+		class is not enough to make one visible."""
+		source = Path(os.path.dirname(lms.__file__), "templates", "signup-form.html").read_text()
+		self.assertIn('css("display", "flex")', source)
+
+	def test_banner_icon_is_sized_and_unfilled_inline(self):
+		"""Released frappe's `.login-*-banner svg` rule sets a fill and no size; a
+		presentation attribute loses to it, which renders the stroked glyph as a blob."""
+		html = self.render_without_framework_templates()
+		self.assertIn('style="fill: none"', html)
+		self.assertIn('width="16" height="16"', html)


### PR DESCRIPTION
### Problem

#2691 inlined the `alert_banner` macro so `/login` stops returning a 500 on a released frappe. That part works — but the banners it renders never become visible. Sign-up succeeds or fails and the user sees nothing: the message lands in the DOM, correctly, and stays invisible.

Two independent causes:

**1. Released frappe hides them by default.** `login.bundle.scss` styles `.login-error-banner` / `.login-success-banner` completely — padding, gap, background, radius, colour, svg fill — but sets `display: none`, expecting its own JS to flip it. LMS only removed the `hidden` class, which does not touch `display`.

**2. frappe's own JS re-hides them.** `login.js` binds a page-wide handler:

```js
$(".page-card-body input").on("input", function () {
    $(this).closest(".page-card-body").removeClass("invalid").find(".login-error-banner").hide();
});
```

The LMS form has its own `.page-card-body`, so it is caught by that selector. jQuery's `.hide()` writes an **inline** `display: none`, which outranks any stylesheet rule — so once the user has typed their email, no class toggle can reopen the banner.

### Fix

Reveal with `.css("display", "flex")` rather than a class toggle. This is what frappe's own `login.show_error_banner` does, and being inline it clears the stamped `display: none` and outranks the stylesheet in a single step — no specificity war, and no assumption about which frappe version is running.

The icon needed two smaller corrections:

- **`width="16" height="16"` attributes** — neither frappe version sizes the banner svg in CSS; released frappe's own login markup carries these same attributes.
- **`fill` moved from an attribute to an inline style** — frappe's `.login-*-banner svg { fill: var(--ink-red-4) }` overrides a presentation attribute, which fills in the stroked lucide glyph and renders the icon as a solid dot.

No CSS is added. Both frappe versions already style these banners (released via `login.bundle.scss`, develop via `es-alert`); the only thing neither supplies is `display`.

### Screenshots

**Error path — existing email**

<img width="744" height="982" alt="signup-error-banner" src="https://github.com/user-attachments/assets/19b77647-4dc0-43b7-84cb-8b305998a233" />


**Success path — new email**

<img width="744" height="1004" alt="signup-success-banner" src="https://github.com/user-attachments/assets/87916aff-b2cd-4c80-8340-f55bede6c087" />


### Tests

Two regression tests added to `lms/tests/test_signup_form.py`, pinning the two decisions a future cleanup would most plausibly undo — the explicit `display`, and the inline `fill` / sized icon.

Note that true visibility can only be asserted in a browser, and this repo has no guest-flow e2e harness (the cypress specs all assume a logged-in author). These tests guard the source-level decisions; the rendering itself was verified manually against a released frappe.

### Verification

Checked end to end against frappe v16 on a live site, driving the real form: both banners report `display: flex`, `isVisible: true`, correct text, and correctly rendered outline icons.
