### PR TITLE
feat(quiz): replace pager with wrapping question chips and add Previous

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -624,10 +624,7 @@
 				</div>
 			</div>
 
-			<div
-				v-if="!quiz.data.show_answers"
-				class="border rounded-lg p-4 mt-4"
-			>
+			<div v-if="!quiz.data.show_answers" class="border rounded-lg p-4 mt-4">
 				<div class="font-semibold">
 					{{ __('Questions') }}
 				</div>

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -641,7 +641,7 @@
 						@click="switchQuestion(index)"
 						class="w-6 h-6 rounded-full flex items-center justify-center text-sm cursor-pointer"
 						:class="{
-							'bg-surface-gray-7 text-ink-white font-medium':
+							'bg-surface-gray-7 text-ink-base font-medium':
 								activeQuestion == index,
 							'bg-surface-blue-2 text-ink-blue-6':
 								activeQuestion != index && attemptedQuestions.includes(index),

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -520,7 +520,7 @@
 						</div>
 						<div class="flex-1 flex justify-end gap-2">
 							<Button
-								v-if="activeQuestion > 1"
+								v-if="!quiz.data.show_answers && activeQuestion > 1"
 								@click="switchQuestion(activeQuestion - 1)"
 							>
 								<span>{{ __('Previous') }}</span>

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -518,55 +518,13 @@
 								@change="markForReview($event, activeQuestion)"
 							/>
 						</div>
-						<nav
-							v-if="!quiz.data.show_answers"
-							:aria-label="__('Question navigation')"
-							class="flex flex-wrap items-center gap-2"
-						>
+						<div class="flex-1 flex justify-end gap-2">
 							<Button
-								:label="__('Previous question')"
+								v-if="activeQuestion > 1"
 								@click="switchQuestion(activeQuestion - 1)"
-								:disabled="activeQuestion == 1"
-								class="rounded-full"
 							>
-								<template #icon>
-									<span class="lucide-chevron-left size-4" />
-								</template>
+								<span>{{ __('Previous') }}</span>
 							</Button>
-							<template v-for="(item, pidx) in paginationWindow" :key="pidx">
-								<span
-									v-if="item === '...'"
-									aria-hidden="true"
-									class="w-7 text-center text-sm text-ink-gray-5"
-								>
-									{{ item }}
-								</span>
-								<Button
-									v-else
-									:label="__('Question {0}').format(item)"
-									:variant="activeQuestion == item ? 'solid' : 'subtle'"
-									:theme="pageTheme(item)"
-									:aria-current="activeQuestion == item ? 'page' : undefined"
-									class="!w-7 !px-0 rounded-full"
-									:class="activeQuestion == item ? 'font-medium' : ''"
-									@click="switchQuestion(item)"
-								>
-									{{ item }}
-								</Button>
-							</template>
-
-							<Button
-								:label="__('Next question')"
-								@click="switchQuestion(activeQuestion + 1)"
-								:disabled="activeQuestion == questions.length"
-								class="rounded-full"
-							>
-								<template #icon>
-									<span class="lucide-chevron-right size-4" />
-								</template>
-							</Button>
-						</nav>
-						<div class="flex-1 flex justify-end">
 							<Button
 								v-if="
 									quiz.data.show_answers &&
@@ -664,6 +622,39 @@
 						</span>
 					</div>
 				</div>
+			</div>
+
+			<div
+				v-if="!quiz.data.show_answers"
+				class="border rounded-lg p-4 mt-4"
+			>
+				<div class="font-semibold">
+					{{ __('Questions') }}
+				</div>
+				<nav
+					:aria-label="__('Question navigation')"
+					class="flex flex-wrap items-center gap-2 mt-2"
+				>
+					<button
+						v-for="index in questions.length"
+						:key="index"
+						type="button"
+						:aria-label="__('Question {0}').format(index)"
+						:aria-current="activeQuestion == index ? 'page' : undefined"
+						@click="switchQuestion(index)"
+						class="w-6 h-6 rounded-full flex items-center justify-center text-sm cursor-pointer"
+						:class="{
+							'bg-surface-gray-7 text-ink-white font-medium':
+								activeQuestion == index,
+							'bg-surface-blue-2 text-ink-blue-6':
+								activeQuestion != index && attemptedQuestions.includes(index),
+							'bg-surface-gray-3':
+								activeQuestion != index && !attemptedQuestions.includes(index),
+						}"
+					>
+						{{ index }}
+					</button>
+				</nav>
 			</div>
 
 			<div v-if="reviewQuestions.length" class="border rounded-lg p-4 mt-4">
@@ -1597,36 +1588,6 @@ const recordCurrentAttempt = () => {
 		attemptedQuestions.value.push(activeQuestion.value)
 	}
 	addToLocalStorage()
-}
-
-const paginationWindow = computed(() => {
-	const total = questions.value.length
-	const current = activeQuestion.value
-	const pages = []
-	const size = 5
-
-	let start = Math.floor((current - 1) / size) * size + 1
-	let end = Math.min(start + size - 1, total)
-
-	if (start > 1) {
-		pages.push('...')
-	}
-
-	for (let i = start; i <= end; i++) {
-		pages.push(i)
-	}
-
-	if (end < total) {
-		pages.push('...')
-	}
-
-	return pages
-})
-
-// The current page wins over the attempted tint, so it reads as "here", not "answered".
-const pageTheme = (questionNumber) => {
-	if (activeQuestion.value == questionNumber) return 'gray'
-	return attemptedQuestions.value.includes(questionNumber) ? 'blue' : 'gray'
 }
 
 const markForReview = (event, questionNumber) => {


### PR DESCRIPTION
## Summary
- Replace the windowed question pager (chevrons + limited page numbers) with wrapping numbered chips in a bordered card, similar to “Questions marked for review”
- Add a **Previous** button beside **Next** / **Submit** so learners can move back without using the chips

## Motivation
The old pager only showed a small window of questions, which made jumping around awkward on longer quizzes. Showing all questions as chips makes navigation clearer and scales better for large question sets.

## Screenshots

### Before
<img width="1272" height="756" alt="Screenshot 2026-09-09 at 2 56 40 PM" src="https://github.com/user-attachments/assets/a7c2db88-946a-48b2-a246-4ce2afd98cdb" />

### After
<img width="1294" height="769" alt="Screenshot 2026-09-09 at 3 02 15 PM" src="https://github.com/user-attachments/assets/78144d8d-48b3-4043-b614-87a76f620018" />

