### PR TITLE
fix: render audio blocks in lessons

### DIFF
--- a/frontend/src/components/AudioBlock.vue
+++ b/frontend/src/components/AudioBlock.vue
@@ -3,7 +3,7 @@
 		<!-- <audio width="100%" controls controlsList="nodownload" class="mb-4">
 			<source :src="encodeURI(file)" type="audio/mp3" />
 		</audio> -->
-		<audio @ended="handleAudioEnd" controlsList="nodownload" class="mb-4">
+		<audio ref="audioEl" @ended="handleAudioEnd" controlsList="nodownload" class="mb-4">
 			<source :src="safeUrl(encodeURI(file))" type="audio/mp3" />
 		</audio>
 		<div class="flex items-center gap-x-2 shadow rounded-lg p-1 w-1/2">
@@ -53,6 +53,7 @@ import { Button } from 'frappe-ui'
 import { safeUrl } from '@/utils/safeUrl'
 
 const isPlaying = ref(false)
+const audioEl = ref(null)
 const audio = ref(null)
 let isMuted = ref(false)
 let currentTime = ref(0)
@@ -66,18 +67,23 @@ const props = defineProps({
 })
 
 onMounted(() => {
-	setTimeout(() => {
-		audio.value = document.querySelector('audio')
-		audio.value.onloadedmetadata = () => {
-			duration.value = audio.value.duration
-		}
-		audio.value.ontimeupdate = () => {
-			currentTime.value = audio.value.currentTime
-		}
-	}, 0)
+	// Bind this component's own <audio> through a template ref. EditorJS mounts
+	// the block into a wrapper that is still detached from the document at this
+	// point, so document.querySelector('audio') returned null and threw. It also
+	// returned the first <audio> in the page, so a lesson with several audio
+	// blocks drove them all from one element.
+	audio.value = audioEl.value
+	if (!audio.value) return
+	audio.value.onloadedmetadata = () => {
+		duration.value = audio.value.duration
+	}
+	audio.value.ontimeupdate = () => {
+		currentTime.value = audio.value.currentTime
+	}
 })
 
 const togglePlay = () => {
+	if (!audio.value) return
 	if (audio.value.paused) {
 		audio.value.play()
 		isPlaying.value = true
@@ -88,11 +94,13 @@ const togglePlay = () => {
 }
 
 const toggleMute = () => {
+	if (!audio.value) return
 	audio.value.muted = !audio.value.muted
 	isMuted.value = audio.value.muted
 }
 
 const changeCurrentTime = () => {
+	if (!audio.value) return
 	audio.value.currentTime = currentTime.value
 }
 
@@ -107,6 +115,7 @@ const formatTime = (time) => {
 }
 
 watch(isPlaying, (newVal) => {
+	if (!audio.value) return
 	if (newVal) {
 		audio.value.play()
 	} else {

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -71,6 +71,10 @@ export class Upload {
 				file: file.file_url,
 			})
 			registerDirectives(app)
+			// AudioBlock's template calls __() for its control labels, so without
+			// the translation plugin __ is undefined on this app and the render
+			// throws. The video and PDF branches already install it.
+			app.use(translationPlugin)
 			app.mount(this.wrapper)
 			return
 		} else if (file.file_type == 'PDF') {


### PR DESCRIPTION
Fixes #2717

## Problem

An `upload` block whose `file_type` is audio (`mp3`/`wav`/`ogg`) renders nothing in a lesson. Image, PDF and video blocks in the same lesson render fine, so the fault is confined to the audio path.

There are two separate causes, which is why the symptom changed after fixing only the first.

### 1. `translationPlugin` is not installed on the AudioBlock app

`frontend/src/utils/upload.js` mounts a fresh Vue app per block. The video and PDF branches call `app.use(translationPlugin)`; the audio branch does not:

```js
// video: registerDirectives(app); app.use(translationPlugin); app.mount(...)
// audio: registerDirectives(app);                             app.mount(...)   <-- missing
// pdf:   registerDirectives(app); app.use(translationPlugin); app.mount(...)
```

`translationPlugin` assigns `__` to `app.config.globalProperties`, which is per-app. `AudioBlock.vue`'s template calls `__('Play')`, `__('Pause')`, `__('Mute')` and `__('Seek')`, so on this app `__` is undefined and the render throws — the block mounts nothing at all. `PdfBlock` never calls `__`, and `VideoBlock` calls it but already gets the plugin, which is why only audio breaks.

### 2. `document.querySelector('audio')` returns `null` during `onMounted`

```js
onMounted(() => {
	setTimeout(() => {
		audio.value = document.querySelector('audio')
		audio.value.onloadedmetadata = () => { ... }   // throws
		...
	}, 0)
})
```

EditorJS's `compose()` calls the tool's `render()` and mounts the returned wrapper **before** inserting it into the document, so the wrapper is still detached here and the query matches nothing:

```
AudioBlock.vue:71 Uncaught TypeError: Cannot set properties of null (setting 'onloadedmetadata')
    mount → renderFile → render → compose (editorjs.mjs:1789)
```

The `setTimeout(…, 0)` looks like it was meant to cover exactly this and does not wait long enough.

The same call carries a second, latent bug: it returns the **first** `<audio>` in the document rather than this component's own, so a lesson containing several audio blocks gets several player UIs all driving one element.

## Fix

- Install `translationPlugin` on the AudioBlock app, matching the video and PDF branches.
- Bind the media element through a template ref (`ref="audioEl"`) instead of querying the document. This is correct regardless of DOM attachment order and scopes each player to its own element.
- Guard `togglePlay`, `toggleMute`, `changeCurrentTime` and the `isPlaying` watcher, which all dereference `audio.value` unconditionally.

## Testing

Verified on frappe `15.120.1` / lms `2.62.1` against a real course:

- Audio blocks render and play; duration and the seek slider populate correctly.
- A lesson with three audio blocks gives three independent players (previously they would all have driven the first element).
- Image, PDF, paragraph, list and header blocks are unaffected.
- Reproduced the original failure in a clean incognito profile first, ruling out caching and service-worker staleness.
