### PR TITLE
feat(quiz): add availability scheduling for quizzes and assignments

### DIFF
--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -274,9 +274,8 @@ useKeyboardShortcuts({
 })
 
 const assignment = createResource({
-	url: 'frappe.client.get',
+	url: 'lms.lms.utils.get_assignment',
 	params: {
-		doctype: 'LMS Assignment',
 		name: props.assignmentID,
 	},
 	auto: true,
@@ -473,13 +472,16 @@ const canModifyAssignment = computed(() => {
 	return false
 })
 
-const scheduleBlockReason = computed(() =>
-	getScheduleBlockReason(
+const scheduleBlockReason = computed(() => {
+	if (assignment.data && 'schedule_block_reason' in assignment.data) {
+		return assignment.data.schedule_block_reason || null
+	}
+	return getScheduleBlockReason(
 		assignment.data?.enable_scheduling,
 		assignment.data?.schedule_start,
 		assignment.data?.schedule_end
 	)
-)
+})
 
 const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
 

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -27,6 +27,12 @@
 
 		<div class="flex flex-col overflow-y-auto">
 			<div class="p-5 space-y-5">
+				<div
+					v-if="scheduleBlocked"
+					class="bg-surface-amber-1 text-ink-amber-6 p-3 rounded-md leading-5 text-sm"
+				>
+					{{ scheduleMessage }}
+				</div>
 				<div class="flex items-center justify-between">
 					<div class="font-semibold text-ink-gray-9">
 						{{ __('Submission') }}
@@ -43,13 +49,17 @@
 							{{ submissionResource.doc?.status }}
 						</Badge>
 						<ShortcutTooltip
-							v-if="canModifyAssignment || canGradeSubmission"
+							v-if="
+								(canModifyAssignment || canGradeSubmission) &&
+								(!scheduleBlocked || canGradeSubmission)
+							"
 							:label="__('Save')"
 							combo="Mod+S"
 						>
 							<Button
 								variant="solid"
 								:loading="isSubmitting"
+								:disabled="scheduleBlocked && !canGradeSubmission"
 								@click="submitAssignment()"
 							>
 								{{ __('Save') }}
@@ -73,7 +83,10 @@
 					}}
 					{{ __('Feel free to make edits to your submission if needed.') }}
 				</div>
-				<div v-if="showUploader()" class="border rounded-lg p-3">
+				<div
+					v-if="showUploader() && canModifyAssignment && !scheduleBlocked"
+					class="border rounded-lg p-3"
+				>
 					<div class="font-semibold mb-2">
 						{{ __('Upload Assignment') }}
 					</div>
@@ -130,7 +143,7 @@
 						</div>
 					</div>
 				</div>
-				<div v-else-if="assignment.data.type == 'URL'">
+				<div v-else-if="assignment.data.type == 'URL' && !scheduleBlocked">
 					<div class="text-p-sm-medium text-ink-gray-7 mb-1.5">
 						{{ __('Enter a URL') }}
 					</div>
@@ -138,16 +151,17 @@
 						v-model="answer"
 						type="text"
 						:aria-label="__('Enter a URL')"
+						:disabled="!canModifyAssignment"
 					/>
 				</div>
-				<div v-else>
+				<div v-else-if="!showUploader() && !scheduleBlocked">
 					<div class="text-sm mb-2 text-ink-gray-7">
 						{{ __('Write your answer here') }}
 					</div>
 					<RichTextEditor
 						:content="answer"
 						@change="(val) => (answer = val)"
-						:editable="true"
+						:editable="canModifyAssignment"
 						:fixedMenu="true"
 						:uploadArgs="{
 							private: true,
@@ -230,6 +244,7 @@ import { useRouter } from 'vue-router'
 import { validateFile } from '@/utils'
 import RichTextEditor from '@/components/RichTextEditor.vue'
 import { safeUrl } from '@/utils/safeUrl'
+import { getScheduleBlockReason } from '@/utils/schedule'
 
 const answer = ref(null)
 const attachment = ref(null)
@@ -298,6 +313,10 @@ const isSubmitting = ref(false)
 
 const submitAssignment = () => {
 	if (isSubmitting.value) return
+	if (scheduleBlocked.value && !canGradeSubmission.value) {
+		toast.error(scheduleMessage.value)
+		return
+	}
 	isSubmitting.value = true
 
 	if (props.submissionName != 'new') {
@@ -440,6 +459,9 @@ const canGradeSubmission = computed(() => {
 })
 
 const canModifyAssignment = computed(() => {
+	if (scheduleBlocked.value) {
+		return false
+	}
 	if (props.submissionName == 'new') {
 		return true
 	} else if (
@@ -450,6 +472,35 @@ const canModifyAssignment = computed(() => {
 	}
 	return false
 })
+
+const scheduleBlockReason = computed(() =>
+	getScheduleBlockReason(
+		assignment.data?.enable_scheduling,
+		assignment.data?.schedule_start,
+		assignment.data?.schedule_end
+	)
+)
+
+const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
+
+const scheduleMessage = computed(() => {
+	if (scheduleBlockReason.value === 'not_started') {
+		return __('This assignment opens on {0}.').format(
+			formatScheduleDate(assignment.data?.schedule_start)
+		)
+	}
+	if (scheduleBlockReason.value === 'ended') {
+		return __('The schedule for this assignment has ended.')
+	}
+	return ''
+})
+
+const formatScheduleDate = (value) => {
+	if (!value) return ''
+	const date = new Date(value)
+	if (Number.isNaN(date.getTime())) return String(value)
+	return date.toLocaleString()
+}
 
 const submissionStatusOptions = computed(() => {
 	return [

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -234,7 +234,7 @@ import {
 	FormControl,
 	toast,
 } from 'frappe-ui'
-import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, inject, onUnmounted, ref, watch } from 'vue'
 import ShortcutTooltip from '@/components/ShortcutTooltip.vue'
 import {
 	useKeyboardShortcuts,
@@ -270,18 +270,20 @@ const props = defineProps({
 	},
 })
 
-onMounted(() => {
-	scheduleClock = setInterval(() => {
-		scheduleNow.value = new Date()
-	}, 15000)
-})
-
-onUnmounted(() => {
+const stopScheduleClock = () => {
 	if (scheduleClock) {
 		clearInterval(scheduleClock)
 		scheduleClock = null
 	}
-})
+}
+
+const startScheduleClock = () => {
+	stopScheduleClock()
+	scheduleNow.value = new Date()
+	scheduleClock = setInterval(() => {
+		scheduleNow.value = new Date()
+	}, 15000)
+}
 
 useKeyboardShortcuts({
 	ignoreTyping: false,
@@ -518,6 +520,18 @@ const formatScheduleDate = (value) => {
 	if (Number.isNaN(date.getTime())) return String(value)
 	return date.toLocaleString()
 }
+
+watch(
+	() => assignment.data?.enable_scheduling,
+	(enabled) => {
+		if (enabled) startScheduleClock()
+		else stopScheduleClock()
+	}
+)
+
+onUnmounted(() => {
+	stopScheduleClock()
+})
 
 const submissionStatusOptions = computed(() => {
 	return [

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -234,7 +234,7 @@ import {
 	FormControl,
 	toast,
 } from 'frappe-ui'
-import { computed, inject, ref, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue'
 import ShortcutTooltip from '@/components/ShortcutTooltip.vue'
 import {
 	useKeyboardShortcuts,
@@ -252,6 +252,8 @@ const comments = ref(null)
 const router = useRouter()
 const user = inject('$user')
 const isDirty = ref(false)
+const scheduleNow = ref(new Date())
+let scheduleClock = null
 
 const props = defineProps({
 	assignmentID: {
@@ -266,6 +268,19 @@ const props = defineProps({
 		type: Boolean,
 		default: true,
 	},
+})
+
+onMounted(() => {
+	scheduleClock = setInterval(() => {
+		scheduleNow.value = new Date()
+	}, 15000)
+})
+
+onUnmounted(() => {
+	if (scheduleClock) {
+		clearInterval(scheduleClock)
+		scheduleClock = null
+	}
 })
 
 useKeyboardShortcuts({
@@ -472,23 +487,23 @@ const canModifyAssignment = computed(() => {
 	return false
 })
 
-const scheduleBlockReason = computed(() => {
-	if (assignment.data && 'schedule_block_reason' in assignment.data) {
-		return assignment.data.schedule_block_reason || null
-	}
-	return getScheduleBlockReason(
+const scheduleBlockReason = computed(() =>
+	getScheduleBlockReason(
 		assignment.data?.enable_scheduling,
-		assignment.data?.schedule_start,
-		assignment.data?.schedule_end
+		assignment.data?.schedule_start_iso || assignment.data?.schedule_start,
+		assignment.data?.schedule_end_iso || assignment.data?.schedule_end,
+		scheduleNow.value
 	)
-})
+)
 
 const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
 
 const scheduleMessage = computed(() => {
 	if (scheduleBlockReason.value === 'not_started') {
 		return __('This assignment opens on {0}.').format(
-			formatScheduleDate(assignment.data?.schedule_start)
+			formatScheduleDate(
+				assignment.data?.schedule_start_iso || assignment.data?.schedule_start
+			)
 		)
 	}
 	if (scheduleBlockReason.value === 'ended') {

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -89,6 +89,22 @@
 							<span class="lucide-camera size-3.5" />
 							{{ __('Proctored') }}
 						</span>
+						<span
+							v-if="quiz.data.enable_scheduling && quiz.data.schedule_start"
+							class="inline-flex items-center gap-1.5 bg-surface-gray-3 text-ink-gray-7 text-xs font-medium px-2.5 py-1 rounded-full"
+						>
+							<span class="lucide-calendar size-3.5" />
+							{{ __('Opens') }}:
+							{{ formatScheduleDate(quiz.data.schedule_start) }}
+						</span>
+						<span
+							v-if="quiz.data.enable_scheduling && quiz.data.schedule_end"
+							class="inline-flex items-center gap-1.5 bg-surface-gray-3 text-ink-gray-7 text-xs font-medium px-2.5 py-1 rounded-full"
+						>
+							<span class="lucide-calendar-x size-3.5" />
+							{{ __('Closes') }}:
+							{{ formatScheduleDate(quiz.data.schedule_end) }}
+						</span>
 					</div>
 				</div>
 
@@ -245,6 +261,16 @@
 							__('Resume Video')
 						}}</Button>
 					</template>
+					<template v-else-if="scheduleBlocked">
+						<div class="bg-surface-amber-1 rounded-lg px-4 py-3 mb-3">
+							<div class="text-sm text-ink-amber-6 leading-5">
+								{{ scheduleMessage }}
+							</div>
+						</div>
+						<Button v-if="inVideo" @click="props.backToVideo()">{{
+							__('Resume Video')
+						}}</Button>
+					</template>
 					<template v-else>
 						<div class="flex items-center justify-center gap-2">
 							<Button
@@ -276,7 +302,9 @@
 			     columns: split early, the camera preview and the rule text each get
 			     a strip too narrow to read, and every rule wraps to three lines. -->
 			<div
-				v-if="quiz.data.enable_proctoring && !attemptsExhausted"
+				v-if="
+					quiz.data.enable_proctoring && !attemptsExhausted && !scheduleBlocked
+				"
 				class="grid gap-4 md:grid-cols-2"
 			>
 				<!-- Camera setup -->
@@ -934,6 +962,7 @@ import {
 } from 'vue'
 import { timeAgo } from '@/utils/format'
 import { safeUrl } from '@/utils/safeUrl'
+import { getScheduleBlockReason } from '@/utils/schedule'
 import ProgressBar from '@/components/ProgressBar.vue'
 import ResponsiveListView from '@/components/ResponsiveListView.vue'
 import RichTextEditor from '@/components/RichTextEditor.vue'
@@ -1141,6 +1170,35 @@ const attemptsExhausted = computed(
 		(attempts.data?.length ?? 0) >= quiz.data.max_attempts
 )
 
+const scheduleBlockReason = computed(() =>
+	getScheduleBlockReason(
+		quiz.data?.enable_scheduling,
+		quiz.data?.schedule_start,
+		quiz.data?.schedule_end
+	)
+)
+
+const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
+
+const scheduleMessage = computed(() => {
+	if (scheduleBlockReason.value === 'not_started') {
+		return __('This quiz opens on {0}.').format(
+			formatScheduleDate(quiz.data?.schedule_start)
+		)
+	}
+	if (scheduleBlockReason.value === 'ended') {
+		return __('The schedule for this quiz has ended.')
+	}
+	return ''
+})
+
+const formatScheduleDate = (value) => {
+	if (!value) return ''
+	const date = new Date(value)
+	if (Number.isNaN(date.getTime())) return String(value)
+	return date.toLocaleString()
+}
+
 const shuffleArray = (array) => {
 	for (let i = array.length - 1; i > 0; i--) {
 		const j = Math.floor(Math.random() * (i + 1))
@@ -1286,6 +1344,7 @@ watch(
 )
 
 const startQuiz = () => {
+	if (scheduleBlocked.value) return
 	activeQuestion.value = 1
 	localStorage.removeItem(quiz.data.title)
 	// Neither in an author preview. Nothing may be submitted there, so a countdown

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -1213,17 +1213,33 @@ watch(scheduleBlockReason, (reason, previous) => {
 	}
 })
 
-onMounted(() => {
-	scheduleClock = setInterval(() => {
-		scheduleNow.value = new Date()
-	}, 15000)
-})
-
-onUnmounted(() => {
+const stopScheduleClock = () => {
 	if (scheduleClock) {
 		clearInterval(scheduleClock)
 		scheduleClock = null
 	}
+}
+
+const startScheduleClock = () => {
+	stopScheduleClock()
+	scheduleNow.value = new Date()
+	scheduleClock = setInterval(() => {
+		scheduleNow.value = new Date()
+	}, 15000)
+}
+
+// Only tick while scheduling is on — keeps lesson-reuse timer tests (and
+// everyday quizzes) free of a leftover interval.
+watch(
+	() => quiz.data?.enable_scheduling,
+	(enabled) => {
+		if (enabled) startScheduleClock()
+		else stopScheduleClock()
+	}
+)
+
+onUnmounted(() => {
+	stopScheduleClock()
 })
 
 const shuffleArray = (array) => {

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -1170,25 +1170,26 @@ const attemptsExhausted = computed(
 		(attempts.data?.length ?? 0) >= quiz.data.max_attempts
 )
 
-const scheduleBlockReason = computed(() => {
-	// Server reason is authoritative (system timezone). Client fallback only
-	// covers payloads that predate schedule_block_reason.
-	if (quiz.data && 'schedule_block_reason' in quiz.data) {
-		return quiz.data.schedule_block_reason || null
-	}
-	return getScheduleBlockReason(
+const scheduleNow = ref(new Date())
+let scheduleClock = null
+
+const scheduleBlockReason = computed(() =>
+	getScheduleBlockReason(
 		quiz.data?.enable_scheduling,
-		quiz.data?.schedule_start,
-		quiz.data?.schedule_end
+		quiz.data?.schedule_start_iso || quiz.data?.schedule_start,
+		quiz.data?.schedule_end_iso || quiz.data?.schedule_end,
+		scheduleNow.value
 	)
-})
+)
 
 const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
 
 const scheduleMessage = computed(() => {
 	if (scheduleBlockReason.value === 'not_started') {
 		return __('This quiz opens on {0}.').format(
-			formatScheduleDate(quiz.data?.schedule_start)
+			formatScheduleDate(
+				quiz.data?.schedule_start_iso || quiz.data?.schedule_start
+			)
 		)
 	}
 	if (scheduleBlockReason.value === 'ended') {
@@ -1203,6 +1204,27 @@ const formatScheduleDate = (value) => {
 	if (Number.isNaN(date.getTime())) return String(value)
 	return date.toLocaleString()
 }
+
+watch(scheduleBlockReason, (reason, previous) => {
+	// Questions are withheld while blocked; once the window opens, refetch so
+	// Start can load real prompts without a full page reload.
+	if (previous && !reason && !Object.keys(questionsByName.value).length) {
+		quiz.reload()
+	}
+})
+
+onMounted(() => {
+	scheduleClock = setInterval(() => {
+		scheduleNow.value = new Date()
+	}, 15000)
+})
+
+onUnmounted(() => {
+	if (scheduleClock) {
+		clearInterval(scheduleClock)
+		scheduleClock = null
+	}
+})
 
 const shuffleArray = (array) => {
 	for (let i = array.length - 1; i > 0; i--) {

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -1170,13 +1170,18 @@ const attemptsExhausted = computed(
 		(attempts.data?.length ?? 0) >= quiz.data.max_attempts
 )
 
-const scheduleBlockReason = computed(() =>
-	getScheduleBlockReason(
+const scheduleBlockReason = computed(() => {
+	// Server reason is authoritative (system timezone). Client fallback only
+	// covers payloads that predate schedule_block_reason.
+	if (quiz.data && 'schedule_block_reason' in quiz.data) {
+		return quiz.data.schedule_block_reason || null
+	}
+	return getScheduleBlockReason(
 		quiz.data?.enable_scheduling,
 		quiz.data?.schedule_start,
 		quiz.data?.schedule_end
 	)
-)
+})
 
 const scheduleBlocked = computed(() => !!scheduleBlockReason.value)
 

--- a/frontend/src/pages/Forms/AssignmentForm.vue
+++ b/frontend/src/pages/Forms/AssignmentForm.vue
@@ -23,6 +23,38 @@
 					doctype="LMS Course"
 					placeholder=" "
 				/>
+				<BooleanSwitch
+					v-model="assignment.enable_scheduling"
+					size="sm"
+					:label="__('Enable Scheduling')"
+					:description="
+						__('Restrict when learners can submit this assignment.')
+					"
+				/>
+				<FormControl
+					v-if="assignment.enable_scheduling"
+					type="datetime-local"
+					:model-value="toDatetimeLocal(assignment.schedule_start)"
+					@update:model-value="
+						(val) => (assignment.schedule_start = fromDatetimeLocal(val))
+					"
+					:label="__('Schedule Start')"
+					:required="true"
+				/>
+				<FormControl
+					v-if="assignment.enable_scheduling"
+					type="datetime-local"
+					:model-value="toDatetimeLocal(assignment.schedule_end)"
+					@update:model-value="
+						(val) => (assignment.schedule_end = fromDatetimeLocal(val))
+					"
+					:label="__('Schedule End')"
+					:description="
+						__(
+							'Optional. Leave empty to keep the assignment open after it starts.'
+						)
+					"
+				/>
 				<div
 					role="group"
 					:aria-labelledby="questionLabelId"
@@ -83,11 +115,13 @@ import { computed, inject, reactive, useId, watch } from 'vue'
 import { sanitizeOnWrite } from '@/utils/sanitizeOnWrite'
 import FormShell from '@/components/FormShell.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
+import BooleanSwitch from '@/components/Controls/BooleanSwitch.vue'
 import { useFormRoute } from '@/composables/useFormRoute'
 import Link from '@/components/Controls/Link.vue'
 import RichTextEditor from '@/components/RichTextEditor.vue'
 import { InputLabel } from '@/components/Form/labeling'
 import { submitResource } from '@/utils/resource'
+import { toDatetimeLocal, fromDatetimeLocal } from '@/utils/schedule'
 
 const questionLabelId = useId()
 
@@ -127,6 +161,9 @@ interface AssignmentFields {
 	type: string
 	question: string
 	course: string
+	enable_scheduling: number
+	schedule_start: string | null
+	schedule_end: string | null
 }
 
 const assignment = reactive<AssignmentFields>({
@@ -134,6 +171,9 @@ const assignment = reactive<AssignmentFields>({
 	type: '',
 	question: '',
 	course: '',
+	enable_scheduling: 0,
+	schedule_start: null,
+	schedule_end: null,
 })
 
 // C4: edit mode used to copy its values out of the parent list's in-memory
@@ -169,6 +209,9 @@ watch(
 		assignment.type = doc.type
 		assignment.question = doc.question
 		assignment.course = doc.course || ''
+		assignment.enable_scheduling = doc.enable_scheduling ? 1 : 0
+		assignment.schedule_start = doc.schedule_start || null
+		assignment.schedule_end = doc.schedule_end || null
 	},
 	{ immediate: true }
 )
@@ -203,9 +246,26 @@ const saving = computed<boolean>(() =>
 	Boolean(newAssignment.loading || assignmentDoc?.setValue?.loading)
 )
 
-const validateFields = (): void => {
+const validateFields = (): boolean => {
 	assignment.title = sanitizeOnWrite(assignment.title.trim())
 	assignment.question = sanitizeOnWrite(assignment.question)
+	if (assignment.enable_scheduling) {
+		if (!assignment.schedule_start) {
+			toast.error(__('Schedule Start is required when scheduling is enabled.'))
+			return false
+		}
+		if (
+			assignment.schedule_end &&
+			new Date(assignment.schedule_end) <= new Date(assignment.schedule_start)
+		) {
+			toast.error(__('Schedule End must be after Schedule Start.'))
+			return false
+		}
+	} else {
+		assignment.schedule_start = null
+		assignment.schedule_end = null
+	}
+	return true
 }
 
 const updateAssignment = (): void => {
@@ -233,7 +293,7 @@ const updateAssignment = (): void => {
 
 const saveAssignment = (): void => {
 	if (!canManageAssignments.value) return
-	validateFields()
+	if (!validateFields()) return
 	if (isNew.value) newAssignment.submit()
 	else updateAssignment()
 }

--- a/frontend/src/pages/Forms/QuizForm.vue
+++ b/frontend/src/pages/Forms/QuizForm.vue
@@ -326,6 +326,38 @@
 						variant="outline"
 						:required="true"
 					/>
+					<BooleanSwitch
+						v-model="doc.enable_scheduling"
+						size="sm"
+						:label="__('Enable Scheduling')"
+						:description="
+							__('Restrict when learners can start and submit this quiz.')
+						"
+					/>
+					<FormControl
+						v-if="doc.enable_scheduling"
+						type="datetime-local"
+						:model-value="toDatetimeLocal(doc.schedule_start)"
+						@update:model-value="
+							(val) => (doc.schedule_start = fromDatetimeLocal(val))
+						"
+						:label="__('Schedule Start')"
+						variant="outline"
+						:required="true"
+					/>
+					<FormControl
+						v-if="doc.enable_scheduling"
+						type="datetime-local"
+						:model-value="toDatetimeLocal(doc.schedule_end)"
+						@update:model-value="
+							(val) => (doc.schedule_end = fromDatetimeLocal(val))
+						"
+						:label="__('Schedule End')"
+						:description="
+							__('Optional. Leave empty to keep the quiz open after it starts.')
+						"
+						variant="outline"
+					/>
 				</div>
 			</div>
 		</div>
@@ -347,6 +379,7 @@ import BooleanSwitch from '@/components/Controls/BooleanSwitch.vue'
 import HeaderButton from '@/components/HeaderButton.vue'
 import EmptyStateLayout from '@/components/Layouts/EmptyStateLayout.vue'
 import PageHeader from '@/components/Layouts/PageHeader.vue'
+import { toDatetimeLocal, fromDatetimeLocal } from '@/utils/schedule'
 import Draggable from 'vuedraggable'
 import QuestionCard from '@/components/Quiz/QuestionCard.vue'
 import QuestionBankPanel from '@/components/Quiz/QuestionBankPanel.vue'

--- a/frontend/src/tests/assignmentForm.test.ts
+++ b/frontend/src/tests/assignmentForm.test.ts
@@ -118,6 +118,9 @@ vi.mock('@/components/Controls/Link.vue', () => ({
 		template: `<label>{{ label }}<input data-testid="assignment-course" :value="modelValue" /></label>`,
 	},
 }))
+vi.mock('@/components/Controls/BooleanSwitch.vue', () => ({
+	default: { props: ['modelValue', 'label'], template: `<div />` },
+}))
 
 import AssignmentForm from '@/pages/Forms/AssignmentForm.vue'
 
@@ -185,6 +188,9 @@ const RECORD = {
 	type: 'Text',
 	question: '<p>Why?</p>',
 	course: 'COURSE-1',
+	enable_scheduling: 0,
+	schedule_start: null,
+	schedule_end: null,
 }
 
 const inputs = (wrapper: any) =>
@@ -350,6 +356,9 @@ describe('AssignmentForm as a route', () => {
 				type: '',
 				question: '',
 				course: '',
+				enable_scheduling: 0,
+				schedule_start: null,
+				schedule_end: null,
 			},
 		})
 	})
@@ -370,6 +379,9 @@ describe('AssignmentForm as a route', () => {
 			type: 'Text',
 			question: '<p>Why?</p>',
 			course: 'COURSE-1',
+			enable_scheduling: 0,
+			schedule_start: null,
+			schedule_end: null,
 		})
 		expect(insertSubmit).not.toHaveBeenCalled()
 	})

--- a/frontend/src/types/lms/LMSAssignment.ts
+++ b/frontend/src/types/lms/LMSAssignment.ts
@@ -23,4 +23,10 @@ export interface LMSAssignment {
 	grade_assignment?: 0 | 1
 	/**	Course : Link - LMS Course	*/
 	course?: string
+	/**	Enable Scheduling : Check	*/
+	enable_scheduling?: 0 | 1
+	/**	Schedule Start : Datetime	*/
+	schedule_start?: string
+	/**	Schedule End : Datetime	*/
+	schedule_end?: string
 }

--- a/frontend/src/types/lms/LMSQuiz.ts
+++ b/frontend/src/types/lms/LMSQuiz.ts
@@ -39,4 +39,10 @@ export interface LMSQuiz {
 	enable_negative_marking?: 0 | 1
 	/**	Marks To Cut : Int	*/
 	marks_to_cut?: number
+	/**	Enable Scheduling : Check	*/
+	enable_scheduling?: 0 | 1
+	/**	Schedule Start : Datetime	*/
+	schedule_start?: string
+	/**	Schedule End : Datetime	*/
+	schedule_end?: string
 }

--- a/frontend/src/utils/schedule.js
+++ b/frontend/src/utils/schedule.js
@@ -1,0 +1,31 @@
+/**
+ * Bridge Frappe Datetime ("YYYY-MM-DD HH:MM:SS") and <input type="datetime-local">
+ * ("YYYY-MM-DDTHH:MM").
+ */
+
+export function toDatetimeLocal(value) {
+	if (!value) return ''
+	return String(value).replace(' ', 'T').slice(0, 16)
+}
+
+export function fromDatetimeLocal(value) {
+	if (!value) return null
+	const normalized = String(value).replace('T', ' ')
+	return normalized.length === 16 ? `${normalized}:00` : normalized
+}
+
+/**
+ * Client-side schedule window check. Mirrors lms.lms.schedule_utils.
+ * @returns {'not_started' | 'ended' | null}
+ */
+export function getScheduleBlockReason(
+	enableScheduling,
+	scheduleStart,
+	scheduleEnd,
+	now = new Date()
+) {
+	if (!enableScheduling) return null
+	if (scheduleStart && now < new Date(scheduleStart)) return 'not_started'
+	if (scheduleEnd && now > new Date(scheduleEnd)) return 'ended'
+	return null
+}

--- a/frontend/src/utils/schedule.js
+++ b/frontend/src/utils/schedule.js
@@ -16,6 +16,11 @@ export function fromDatetimeLocal(value) {
 
 /**
  * Client-side schedule window check. Mirrors lms.lms.schedule_utils.
+ *
+ * Prefer the server-provided `schedule_block_reason` on quiz/assignment
+ * payloads when present — Frappe Datetimes are system-timezone wall clocks,
+ * so a browser-local parse can disagree with the server across timezones.
+ *
  * @returns {'not_started' | 'ended' | null}
  */
 export function getScheduleBlockReason(

--- a/frontend/src/utils/schedule.js
+++ b/frontend/src/utils/schedule.js
@@ -17,9 +17,9 @@ export function fromDatetimeLocal(value) {
 /**
  * Client-side schedule window check. Mirrors lms.lms.schedule_utils.
  *
- * Prefer the server-provided `schedule_block_reason` on quiz/assignment
- * payloads when present — Frappe Datetimes are system-timezone wall clocks,
- * so a browser-local parse can disagree with the server across timezones.
+ * Prefer offset-bearing ISO values from the server (`schedule_start_iso` /
+ * `schedule_end_iso`) so browser and system timezones agree. Naive Frappe
+ * strings are a last-resort fallback only.
  *
  * @returns {'not_started' | 'ended' | null}
  */
@@ -30,7 +30,18 @@ export function getScheduleBlockReason(
 	now = new Date()
 ) {
 	if (!enableScheduling) return null
-	if (scheduleStart && now < new Date(scheduleStart)) return 'not_started'
-	if (scheduleEnd && now > new Date(scheduleEnd)) return 'ended'
+	const start = parseScheduleInstant(scheduleStart)
+	const end = parseScheduleInstant(scheduleEnd)
+	if (start && now < start) return 'not_started'
+	if (end && now > end) return 'ended'
 	return null
+}
+
+function parseScheduleInstant(value) {
+	if (!value) return null
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? null : value
+	}
+	const date = new Date(value)
+	return Number.isNaN(date.getTime()) ? null : date
 }

--- a/lms/lms/doctype/lms_assignment/lms_assignment.json
+++ b/lms/lms/doctype/lms_assignment/lms_assignment.json
@@ -17,7 +17,12 @@
   "question",
   "section_break_sjti",
   "show_answer",
-  "answer"
+  "answer",
+  "section_break_schedule",
+  "enable_scheduling",
+  "schedule_start",
+  "column_break_schedule",
+  "schedule_end"
  ],
  "fields": [
   {
@@ -76,6 +81,34 @@
    "fieldtype": "Link",
    "label": "Course",
    "options": "LMS Course"
+  },
+  {
+   "fieldname": "section_break_schedule",
+   "fieldtype": "Section Break",
+   "label": "Scheduling"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_scheduling",
+   "fieldtype": "Check",
+   "label": "Enable Scheduling"
+  },
+  {
+   "depends_on": "enable_scheduling",
+   "fieldname": "schedule_start",
+   "fieldtype": "Datetime",
+   "label": "Schedule Start",
+   "mandatory_depends_on": "enable_scheduling"
+  },
+  {
+   "fieldname": "column_break_schedule",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "enable_scheduling",
+   "fieldname": "schedule_end",
+   "fieldtype": "Datetime",
+   "label": "Schedule End"
   }
  ],
  "grid_page_length": 50,

--- a/lms/lms/doctype/lms_assignment/lms_assignment.py
+++ b/lms/lms/doctype/lms_assignment/lms_assignment.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2023, Frappe and contributors
 # For license information, please see license.txt
 
-import frappe
 from frappe.model.document import Document
 
-from lms.lms.utils import has_course_instructor_role, has_moderator_role
+from lms.lms.schedule_utils import validate_schedule_fields
 
 
 class LMSAssignment(Document):
-	pass
+	def validate(self):
+		validate_schedule_fields(self)

--- a/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
+++ b/lms/lms/doctype/lms_assignment_submission/lms_assignment_submission.py
@@ -7,6 +7,7 @@ from frappe.desk.doctype.notification_log.notification_log import make_notificat
 from frappe.model.document import Document
 from frappe.utils import validate_url
 
+from lms.lms.schedule_utils import assert_within_schedule
 from lms.lms.utils import PRIVILEGED_ROLES, get_lms_route
 
 
@@ -14,9 +15,38 @@ class LMSAssignmentSubmission(Document):
 	def validate(self):
 		self.enforce_member_ownership()
 		self.enforce_grading_permission()
+		self.validate_schedule_window()
 		self.validate_duplicates()
 		self.validate_url()
 		self.validate_status()
+
+	def validate_schedule_window(self):
+		"""Students cannot create or edit submission content outside the window.
+
+		Privileged roles may still grade (and manage submissions) outside the
+		schedule.
+		"""
+		if PRIVILEGED_ROLES & set(frappe.get_roles()):
+			return
+
+		if not self.assignment:
+			return
+
+		schedule = frappe.db.get_value(
+			"LMS Assignment",
+			self.assignment,
+			["title", "enable_scheduling", "schedule_start", "schedule_end"],
+			as_dict=True,
+		)
+		if not schedule:
+			return
+
+		assert_within_schedule(
+			schedule.enable_scheduling,
+			schedule.schedule_start,
+			schedule.schedule_end,
+			label=schedule.title or _("This assignment"),
+		)
 
 	def enforce_grading_permission(self):
 		"""Only evaluators/instructors may set the grading fields.

--- a/lms/lms/doctype/lms_quiz/lms_quiz.json
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.json
@@ -17,6 +17,9 @@
   "duration",
   "enable_proctoring",
   "max_violations",
+  "enable_scheduling",
+  "schedule_start",
+  "schedule_end",
   "section_break_tzbu",
   "shuffle_questions",
   "limit_questions_to",
@@ -165,6 +168,25 @@
    "fieldname": "marks_to_cut",
    "fieldtype": "Int",
    "label": "Marks To Cut"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_scheduling",
+   "fieldtype": "Check",
+   "label": "Enable Scheduling"
+  },
+  {
+   "depends_on": "enable_scheduling",
+   "fieldname": "schedule_start",
+   "fieldtype": "Datetime",
+   "label": "Schedule Start",
+   "mandatory_depends_on": "enable_scheduling"
+  },
+  {
+   "depends_on": "enable_scheduling",
+   "fieldname": "schedule_end",
+   "fieldtype": "Datetime",
+   "label": "Schedule End"
   }
  ],
  "grid_page_length": 50,

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -28,6 +28,7 @@ from lms.lms.doctype.lms_question.lms_question import (
 	QUESTION_OPTION_FIELDS,
 	QUESTION_POSSIBILITY_FIELDS,
 )
+from lms.lms.schedule_utils import assert_within_schedule, validate_schedule_fields
 from lms.lms.utils import (
 	generate_slug,
 	has_course_instructor_role,
@@ -60,6 +61,7 @@ class LMSQuiz(Document):
 		self.validate_limit()
 		self.calculate_total_marks()
 		self.validate_open_ended_questions()
+		validate_schedule_fields(self)
 
 	def validate_duplicate_questions(self):
 		questions = [row.question for row in self.questions]
@@ -178,6 +180,7 @@ def submit_quiz(
 		quiz,
 		[
 			"name",
+			"title",
 			"total_marks",
 			"passing_percentage",
 			"lesson",
@@ -186,6 +189,9 @@ def submit_quiz(
 			"marks_to_cut",
 			"enable_proctoring",
 			"max_violations",
+			"enable_scheduling",
+			"schedule_start",
+			"schedule_end",
 		],
 		as_dict=1,
 	)
@@ -196,6 +202,13 @@ def submit_quiz(
 
 	if not can_access_quiz(quiz):
 		frappe.throw(_("You are not authorized to submit this quiz."), frappe.PermissionError)
+
+	assert_within_schedule(
+		quiz_details.enable_scheduling,
+		quiz_details.schedule_start,
+		quiz_details.schedule_end,
+		label=quiz_details.title or _("This quiz"),
+	)
 
 	data = process_results(results, quiz_details)
 	is_open_ended = data["is_open_ended"]

--- a/lms/lms/schedule_utils.py
+++ b/lms/lms/schedule_utils.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+from zoneinfo import ZoneInfo
+
 import frappe
 from frappe import _
-from frappe.utils import get_datetime, now_datetime
+from frappe.utils import get_datetime, get_system_timezone, now_datetime
 
 
 def validate_schedule_fields(doc) -> None:
@@ -82,3 +84,29 @@ def assert_doc_within_schedule(doc, *, label: str | None = None) -> None:
 		doc.get("schedule_end") if hasattr(doc, "get") else getattr(doc, "schedule_end", None),
 		label=label,
 	)
+
+
+def datetime_to_iso(value) -> str | None:
+	"""Convert a naive system-timezone Datetime to an offset-bearing ISO string.
+
+	Learners' browsers must not treat schedule boundaries as local wall clocks;
+	ISO with an explicit offset keeps client and server windows aligned.
+	"""
+	if not value:
+		return None
+	dt = get_datetime(value)
+	if dt.tzinfo is None:
+		dt = dt.replace(tzinfo=ZoneInfo(get_system_timezone()))
+	return dt.isoformat()
+
+
+def enrich_schedule_payload(doc: dict) -> dict:
+	"""Attach schedule_block_reason and offset-aware ISO timestamps for the UI."""
+	doc["schedule_block_reason"] = get_schedule_block_reason(
+		doc.get("enable_scheduling"),
+		doc.get("schedule_start"),
+		doc.get("schedule_end"),
+	)
+	doc["schedule_start_iso"] = datetime_to_iso(doc.get("schedule_start"))
+	doc["schedule_end_iso"] = datetime_to_iso(doc.get("schedule_end"))
+	return doc

--- a/lms/lms/schedule_utils.py
+++ b/lms/lms/schedule_utils.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, Frappe and contributors
+# For license information, please see license.txt
+
+"""Shared availability-window helpers for LMS Quiz and LMS Assignment."""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+from frappe.utils import get_datetime, now_datetime
+
+
+def validate_schedule_fields(doc) -> None:
+	"""DocType validate for enable_scheduling / schedule_start / schedule_end.
+
+	When scheduling is off, clear start/end so stale values are not kept.
+	When on, start is required and end (if set) must be after start.
+	"""
+	if not doc.enable_scheduling:
+		doc.schedule_start = None
+		doc.schedule_end = None
+		return
+
+	if not doc.schedule_start:
+		frappe.throw(_("Schedule Start is required when scheduling is enabled."))
+
+	if doc.schedule_end:
+		start = get_datetime(doc.schedule_start)
+		end = get_datetime(doc.schedule_end)
+		if end <= start:
+			frappe.throw(_("Schedule End must be after Schedule Start."))
+
+
+def get_schedule_block_reason(
+	enable_scheduling,
+	schedule_start,
+	schedule_end,
+	*,
+	now=None,
+) -> str | None:
+	"""Return 'not_started', 'ended', or None if the window is open."""
+	if not enable_scheduling:
+		return None
+
+	now = now or now_datetime()
+	if schedule_start and now < get_datetime(schedule_start):
+		return "not_started"
+	if schedule_end and now > get_datetime(schedule_end):
+		return "ended"
+	return None
+
+
+def assert_within_schedule(
+	enable_scheduling,
+	schedule_start,
+	schedule_end,
+	*,
+	label: str | None = None,
+) -> None:
+	"""Throw if the current time is outside the availability window."""
+	reason = get_schedule_block_reason(enable_scheduling, schedule_start, schedule_end)
+	if not reason:
+		return
+
+	item = label or _("This item")
+	if reason == "not_started":
+		frappe.throw(
+			_("{0} opens on {1}.").format(item, frappe.format(schedule_start, {"fieldtype": "Datetime"})),
+			frappe.ValidationError,
+		)
+	frappe.throw(
+		_("The schedule for {0} has ended.").format(item),
+		frappe.ValidationError,
+	)
+
+
+def assert_doc_within_schedule(doc, *, label: str | None = None) -> None:
+	"""Convenience wrapper for a quiz/assignment document or dict."""
+	assert_within_schedule(
+		doc.get("enable_scheduling") if hasattr(doc, "get") else getattr(doc, "enable_scheduling", 0),
+		doc.get("schedule_start") if hasattr(doc, "get") else getattr(doc, "schedule_start", None),
+		doc.get("schedule_end") if hasattr(doc, "get") else getattr(doc, "schedule_end", None),
+		label=label,
+	)

--- a/lms/lms/test_schedule_utils.py
+++ b/lms/lms/test_schedule_utils.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+import unittest
+from datetime import timedelta
+from unittest.mock import patch
+
+import frappe
+from frappe.utils import now_datetime
+
+from lms.lms.schedule_utils import (
+	assert_within_schedule,
+	get_schedule_block_reason,
+	validate_schedule_fields,
+)
+
+
+class _ScheduleDoc:
+	def __init__(self, enable_scheduling=0, schedule_start=None, schedule_end=None):
+		self.enable_scheduling = enable_scheduling
+		self.schedule_start = schedule_start
+		self.schedule_end = schedule_end
+
+
+class TestScheduleUtils(unittest.TestCase):
+	def test_disabled_schedule_clears_dates(self):
+		doc = _ScheduleDoc(
+			enable_scheduling=0,
+			schedule_start=now_datetime(),
+			schedule_end=now_datetime() + timedelta(days=1),
+		)
+		validate_schedule_fields(doc)
+		self.assertIsNone(doc.schedule_start)
+		self.assertIsNone(doc.schedule_end)
+
+	def test_enabled_requires_start(self):
+		doc = _ScheduleDoc(enable_scheduling=1, schedule_start=None)
+		self.assertRaises(frappe.ValidationError, validate_schedule_fields, doc)
+
+	def test_end_must_be_after_start(self):
+		start = now_datetime()
+		doc = _ScheduleDoc(
+			enable_scheduling=1,
+			schedule_start=start,
+			schedule_end=start - timedelta(hours=1),
+		)
+		self.assertRaises(frappe.ValidationError, validate_schedule_fields, doc)
+
+	def test_valid_window_passes(self):
+		start = now_datetime()
+		doc = _ScheduleDoc(
+			enable_scheduling=1,
+			schedule_start=start,
+			schedule_end=start + timedelta(days=1),
+		)
+		validate_schedule_fields(doc)
+
+	def test_block_reason_not_started(self):
+		start = now_datetime() + timedelta(days=1)
+		self.assertEqual(
+			get_schedule_block_reason(1, start, None),
+			"not_started",
+		)
+
+	def test_block_reason_ended(self):
+		end = now_datetime() - timedelta(hours=1)
+		self.assertEqual(
+			get_schedule_block_reason(1, now_datetime() - timedelta(days=1), end),
+			"ended",
+		)
+
+	def test_block_reason_open_without_end(self):
+		start = now_datetime() - timedelta(hours=1)
+		self.assertIsNone(get_schedule_block_reason(1, start, None))
+
+	def test_assert_within_schedule_throws_before_start(self):
+		start = now_datetime() + timedelta(days=1)
+		with self.assertRaises(frappe.ValidationError):
+			assert_within_schedule(1, start, None, label="Quiz")
+
+
+class TestLMSQuizScheduling(unittest.TestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_quiz_validate_requires_schedule_start(self):
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": f"Schedule Quiz {frappe.generate_hash(length=6)}",
+				"passing_percentage": 50,
+				"enable_scheduling": 1,
+			}
+		)
+		self.assertRaises(frappe.ValidationError, quiz.insert)
+
+	def test_quiz_validate_rejects_end_before_start(self):
+		start = now_datetime()
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": f"Schedule Quiz {frappe.generate_hash(length=6)}",
+				"passing_percentage": 50,
+				"enable_scheduling": 1,
+				"schedule_start": start,
+				"schedule_end": start - timedelta(hours=1),
+			}
+		)
+		self.assertRaises(frappe.ValidationError, quiz.insert)
+
+	def test_submit_quiz_blocked_before_start(self):
+		from lms.lms.doctype.lms_quiz.lms_quiz import submit_quiz
+
+		start = now_datetime() + timedelta(days=2)
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": f"Future Quiz {frappe.generate_hash(length=6)}",
+				"passing_percentage": 50,
+				"enable_scheduling": 1,
+				"schedule_start": start,
+			}
+		).insert(ignore_permissions=True)
+
+		with patch("lms.lms.permissions.can_access_quiz", return_value=True):
+			with self.assertRaises(frappe.ValidationError):
+				submit_quiz(quiz=quiz.name, results="[]")
+
+
+class TestLMSAssignmentScheduling(unittest.TestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_assignment_validate_requires_schedule_start(self):
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": f"Schedule ASG {frappe.generate_hash(length=6)}",
+				"type": "Text",
+				"question": "Answer this",
+				"enable_scheduling": 1,
+			}
+		)
+		self.assertRaises(frappe.ValidationError, assignment.insert)
+
+	def test_assignment_submission_blocked_after_end(self):
+		end = now_datetime() - timedelta(hours=1)
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": f"Ended ASG {frappe.generate_hash(length=6)}",
+				"type": "Text",
+				"question": "Answer this",
+				"enable_scheduling": 1,
+				"schedule_start": end - timedelta(days=1),
+				"schedule_end": end,
+			}
+		).insert(ignore_permissions=True)
+
+		submission = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment Submission",
+				"assignment": assignment.name,
+				"member": frappe.session.user,
+				"type": "Text",
+				"answer": "late answer",
+			}
+		)
+		# Force student path: patch privileged roles empty for this user.
+		with patch(
+			"lms.lms.doctype.lms_assignment_submission.lms_assignment_submission.PRIVILEGED_ROLES",
+			frozenset(),
+		):
+			with patch(
+				"lms.lms.doctype.lms_assignment_submission.lms_assignment_submission.frappe.get_roles",
+				return_value=["LMS Student"],
+			):
+				self.assertRaises(frappe.ValidationError, submission.insert, ignore_permissions=True)

--- a/lms/lms/test_schedule_utils.py
+++ b/lms/lms/test_schedule_utils.py
@@ -6,13 +6,17 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import frappe
-from frappe.utils import now_datetime
+from frappe.utils import get_datetime
 
 from lms.lms.schedule_utils import (
 	assert_within_schedule,
 	get_schedule_block_reason,
 	validate_schedule_fields,
 )
+
+# Fixed wall-clock used for every time-dependent assertion so the suite does
+# not depend on when it runs.
+FIXED_NOW = get_datetime("2026-06-15 12:00:00")
 
 
 class _ScheduleDoc:
@@ -26,8 +30,8 @@ class TestScheduleUtils(unittest.TestCase):
 	def test_disabled_schedule_clears_dates(self):
 		doc = _ScheduleDoc(
 			enable_scheduling=0,
-			schedule_start=now_datetime(),
-			schedule_end=now_datetime() + timedelta(days=1),
+			schedule_start=FIXED_NOW,
+			schedule_end=FIXED_NOW + timedelta(days=1),
 		)
 		validate_schedule_fields(doc)
 		self.assertIsNone(doc.schedule_start)
@@ -38,45 +42,44 @@ class TestScheduleUtils(unittest.TestCase):
 		self.assertRaises(frappe.ValidationError, validate_schedule_fields, doc)
 
 	def test_end_must_be_after_start(self):
-		start = now_datetime()
 		doc = _ScheduleDoc(
 			enable_scheduling=1,
-			schedule_start=start,
-			schedule_end=start - timedelta(hours=1),
+			schedule_start=FIXED_NOW,
+			schedule_end=FIXED_NOW - timedelta(hours=1),
 		)
 		self.assertRaises(frappe.ValidationError, validate_schedule_fields, doc)
 
 	def test_valid_window_passes(self):
-		start = now_datetime()
 		doc = _ScheduleDoc(
 			enable_scheduling=1,
-			schedule_start=start,
-			schedule_end=start + timedelta(days=1),
+			schedule_start=FIXED_NOW,
+			schedule_end=FIXED_NOW + timedelta(days=1),
 		)
 		validate_schedule_fields(doc)
 
 	def test_block_reason_not_started(self):
-		start = now_datetime() + timedelta(days=1)
+		start = FIXED_NOW + timedelta(days=1)
 		self.assertEqual(
-			get_schedule_block_reason(1, start, None),
+			get_schedule_block_reason(1, start, None, now=FIXED_NOW),
 			"not_started",
 		)
 
 	def test_block_reason_ended(self):
-		end = now_datetime() - timedelta(hours=1)
+		end = FIXED_NOW - timedelta(hours=1)
 		self.assertEqual(
-			get_schedule_block_reason(1, now_datetime() - timedelta(days=1), end),
+			get_schedule_block_reason(1, FIXED_NOW - timedelta(days=1), end, now=FIXED_NOW),
 			"ended",
 		)
 
 	def test_block_reason_open_without_end(self):
-		start = now_datetime() - timedelta(hours=1)
-		self.assertIsNone(get_schedule_block_reason(1, start, None))
+		start = FIXED_NOW - timedelta(hours=1)
+		self.assertIsNone(get_schedule_block_reason(1, start, None, now=FIXED_NOW))
 
 	def test_assert_within_schedule_throws_before_start(self):
-		start = now_datetime() + timedelta(days=1)
-		with self.assertRaises(frappe.ValidationError):
-			assert_within_schedule(1, start, None, label="Quiz")
+		start = FIXED_NOW + timedelta(days=1)
+		with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+			with self.assertRaises(frappe.ValidationError):
+				assert_within_schedule(1, start, None, label="Quiz")
 
 
 class TestLMSQuizScheduling(unittest.TestCase):
@@ -95,15 +98,14 @@ class TestLMSQuizScheduling(unittest.TestCase):
 		self.assertRaises(frappe.ValidationError, quiz.insert)
 
 	def test_quiz_validate_rejects_end_before_start(self):
-		start = now_datetime()
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
 				"title": f"Schedule Quiz {frappe.generate_hash(length=6)}",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
-				"schedule_start": start,
-				"schedule_end": start - timedelta(hours=1),
+				"schedule_start": FIXED_NOW,
+				"schedule_end": FIXED_NOW - timedelta(hours=1),
 			}
 		)
 		self.assertRaises(frappe.ValidationError, quiz.insert)
@@ -111,20 +113,61 @@ class TestLMSQuizScheduling(unittest.TestCase):
 	def test_submit_quiz_blocked_before_start(self):
 		from lms.lms.doctype.lms_quiz.lms_quiz import submit_quiz
 
-		start = now_datetime() + timedelta(days=2)
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
 				"title": f"Future Quiz {frappe.generate_hash(length=6)}",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
-				"schedule_start": start,
+				"schedule_start": FIXED_NOW + timedelta(days=2),
 			}
-		).insert(ignore_permissions=True)
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture, seeding the quiz under test
+		quiz.insert(ignore_permissions=True)
 
 		with patch("lms.lms.permissions.can_access_quiz", return_value=True):
-			with self.assertRaises(frappe.ValidationError):
-				submit_quiz(quiz=quiz.name, results="[]")
+			with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+				with self.assertRaises(frappe.ValidationError):
+					submit_quiz(quiz=quiz.name, results="[]")
+
+	def test_get_quiz_withholds_questions_before_start(self):
+		from lms.lms.utils import get_quiz_with_questions
+
+		question = frappe.get_doc(
+			{
+				"doctype": "LMS Question",
+				"question": "Secret prompt",
+				"type": "Choices",
+				"option_1": "A",
+				"is_correct_1": 1,
+				"option_2": "B",
+				"is_correct_2": 0,
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture
+		question.insert(ignore_permissions=True)
+
+		quiz = frappe.get_doc(
+			{
+				"doctype": "LMS Quiz",
+				"title": f"Future Quiz {frappe.generate_hash(length=6)}",
+				"passing_percentage": 50,
+				"enable_scheduling": 1,
+				"schedule_start": FIXED_NOW + timedelta(days=2),
+				"questions": [{"question": question.name, "marks": 1}],
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture
+		quiz.insert(ignore_permissions=True)
+
+		with patch("lms.lms.permissions.can_access_quiz", return_value=True):
+			with patch("lms.lms.utils.PRIVILEGED_ROLES", frozenset()):
+				with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+					payload = get_quiz_with_questions(quiz.name)
+
+		self.assertEqual(payload["quiz"]["schedule_block_reason"], "not_started")
+		self.assertEqual(payload["quiz"]["questions"], [])
+		self.assertEqual(payload["questions_by_name"], {})
 
 
 class TestLMSAssignmentScheduling(unittest.TestCase):
@@ -144,7 +187,6 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 		self.assertRaises(frappe.ValidationError, assignment.insert)
 
 	def test_assignment_submission_blocked_after_end(self):
-		end = now_datetime() - timedelta(hours=1)
 		assignment = frappe.get_doc(
 			{
 				"doctype": "LMS Assignment",
@@ -152,10 +194,12 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 				"type": "Text",
 				"question": "Answer this",
 				"enable_scheduling": 1,
-				"schedule_start": end - timedelta(days=1),
-				"schedule_end": end,
+				"schedule_start": FIXED_NOW - timedelta(days=1),
+				"schedule_end": FIXED_NOW - timedelta(hours=1),
 			}
-		).insert(ignore_permissions=True)
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture, seeding the assignment under test
+		assignment.insert(ignore_permissions=True)
 
 		submission = frappe.get_doc(
 			{
@@ -175,4 +219,28 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 				"lms.lms.doctype.lms_assignment_submission.lms_assignment_submission.frappe.get_roles",
 				return_value=["LMS Student"],
 			):
-				self.assertRaises(frappe.ValidationError, submission.insert, ignore_permissions=True)
+				with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+					with self.assertRaises(frappe.ValidationError):
+						# nosemgrep: lms-unjustified-ignore-permissions - exercise validate, not DocPerm
+						submission.insert(ignore_permissions=True)
+
+	def test_get_assignment_includes_schedule_block_reason(self):
+		from lms.lms.utils import get_assignment
+
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": f"Future ASG {frappe.generate_hash(length=6)}",
+				"type": "Text",
+				"question": "Answer this",
+				"enable_scheduling": 1,
+				"schedule_start": FIXED_NOW + timedelta(days=1),
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture
+		assignment.insert(ignore_permissions=True)
+
+		with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+			payload = get_assignment(assignment.name)
+
+		self.assertEqual(payload["schedule_block_reason"], "not_started")

--- a/lms/lms/test_schedule_utils.py
+++ b/lms/lms/test_schedule_utils.py
@@ -4,12 +4,15 @@
 import unittest
 from datetime import timedelta
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import frappe
-from frappe.utils import get_datetime
+from frappe.utils import get_datetime, get_system_timezone
 
 from lms.lms.schedule_utils import (
 	assert_within_schedule,
+	datetime_to_iso,
+	enrich_schedule_payload,
 	get_schedule_block_reason,
 	validate_schedule_fields,
 )
@@ -81,6 +84,25 @@ class TestScheduleUtils(unittest.TestCase):
 			with self.assertRaises(frappe.ValidationError):
 				assert_within_schedule(1, start, None, label="Quiz")
 
+	def test_datetime_to_iso_uses_system_timezone(self):
+		iso = datetime_to_iso(FIXED_NOW)
+		self.assertTrue(iso.startswith("2026-06-15T12:00:00"))
+		aware = get_datetime(FIXED_NOW).replace(tzinfo=ZoneInfo(get_system_timezone()))
+		self.assertEqual(iso, aware.isoformat())
+
+	def test_enrich_schedule_payload_adds_iso_and_reason(self):
+		with patch("lms.lms.schedule_utils.now_datetime", return_value=FIXED_NOW):
+			payload = enrich_schedule_payload(
+				{
+					"enable_scheduling": 1,
+					"schedule_start": FIXED_NOW + timedelta(days=1),
+					"schedule_end": None,
+				}
+			)
+		self.assertEqual(payload["schedule_block_reason"], "not_started")
+		self.assertTrue(payload["schedule_start_iso"].startswith("2026-06-16T12:00:00"))
+		self.assertIsNone(payload["schedule_end_iso"])
+
 
 class TestLMSQuizScheduling(unittest.TestCase):
 	def tearDown(self):
@@ -90,7 +112,7 @@ class TestLMSQuizScheduling(unittest.TestCase):
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
-				"title": f"Schedule Quiz {frappe.generate_hash(length=6)}",
+				"title": "Schedule Quiz Missing Start",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
 			}
@@ -101,7 +123,7 @@ class TestLMSQuizScheduling(unittest.TestCase):
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
-				"title": f"Schedule Quiz {frappe.generate_hash(length=6)}",
+				"title": "Schedule Quiz End Before Start",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
 				"schedule_start": FIXED_NOW,
@@ -116,7 +138,7 @@ class TestLMSQuizScheduling(unittest.TestCase):
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
-				"title": f"Future Quiz {frappe.generate_hash(length=6)}",
+				"title": "Schedule Quiz Submit Before Start",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
 				"schedule_start": FIXED_NOW + timedelta(days=2),
@@ -150,7 +172,7 @@ class TestLMSQuizScheduling(unittest.TestCase):
 		quiz = frappe.get_doc(
 			{
 				"doctype": "LMS Quiz",
-				"title": f"Future Quiz {frappe.generate_hash(length=6)}",
+				"title": "Schedule Quiz Withhold Questions",
 				"passing_percentage": 50,
 				"enable_scheduling": 1,
 				"schedule_start": FIXED_NOW + timedelta(days=2),
@@ -166,6 +188,7 @@ class TestLMSQuizScheduling(unittest.TestCase):
 					payload = get_quiz_with_questions(quiz.name)
 
 		self.assertEqual(payload["quiz"]["schedule_block_reason"], "not_started")
+		self.assertTrue(payload["quiz"]["schedule_start_iso"].startswith("2026-06-17T12:00:00"))
 		self.assertEqual(payload["quiz"]["questions"], [])
 		self.assertEqual(payload["questions_by_name"], {})
 
@@ -178,7 +201,7 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 		assignment = frappe.get_doc(
 			{
 				"doctype": "LMS Assignment",
-				"title": f"Schedule ASG {frappe.generate_hash(length=6)}",
+				"title": "Schedule Assignment Missing Start",
 				"type": "Text",
 				"question": "Answer this",
 				"enable_scheduling": 1,
@@ -190,7 +213,7 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 		assignment = frappe.get_doc(
 			{
 				"doctype": "LMS Assignment",
-				"title": f"Ended ASG {frappe.generate_hash(length=6)}",
+				"title": "Schedule Assignment Ended Window",
 				"type": "Text",
 				"question": "Answer this",
 				"enable_scheduling": 1,
@@ -230,7 +253,7 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 		assignment = frappe.get_doc(
 			{
 				"doctype": "LMS Assignment",
-				"title": f"Future ASG {frappe.generate_hash(length=6)}",
+				"title": "Schedule Assignment Future Window",
 				"type": "Text",
 				"question": "Answer this",
 				"enable_scheduling": 1,
@@ -244,3 +267,26 @@ class TestLMSAssignmentScheduling(unittest.TestCase):
 			payload = get_assignment(assignment.name)
 
 		self.assertEqual(payload["schedule_block_reason"], "not_started")
+		self.assertTrue(payload["schedule_start_iso"].startswith("2026-06-16T12:00:00"))
+
+	def test_get_assignment_requires_read_permission(self):
+		from lms.lms.utils import get_assignment
+
+		assignment = frappe.get_doc(
+			{
+				"doctype": "LMS Assignment",
+				"title": "Schedule Assignment Permission Check",
+				"type": "Text",
+				"question": "Answer this",
+				"enable_scheduling": 0,
+			}
+		)
+		# nosemgrep: lms-unjustified-ignore-permissions - test fixture
+		assignment.insert(ignore_permissions=True)
+
+		with patch.object(
+			frappe.model.document.Document,
+			"check_permission",
+			side_effect=frappe.PermissionError,
+		):
+			self.assertRaises(frappe.PermissionError, get_assignment, assignment.name)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1750,12 +1750,19 @@ def get_country_code():
 
 @frappe.whitelist()
 def get_quiz_with_questions(quiz: str) -> dict:
-	"""Return the quiz doc plus every question's details in a single round trip."""
+	"""Return the quiz doc plus every question's details in a single round trip.
+
+	When scheduling blocks the quiz for a non-privileged user, question content
+	is withheld so learners cannot inspect it before the window opens (or after
+	it ends). Metadata including ``schedule_block_reason`` is still returned so
+	the UI can show the availability message.
+	"""
 	from lms.lms.doctype.lms_question.lms_question import (
 		QUESTION_EXPLANATION_FIELDS,
 		QUESTION_OPTION_FIELDS,
 	)
 	from lms.lms.permissions import can_access_quiz
+	from lms.lms.schedule_utils import get_schedule_block_reason
 
 	if not isinstance(quiz, str):
 		frappe.throw(_("Quiz must be a string."))
@@ -1767,27 +1774,61 @@ def get_quiz_with_questions(quiz: str) -> dict:
 		frappe.throw(_("You are not authorized to view this quiz."), frappe.PermissionError)
 
 	quiz_doc = frappe.get_doc("LMS Quiz", quiz).as_dict()
+	reason = get_schedule_block_reason(
+		quiz_doc.get("enable_scheduling"),
+		quiz_doc.get("schedule_start"),
+		quiz_doc.get("schedule_end"),
+	)
+	quiz_doc["schedule_block_reason"] = reason
 
-	question_names = [row.get("question") for row in quiz_doc.get("questions") or [] if row.get("question")]
+	privileged = bool(PRIVILEGED_ROLES & set(frappe.get_roles()))
+	withhold_questions = bool(reason) and not privileged
+
 	questions_by_name = {}
-	if question_names:
-		fields = [
-			"name",
-			"question",
-			"type",
-			"multiple",
-			*QUESTION_OPTION_FIELDS,
-			*QUESTION_EXPLANATION_FIELDS,
+	if withhold_questions:
+		# Child rows only hold question names / marks; clearing them plus the
+		# detail map keeps prompt/options out of the response entirely.
+		quiz_doc["questions"] = []
+	else:
+		question_names = [
+			row.get("question") for row in quiz_doc.get("questions") or [] if row.get("question")
 		]
-		rows = frappe.get_all(
-			"LMS Question",
-			filters=[["name", "in", question_names]],
-			fields=fields,
-			ignore_permissions=True,
-		)
-		questions_by_name = {row["name"]: row for row in rows}
+		if question_names:
+			fields = [
+				"name",
+				"question",
+				"type",
+				"multiple",
+				*QUESTION_OPTION_FIELDS,
+				*QUESTION_EXPLANATION_FIELDS,
+			]
+			rows = frappe.get_all(
+				"LMS Question",
+				filters=[["name", "in", question_names]],
+				fields=fields,
+				# nosemgrep: lms-unjustified-ignore-permissions - access gated by can_access_quiz above
+				ignore_permissions=True,
+			)
+			questions_by_name = {row["name"]: row for row in rows}
 
 	return {"quiz": quiz_doc, "questions_by_name": questions_by_name}
+
+
+@frappe.whitelist()
+def get_assignment(name: str) -> dict:
+	"""Return an LMS Assignment with a server-computed schedule_block_reason."""
+	from lms.lms.schedule_utils import get_schedule_block_reason
+
+	if not isinstance(name, str):
+		frappe.throw(_("Assignment must be a string."))
+
+	assignment = frappe.get_doc("LMS Assignment", name).as_dict()
+	assignment["schedule_block_reason"] = get_schedule_block_reason(
+		assignment.get("enable_scheduling"),
+		assignment.get("schedule_start"),
+		assignment.get("schedule_end"),
+	)
+	return assignment
 
 
 @frappe.whitelist(allow_guest=True)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1762,7 +1762,7 @@ def get_quiz_with_questions(quiz: str) -> dict:
 		QUESTION_OPTION_FIELDS,
 	)
 	from lms.lms.permissions import can_access_quiz
-	from lms.lms.schedule_utils import get_schedule_block_reason
+	from lms.lms.schedule_utils import enrich_schedule_payload
 
 	if not isinstance(quiz, str):
 		frappe.throw(_("Quiz must be a string."))
@@ -1773,13 +1773,8 @@ def get_quiz_with_questions(quiz: str) -> dict:
 		)
 		frappe.throw(_("You are not authorized to view this quiz."), frappe.PermissionError)
 
-	quiz_doc = frappe.get_doc("LMS Quiz", quiz).as_dict()
-	reason = get_schedule_block_reason(
-		quiz_doc.get("enable_scheduling"),
-		quiz_doc.get("schedule_start"),
-		quiz_doc.get("schedule_end"),
-	)
-	quiz_doc["schedule_block_reason"] = reason
+	quiz_doc = enrich_schedule_payload(frappe.get_doc("LMS Quiz", quiz).as_dict())
+	reason = quiz_doc.get("schedule_block_reason")
 
 	privileged = bool(PRIVILEGED_ROLES & set(frappe.get_roles()))
 	withhold_questions = bool(reason) and not privileged
@@ -1802,11 +1797,11 @@ def get_quiz_with_questions(quiz: str) -> dict:
 				*QUESTION_OPTION_FIELDS,
 				*QUESTION_EXPLANATION_FIELDS,
 			]
+			# nosemgrep: lms-unjustified-ignore-permissions - access gated by can_access_quiz above
 			rows = frappe.get_all(
 				"LMS Question",
 				filters=[["name", "in", question_names]],
 				fields=fields,
-				# nosemgrep: lms-unjustified-ignore-permissions - access gated by can_access_quiz above
 				ignore_permissions=True,
 			)
 			questions_by_name = {row["name"]: row for row in rows}
@@ -1816,19 +1811,20 @@ def get_quiz_with_questions(quiz: str) -> dict:
 
 @frappe.whitelist()
 def get_assignment(name: str) -> dict:
-	"""Return an LMS Assignment with a server-computed schedule_block_reason."""
-	from lms.lms.schedule_utils import get_schedule_block_reason
+	"""Return an LMS Assignment with a server-computed schedule_block_reason.
+
+	Mirrors ``frappe.client.get`` permission checks so callers cannot bypass
+	DocPerm by hitting this whitelist directly.
+	"""
+	from lms.lms.schedule_utils import enrich_schedule_payload
 
 	if not isinstance(name, str):
 		frappe.throw(_("Assignment must be a string."))
 
-	assignment = frappe.get_doc("LMS Assignment", name).as_dict()
-	assignment["schedule_block_reason"] = get_schedule_block_reason(
-		assignment.get("enable_scheduling"),
-		assignment.get("schedule_start"),
-		assignment.get("schedule_end"),
-	)
-	return assignment
+	doc = frappe.get_doc("LMS Assignment", name)
+	doc.check_permission("read")
+	doc.apply_fieldlevel_read_permissions()
+	return enrich_schedule_payload(doc.as_dict())
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
## Summary
- Add opt-in **Enable Scheduling** on **LMS Quiz** and **LMS Assignment**
- When enabled, **Schedule Start** is required and **Schedule End** is optional
- Learners cannot start/submit before start; if end is set, they cannot start/submit after end
- Enforced in the UI and on the server (`submit_quiz` / assignment submission validate)
- Shared helpers in `lms/lms/schedule_utils.py` (+ tests)

## Motivation
Instructors need a simple availability window so quizzes and assignments are only attemptable during a defined period, without relying on manual open/close.

## Screenshots

### Author — Quiz settings
<!-- Enable Scheduling + Start / End fields on the quiz form -->
<img width="1278" height="770" alt="Screenshot 2026-09-10 at 12 20 03 PM" src="https://github.com/user-attachments/assets/59684ddb-2985-43e3-b1cd-1d595bee6db1" />

### Author — Assignment form
<!-- Same scheduling controls on the assignment form -->
<img width="523" height="739" alt="Screenshot 2026-09-10 at 12 20 38 PM" src="https://github.com/user-attachments/assets/ca30c9b9-b7c6-48b8-90bf-f76310a63f84" />


### Learner — Quiz before start
<!-- Start blocked with “This quiz opens on …” -->
<img width="1288" height="773" alt="Screenshot 2026-09-10 at 12 21 23 PM" src="https://github.com/user-attachments/assets/3c1122c9-7af1-4365-9966-46ec53edf589" />


### Learner — Quiz after end (optional end set)
<!-- Start blocked with “The schedule for this quiz has ended.” -->
<img width="1287" height="768" alt="Screenshot 2026-09-10 at 12 22 18 PM" src="https://github.com/user-attachments/assets/9a8c2483-02ae-429d-becc-e4cc936d8bea" />


### Learner — Assignment outside window
<!-- Submit/upload blocked with the schedule message -->
<img width="1298" height="778" alt="Screenshot 2026-09-10 at 12 43 13 PM" src="https://github.com/user-attachments/assets/e323a7a3-daab-4ce4-a6a8-90fcddd2838a" />


## Test plan
- [ ] Scheduling off → quiz/assignment behave as before
- [ ] Scheduling on, missing start → save rejected
- [ ] End ≤ start → save rejected
- [ ] Before start → learner cannot start quiz / submit assignment
- [ ] After end → learner cannot start quiz / submit assignment
- [ ] No end date → remains open after start
- [ ] Student submit API blocked outside window; privileged grading still works