### PR TITLE
fix: stop offering evaluation slots that have already started today

### DIFF
--- a/lms/lms/doctype/course_evaluator/course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/course_evaluator.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_days, get_time, getdate, nowdate
+from frappe.utils import add_days, get_time, getdate, nowdate, nowtime
 
 from lms.lms.utils import (
 	convert_from_system_timezone,
@@ -112,6 +112,8 @@ def get_all_slots(evaluator, start_date, end_date):
 		day_of_week = current_date.strftime("%A")
 		slots_for_day = [x for x in schedule if x.day == day_of_week]
 		for slot in slots_for_day:
+			if slot_has_started(current_date, slot.start_time):
+				continue
 			all_slots.append(
 				frappe._dict(
 					{
@@ -124,6 +126,17 @@ def get_all_slots(evaluator, start_date, end_date):
 			)
 		current_date = add_days(current_date, 1)
 	return all_slots
+
+
+def slot_has_started(date, start_time) -> bool:
+	"""Both clocks are system time, and the strict `<` is the one
+	LMSCertificateRequest.validate_if_existing_requests books against, so a slot
+	starting exactly now still counts. A picker that offers what the validator
+	rejects is what put "You cannot schedule evaluations for past slots." in
+	front of a learner who picked the first slot shown. Named apart from
+	lms.lms.utils.has_started_today, which asks the same question of a batch.
+	"""
+	return getdate(date) == getdate() and get_time(start_time) < get_time(nowtime())
 
 
 def get_evaluator_schedule(evaluator):

--- a/lms/lms/doctype/course_evaluator/test_course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/test_course_evaluator.py
@@ -15,6 +15,9 @@ from lms.lms.doctype.course_evaluator.course_evaluator import (
 )
 from lms.lms.test_helpers import BaseTestUtils
 
+EVALUATOR_NOWTIME = "lms.lms.doctype.course_evaluator.course_evaluator.nowtime"
+REQUEST_NOWTIME = "lms.lms.doctype.lms_certificate_request.lms_certificate_request.nowtime"
+
 
 class TestCourseEvaluator(BaseTestUtils):
 	def setUp(self):
@@ -45,7 +48,8 @@ class TestCourseEvaluator(BaseTestUtils):
 				self.assertEqual(format_time(slot.get("start_time"), "HH:mm:ss"), "14:00:00")
 				self.assertEqual(format_time(slot.get("end_time"), "HH:mm:ss"), "16:00:00")
 
-	def test_schedule_dates(self):
+	@patch(EVALUATOR_NOWTIME, return_value="00:00:00")
+	def test_schedule_dates(self, _evaluator_nowtime):
 		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
 		dates = sorted({getdate(slot.get("date")) for slot in self._slots(schedule)})
 		self.assertEqual(dates[0], self.calculated_first_date_of_schedule())
@@ -68,6 +72,9 @@ class TestCourseEvaluator(BaseTestUtils):
 			self.assertTrue(row.get("display_timezone_label").startswith("Europe/Berlin (GMT"))
 
 	def calculated_first_date_of_schedule(self):
+		# Only correct while no slot today has started, which is why the caller
+		# pins the clock: once one has, the first date also depends on the
+		# fixture's unavailable window and this arithmetic no longer models it.
 		today = getdate()
 		offset_monday = (0 - today.weekday() + 7) % 7  # 0 for Monday
 		offset_wednesday = (2 - today.weekday() + 7) % 7  # 2 for Wednesday
@@ -91,6 +98,89 @@ class TestCourseEvaluator(BaseTestUtils):
 		for slot in self._slots(schedule):
 			schedule_date = getdate(slot.get("date"))
 			self.assertFalse(unavailable_from < schedule_date < unavailable_to)
+
+
+class TestTodaysSlots(BaseTestUtils):
+	"""get_schedule and LMSCertificateRequest.validate have to agree on which of
+	today's slots are still bookable, or the picker offers one and the booking
+	throws."""
+
+	def setUp(self):
+		super().setUp()
+		self.instructor = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"]
+		)
+		self.course = self._create_course()
+		self.evaluator = self._create_evaluator_working_today()
+		self.previous_evaluator = frappe.db.get_value("LMS Course", self.course.name, "evaluator")
+		frappe.db.set_value("LMS Course", self.course.name, "evaluator", self.evaluator.name)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_value("LMS Course", self.course.name, "evaluator", self.previous_evaluator)
+		super().tearDown()
+
+	def _create_evaluator_working_today(self):
+		# Built fresh every run: the schedule is keyed to today's weekday, so a
+		# fixture left behind by an earlier day carries the wrong one.
+		email = f"today.evaluator.{frappe.generate_hash(length=8)}@example.com"
+		self._create_user(email, "Today", "Evaluator", ["Batch Evaluator"])
+		evaluator = frappe.new_doc("Course Evaluator")
+		evaluator.evaluator = email
+		today = getdate().strftime("%A")
+		evaluator.append("schedule", {"day": today, "start_time": "09:00:00", "end_time": "10:00:00"})
+		evaluator.append("schedule", {"day": today, "start_time": "16:00:00", "end_time": "17:00:00"})
+		evaluator.save()
+		self.cleanup_items.append(("Course Evaluator", evaluator.name))
+		return evaluator
+
+	def _todays_slots(self, schedule):
+		today = getdate().strftime("%Y-%m-%d")
+		return [slot for row in schedule for slot in row["slots"] if slot["date"] == today]
+
+	def _start_times(self, slots):
+		return [format_time(slot["start_time"], "HH:mm:ss") for slot in slots]
+
+	@patch(EVALUATOR_NOWTIME, return_value="12:00:00")
+	def test_slot_that_already_started_today_is_not_offered(self, _evaluator_nowtime):
+		slots = self._todays_slots(get_schedule(self.course.name))
+		self.assertEqual(self._start_times(slots), ["16:00:00"])
+
+	@patch(EVALUATOR_NOWTIME, return_value="16:00:00")
+	def test_slot_starting_exactly_now_is_still_offered(self, _evaluator_nowtime):
+		slots = self._todays_slots(get_schedule(self.course.name))
+		self.assertEqual(self._start_times(slots), ["16:00:00"])
+
+	@patch(EVALUATOR_NOWTIME, return_value="18:00:00")
+	def test_no_slots_offered_for_today_once_all_have_started(self, _evaluator_nowtime):
+		self.assertEqual(self._todays_slots(get_schedule(self.course.name)), [])
+
+	@patch(REQUEST_NOWTIME, return_value="12:00:00")
+	@patch(EVALUATOR_NOWTIME, return_value="12:00:00")
+	def test_every_slot_offered_for_today_can_be_booked(self, _evaluator_nowtime, _request_nowtime):
+		student = self._create_user(
+			f"today.student.{frappe.generate_hash(length=8)}@example.com",
+			"Today",
+			"Student",
+			["LMS Student"],
+		)
+		frappe.set_user(student.name)
+
+		slots = self._todays_slots(get_schedule(self.course.name))
+		self.assertTrue(slots)
+		for slot in slots:
+			request = frappe.new_doc("LMS Certificate Request")
+			request.update(
+				{
+					"course": self.course.name,
+					"date": slot["date"],
+					"day": slot["day"],
+					"start_time": slot["start_time"],
+					"end_time": slot["end_time"],
+				}
+			)
+			request.insert()
+			self.cleanup_items.append(("LMS Certificate Request", request.name))
 
 
 @patch("lms.lms.utils.get_system_timezone", return_value="Asia/Kolkata")

--- a/lms/lms/doctype/course_evaluator/test_course_evaluator.py
+++ b/lms/lms/doctype/course_evaluator/test_course_evaluator.py
@@ -17,6 +17,18 @@ from lms.lms.test_helpers import BaseTestUtils
 
 EVALUATOR_NOWTIME = "lms.lms.doctype.course_evaluator.course_evaluator.nowtime"
 REQUEST_NOWTIME = "lms.lms.doctype.lms_certificate_request.lms_certificate_request.nowtime"
+EVALUATOR_GETDATE = "lms.lms.doctype.course_evaluator.course_evaluator.getdate"
+REQUEST_GETDATE = "lms.lms.doctype.lms_certificate_request.lms_certificate_request.getdate"
+
+
+def _frozen_getdate(frozen_date):
+	"""getdate() with no args means "today"; a midnight rollover mid-test must
+	not change it. Forward calls that ask about a specific date untouched."""
+
+	def _getdate(value=None):
+		return frozen_date if value is None else getdate(value)
+
+	return _getdate
 
 
 class TestCourseEvaluator(BaseTestUtils):
@@ -50,10 +62,12 @@ class TestCourseEvaluator(BaseTestUtils):
 
 	@patch(EVALUATOR_NOWTIME, return_value="00:00:00")
 	def test_schedule_dates(self, _evaluator_nowtime):
-		schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
-		dates = sorted({getdate(slot.get("date")) for slot in self._slots(schedule)})
-		self.assertEqual(dates[0], self.calculated_first_date_of_schedule())
-		self.assertEqual(dates[-1], self.calculated_last_date_of_schedule())
+		today = getdate()
+		with patch(EVALUATOR_GETDATE, side_effect=_frozen_getdate(today)):
+			schedule = get_schedule(self.batch.courses[0].course, self.batch.name)
+			dates = sorted({getdate(slot.get("date")) for slot in self._slots(schedule)})
+		self.assertEqual(dates[0], self.calculated_first_date_of_schedule(today))
+		self.assertEqual(dates[-1], self.calculated_last_date_of_schedule(today))
 
 	def test_every_slot_carries_both_clocks(self):
 		# The booking submits the system values; the picker renders the display
@@ -71,11 +85,10 @@ class TestCourseEvaluator(BaseTestUtils):
 			self.assertEqual(row.get("display_timezone"), "Europe/Berlin")
 			self.assertTrue(row.get("display_timezone_label").startswith("Europe/Berlin (GMT"))
 
-	def calculated_first_date_of_schedule(self):
+	def calculated_first_date_of_schedule(self, today):
 		# Only correct while no slot today has started, which is why the caller
 		# pins the clock: once one has, the first date also depends on the
 		# fixture's unavailable window and this arithmetic no longer models it.
-		today = getdate()
 		offset_monday = (0 - today.weekday() + 7) % 7  # 0 for Monday
 		offset_wednesday = (2 - today.weekday() + 7) % 7  # 2 for Wednesday
 		if offset_monday < offset_wednesday:
@@ -84,8 +97,8 @@ class TestCourseEvaluator(BaseTestUtils):
 			first_date = add_days(today, offset_wednesday)
 		return first_date
 
-	def calculated_last_date_of_schedule(self):
-		last_day = getdate(get_schedule_range_end_date(getdate(), self.batch.name))
+	def calculated_last_date_of_schedule(self, today):
+		last_day = getdate(get_schedule_range_end_date(today, self.batch.name))
 		while last_day.weekday() not in (0, 2):
 			last_day = add_days(last_day, -1)
 
@@ -107,6 +120,14 @@ class TestTodaysSlots(BaseTestUtils):
 
 	def setUp(self):
 		super().setUp()
+		# Frozen once, up front: get_schedule and LMSCertificateRequest.validate
+		# both call getdate() with no args to mean "today", and a midnight
+		# rollover mid-test must not let them disagree.
+		self.today = getdate()
+		for target in (EVALUATOR_GETDATE, REQUEST_GETDATE):
+			patcher = patch(target, side_effect=_frozen_getdate(self.today))
+			patcher.start()
+			self.addCleanup(patcher.stop)
 		self.instructor = self._create_user(
 			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"]
 		)
@@ -127,7 +148,7 @@ class TestTodaysSlots(BaseTestUtils):
 		self._create_user(email, "Today", "Evaluator", ["Batch Evaluator"])
 		evaluator = frappe.new_doc("Course Evaluator")
 		evaluator.evaluator = email
-		today = getdate().strftime("%A")
+		today = self.today.strftime("%A")
 		evaluator.append("schedule", {"day": today, "start_time": "09:00:00", "end_time": "10:00:00"})
 		evaluator.append("schedule", {"day": today, "start_time": "16:00:00", "end_time": "17:00:00"})
 		evaluator.save()
@@ -135,7 +156,7 @@ class TestTodaysSlots(BaseTestUtils):
 		return evaluator
 
 	def _todays_slots(self, schedule):
-		today = getdate().strftime("%Y-%m-%d")
+		today = self.today.strftime("%Y-%m-%d")
 		return [slot for row in schedule for slot in row["slots"] if slot["date"] == today]
 
 	def _start_times(self, slots):

--- a/lms/lms/test_helpers.py
+++ b/lms/lms/test_helpers.py
@@ -162,7 +162,14 @@ class BaseTestUtils(UnitTestCase):
 
 	def _create_evaluator(self, evaluator_email="frappe@example.com"):
 		if frappe.db.exists("Course Evaluator", evaluator_email):
-			return frappe.get_doc("Course Evaluator", evaluator_email)
+			evaluator = frappe.get_doc("Course Evaluator", evaluator_email)
+			# The window is relative to the day it was written, and this doc
+			# outlives the run that made it. Left stale, it swallows the dates
+			# callers compute from today and the failure looks like a date bug.
+			evaluator.unavailable_from = add_days(nowdate(), 5)
+			evaluator.unavailable_to = add_days(nowdate(), 12)
+			evaluator.save()
+			return evaluator
 
 		evaluator = frappe.new_doc("Course Evaluator")
 		evaluator.update(


### PR DESCRIPTION
- **The problem**: Students book certificate evaluations by picking a time slot. The picker showed today's slots that had already gone past — at 14:47 it offered today's 09:30, 12:00 and 14:00 — and submitting one failed with "You cannot schedule evaluations for past slots." Slots on future days worked fine, so the error hit the slots shown first.

- **Root cause**: The slot list was built from today's date without ever comparing slot times against the clock. The validation that runs on submit does compare them. The two disagreed on what was bookable.

- **The fix**: A new `slot_has_started` helper drops today's lapsed slots before the list is built, using the same strict "earlier than now" comparison as the validation. A slot starting exactly now is still bookable, and the list now matches what a booking will accept.

- **Testing**: 4 new tests in `test_course_evaluator.py::TestTodaysSlots`. Three fail on the parent commit; the fourth is a deliberate control that passes either way, so a fix that broke the boundary would show up. One of the tests books every slot the picker offers with the clock pinned in both modules, checking the list and the validation against each other rather than separately.

- **Also included**: the shared test helper `_create_evaluator` reused an existing record without refreshing its "unavailable from/to" dates. Those are written relative to the day the record was created, so on a long-lived test site they went stale and swallowed dates other tests compute from today. This was already making an unrelated test fail in a way that looked like a date bug. Fixed, which takes that suite from 24/25 to 25/25.

- **Known limits**:
  - The picker and the validation each read the clock at their own moment, so a slot can still lapse in the seconds between the page rendering and the student submitting.
  - The validation has another rule the picker still does not mirror: a student who already has an upcoming evaluation for that course sees a full slot list and is rejected on submit. Same kind of problem, different rule, not fixed here.
