### PR TITLE
fix: let a student reach the evaluation scheduler on a course

### DIFF
--- a/frontend/src/pages/Courses/CourseCertification.vue
+++ b/frontend/src/pages/Courses/CourseCertification.vue
@@ -2,7 +2,7 @@
 	<PageHeader :breadcrumbs="breadcrumbs" />
 	<PageBody :title="__('Certification')">
 		<div class="px-5 pb-5">
-			<div v-if="certificate.data && Object.keys(certificate.data).length">
+			<div v-if="certificate">
 				<div class="text-ink-gray-9 text-sm">
 					{{
 						__(
@@ -13,14 +13,14 @@
 				<button
 					type="button"
 					class="border p-3 w-fit min-w-60 rounded-md space-y-2 hover:bg-surface-gray-1 cursor-pointer mt-5 text-start block"
-					@click="openCertificate(certificate.data)"
+					@click="openCertificate"
 				>
 					<div class="text-ink-gray-9 font-semibold">
 						{{ courseTitle }}
 					</div>
 					<div class="text-sm-medium text-ink-gray-7">
 						{{ __('Issued On') }}:
-						{{ dayjs(certificate.data.issue_date).format('DD MMM YYYY') }}
+						{{ dayjs(certificate.issue_date).format('DD MMM YYYY') }}
 					</div>
 				</button>
 			</div>
@@ -30,93 +30,91 @@
 		</div>
 	</PageBody>
 </template>
-<script setup>
-import { computed, inject, onMounted, ref } from 'vue'
+<script setup lang="ts">
+import { computed, inject, watch } from 'vue'
 import PageHeader from '@/components/Layouts/pages/PageHeader.vue'
 import PageBody from '@/components/Layouts/pages/PageBody.vue'
-import { call, createResource, usePageMeta } from 'frappe-ui'
+import { createResource, toast, usePageMeta } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 import { sessionStore } from '../../stores/session'
 import UpcomingEvaluations from '@/components/UpcomingEvaluations.vue'
 import { openExternal } from '@/utils/openExternal'
+import { resourceErrorMessage } from '@/utils/resource'
+import type dayjsType from 'dayjs'
+import type { CertificationInfo, Resource, SessionUser } from '@/types'
 
-const courseTitle = ref(null)
-const evaluator = ref(null)
 const { brand } = sessionStore()
-const courses = ref([])
-const user = inject('$user')
-const dayjs = inject('$dayjs')
+const user = inject<SessionUser>('$user')!
+const dayjs = inject<typeof dayjsType>('$dayjs')!
 const router = useRouter()
 
-const props = defineProps({
-	courseName: {
-		type: String,
-		required: true,
+const props = defineProps<{ courseName: string }>()
+
+/* One call for the title, the evaluator, the enrollment and the certificate:
+   LMS Student cannot read LMS Course, so fetching the title and evaluator
+   through frappe.client.get_value 403s for the learner this page is for. */
+const certification = createResource({
+	url: 'lms.lms.api.get_certification_details',
+	makeParams() {
+		return { course: props.courseName }
 	},
-})
-
-onMounted(() => {
-	fetchEnrollmentDetails()
-	fetchCourseDetails()
-})
-
-const certificate = createResource({
-	url: 'frappe.client.get_value',
-	params: {
-		doctype: 'LMS Certificate',
-		filters: {
-			member: user.data?.name,
-			course: props.courseName,
-		},
-		fieldname: ['name', 'template', 'issue_date'],
-	},
-	cache: [user.data?.name, props.courseName],
-})
-
-const fetchEnrollmentDetails = () => {
-	call('frappe.client.get_value', {
-		doctype: 'LMS Enrollment',
-		filters: { member: user.data?.name, course: props.courseName },
-		fieldname: ['purchased_certificate'],
-	}).then((data) => {
-		if (data.purchased_certificate) {
-			certificate.reload()
-		} else {
+	auto: false,
+	onSuccess(data: CertificationInfo | null) {
+		if (!data?.membership?.purchased_certificate) {
 			router.push({
 				name: 'CourseDetail',
 				params: { courseName: props.courseName },
 			})
 		}
-	})
+	},
+	onError(error: unknown) {
+		toast.error(
+			resourceErrorMessage(error, __('Could not load this certification.'))
+		)
+	},
+}) as Resource<CertificationInfo | null>
+
+/* auto: user.data ? true : false evaluates once, at setup, so a load reaching
+   here before userResource resolves locked auto false forever. Fetch once
+   user.data arrives; a guest whose data never arrives never fires this route. */
+if (user.data) {
+	certification.fetch()
+} else {
+	const stopUserWatch = watch(
+		() => user.data,
+		(data) => {
+			if (data) {
+				certification.fetch()
+				stopUserWatch()
+			}
+		}
+	)
 }
 
-const fetchCourseDetails = () => {
-	call('frappe.client.get_value', {
-		doctype: 'LMS Course',
-		filters: { name: props.courseName },
-		fieldname: ['title', 'evaluator'],
-	}).then((data) => {
-		courseTitle.value = data.title
-		evaluator.value = data.evaluator
-		populateCourses()
-	})
-}
+const certificate = computed(() => certification.data?.certificate)
+const courseTitle = computed(() => certification.data?.title)
 
-const populateCourses = () => {
-	courses.value = [
+/* UpcomingEvaluations takes the batch shape, where each row carries its own
+   evaluator. A course evaluated on its own is a list of one. */
+const courses = computed(() => {
+	const details = certification.data
+	if (!details?.title) return []
+	return [
 		{
 			course: props.courseName,
-			title: courseTitle.value,
-			evaluator: evaluator.value,
+			title: details.title,
+			evaluator: details.evaluator,
 		},
 	]
-}
+})
 
-const openCertificate = (certificate) => {
+const openCertificate = () => {
+	const cert = certificate.value
+	if (!cert) return
 	openExternal(
 		`/api/method/frappe.utils.print_format.download_pdf?doctype=LMS+Certificate&name=${
-			certificate.name
-		}&format=${encodeURIComponent(certificate.template)}`
+			cert.name
+		}&format=${encodeURIComponent(cert.template)}`
 	)
 }
 
@@ -126,7 +124,7 @@ const breadcrumbs = computed(() => [
 		route: { name: 'Courses' },
 	},
 	{
-		label: courseTitle.value,
+		label: courseTitle.value ?? '',
 		route: { name: 'CourseDetail', params: { courseName: props.courseName } },
 	},
 	{
@@ -136,7 +134,7 @@ const breadcrumbs = computed(() => [
 
 usePageMeta(() => {
 	return {
-		title: courseTitle.value,
+		title: courseTitle.value ?? '',
 		icon: brand.favicon,
 	}
 })

--- a/frontend/src/tests/courseCertification.test.ts
+++ b/frontend/src/tests/courseCertification.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { reactive } from 'vue'
+import type { CertificationInfo } from '@/types'
+
+// LMS Student has no read permission on LMS Course, so this page has to get the
+// title and the evaluator from the whitelisted endpoint. Reading them with
+// frappe.client.get_value throws a PermissionError for the learner the page is
+// for, `courses` stays empty, and no Schedule button is ever rendered.
+const { createResourceMock, pushMock, callMock, toastMock } = vi.hoisted(() => {
+	window.matchMedia ??= (() => ({
+		matches: false,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+	})) as unknown as typeof window.matchMedia
+	return {
+		createResourceMock: vi.fn(),
+		pushMock: vi.fn(),
+		callMock: vi.fn(() => Promise.resolve({})),
+		toastMock: { success: vi.fn(), error: vi.fn() },
+	}
+})
+
+vi.mock('@/stores/session', () => ({ sessionStore: () => ({ brand: {} }) }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: pushMock }) }))
+vi.mock('frappe-ui', () => ({
+	createResource: createResourceMock,
+	usePageMeta: vi.fn(),
+	toast: toastMock,
+	call: callMock,
+}))
+vi.mock('@/components/Layouts/pages/PageHeader.vue', () => ({
+	default: { template: '<div><slot /></div>' },
+}))
+vi.mock('@/components/Layouts/pages/PageBody.vue', () => ({
+	default: { template: '<div><slot /></div>' },
+}))
+vi.mock('@/components/UpcomingEvaluations.vue', () => ({
+	default: {
+		name: 'UpcomingEvaluations',
+		props: ['courses', 'batch', 'endDate', 'forHome'],
+		template: '<div />',
+	},
+}))
+
+import CourseCertification from '@/pages/Courses/CourseCertification.vue'
+
+type ResourceOptions = {
+	url: string
+	makeParams: () => { course: string }
+	auto: boolean
+	onSuccess: (data: CertificationInfo | null) => void
+	onError: (error: unknown) => void
+}
+
+type MockResource = {
+	data: CertificationInfo | null
+	fetch: ReturnType<typeof vi.fn>
+}
+
+const COURSE = 'python-basics'
+
+const ENROLLED: CertificationInfo = {
+	title: 'Python Basics',
+	evaluator: 'eval@example.com',
+	membership: { purchased_certificate: 1 },
+	certificate: null,
+}
+
+const CERTIFIED: CertificationInfo = {
+	...ENROLLED,
+	certificate: {
+		name: 'CERT-0001',
+		template: 'Default',
+		issue_date: '2026-01-01',
+	},
+}
+
+function mountPage({ signedIn = true }: { signedIn?: boolean } = {}) {
+	const resource = reactive<MockResource>({ data: null, fetch: vi.fn() })
+	let options: ResourceOptions | undefined
+	createResourceMock.mockImplementation((given: ResourceOptions) => {
+		options = given
+		return resource
+	})
+	// Reactive, like the real $user: tests need to flip .data after mount, not
+	// just at provide, since the route guard can resolve it after setup runs.
+	const userResource = reactive<{ data: { name: string } | null }>({
+		data: signedIn ? { name: 'learner@example.com' } : null,
+	})
+	const wrapper = mount(CourseCertification, {
+		props: { courseName: COURSE },
+		global: {
+			provide: {
+				$dayjs: () => ({ format: () => '01 Jan 2026' }),
+				$user: userResource,
+			},
+			mocks: { __: (text: string) => text },
+		},
+	})
+	return {
+		wrapper,
+		resource,
+		userResource,
+		options: () => options as ResourceOptions,
+	}
+}
+
+const evaluations = (wrapper: ReturnType<typeof mountPage>['wrapper']) =>
+	wrapper.findComponent({ name: 'UpcomingEvaluations' })
+
+describe('CourseCertification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('reads the course details from the whitelisted endpoint', () => {
+		const { options } = mountPage()
+		expect(options().url).toBe('lms.lms.api.get_certification_details')
+		expect(options().makeParams()).toEqual({ course: COURSE })
+	})
+
+	it('never reads the course through frappe.client', () => {
+		mountPage()
+		expect(callMock).not.toHaveBeenCalled()
+	})
+
+	// Without this the suite passes against a page that fetches nothing and
+	// renders blank forever, because every case below assigns data by hand.
+	// auto stays false (frappe-ui only reads it once, at creation, and $user.data
+	// may not have arrived yet) - the fetch is driven by watching $user.data instead.
+	it('fetches on mount for a signed-in learner', () => {
+		const { options, resource } = mountPage()
+		expect(options().auto).toBe(false)
+		expect(resource.fetch).toHaveBeenCalled()
+	})
+
+	// A watcher left running after firing once repeats certification.fetch()
+	// (and its navigate/toast side effects) on the next unrelated user-resource
+	// reload, which is why data-already-present-at-mount must never watch.
+	it('does not keep watching once $user.data was already there at mount', async () => {
+		const { resource, userResource } = mountPage()
+		expect(resource.fetch).toHaveBeenCalledTimes(1)
+		userResource.data = { name: 'someone-else@example.com' }
+		await flushPromises()
+		expect(resource.fetch).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not fetch for a guest, whom the endpoint would reject', () => {
+		const { resource } = mountPage({ signedIn: false })
+		expect(resource.fetch).not.toHaveBeenCalled()
+	})
+
+	// The bug this regresses: auto is read once at setup, so $user.data
+	// arriving after mount rather than before it used to lose the fetch.
+	it('fetches once $user.data arrives after mount, not only if it was there at setup', async () => {
+		const { resource, userResource } = mountPage({ signedIn: false })
+		expect(resource.fetch).not.toHaveBeenCalled()
+		userResource.data = { name: 'learner@example.com' }
+		await flushPromises()
+		expect(resource.fetch).toHaveBeenCalledTimes(1)
+	})
+
+	it('hands the evaluator it returns to the evaluation list', async () => {
+		const { wrapper, resource } = mountPage()
+		resource.data = ENROLLED
+		await flushPromises()
+		expect(evaluations(wrapper).props('courses')).toEqual([
+			{ course: COURSE, title: 'Python Basics', evaluator: 'eval@example.com' },
+		])
+	})
+
+	it('renders no evaluation list before the details arrive', () => {
+		const { wrapper } = mountPage()
+		expect(evaluations(wrapper).exists()).toBe(false)
+	})
+
+	// UpcomingEvaluations filters evaluator-less rows out of its own list, so the
+	// row is still passed down; it is that component's call what to show.
+	it('still lists a course whose evaluator is unset', async () => {
+		const { wrapper, resource } = mountPage()
+		resource.data = { ...ENROLLED, evaluator: null }
+		await flushPromises()
+		expect(evaluations(wrapper).props('courses')).toEqual([
+			{ course: COURSE, title: 'Python Basics', evaluator: null },
+		])
+	})
+
+	it('renders the certificate instead of the scheduler once one exists', async () => {
+		const { wrapper, resource } = mountPage()
+		resource.data = CERTIFIED
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Python Basics')
+		expect(wrapper.text()).toContain('01 Jan 2026')
+		expect(evaluations(wrapper).exists()).toBe(false)
+	})
+
+	it('sends a learner without a purchased certificate back to the course', () => {
+		const { options } = mountPage()
+		options().onSuccess({ membership: null })
+		expect(pushMock).toHaveBeenCalledWith({
+			name: 'CourseDetail',
+			params: { courseName: COURSE },
+		})
+	})
+
+	it('reports a failed load rather than rendering an empty page', () => {
+		const { options } = mountPage()
+		options().onError({ messages: ['No permission for LMS Course'] })
+		expect(toastMock.error).toHaveBeenCalledWith('No permission for LMS Course')
+	})
+})

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -98,7 +98,13 @@ export interface OutlineChapter {
 }
 
 export interface CertificationInfo {
-	certificate?: { name: string; template: string } | null
+	title?: string | null
+	evaluator?: string | null
+	certificate?: {
+		name: string
+		template: string
+		issue_date?: string
+	} | null
 	membership?: {
 		purchased_certificate?: 0 | 1
 		certificate?: string

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -2011,7 +2011,18 @@ def cancel_evaluation(evaluation: dict):
 
 
 @frappe.whitelist()
-def get_certification_details(course: str):
+def get_certification_details(course: str) -> dict:
+	"""Everything the certification CTA and page need about one course.
+
+	`title` and `evaluator` are served here because LMS Student has no read
+	permission on LMS Course, so a client-side frappe.client.get_value for them
+	fails for the learner the page exists for.
+	"""
+	# Unreachable while require_type_annotated_api_methods is on, since frappe
+	# coerces the argument first. This is the guard for every other caller.
+	if not isinstance(course, str):
+		frappe.throw(_("course must be a string"))
+
 	membership = None
 	filters = {"course": course, "member": frappe.session.user}
 
@@ -2023,17 +2034,37 @@ def get_certification_details(course: str):
 			as_dict=1,
 		)
 
-	paid_certificate = frappe.db.get_value("LMS Course", course, "paid_certificate")
+	# Same gate as get_course_details: an unenrolled, non-staff caller can only
+	# see a published course, or they can enumerate titles that were never
+	# meant to be visible. A course that doesn't exist isn't gated here.
+	is_course_published = frappe.db.get_value("LMS Course", course, "published")
+	course_exists = is_course_published is not None
+	if course_exists and not is_course_published and not can_modify_course(course) and not membership:
+		frappe.throw(_("You do not have permission to view this course."), frappe.PermissionError)
+
+	details = (
+		frappe.db.get_value(
+			"LMS Course",
+			course,
+			["title", "paid_certificate", "evaluator"],
+			as_dict=1,
+		)
+		or frappe._dict()
+	)
 	certificate = frappe.db.get_value(
 		"LMS Certificate",
 		{"member": frappe.session.user, "course": course},
-		["name", "template"],
+		["name", "template", "issue_date"],
 		as_dict=1,
 	)
 
 	return {
+		"title": details.title,
 		"membership": membership,
-		"paid_certificate": paid_certificate,
+		"paid_certificate": details.paid_certificate,
+		# A staff email address. The page only reads it once the certificate has
+		# been paid for, so that is the gate rather than bare enrollment.
+		"evaluator": details.evaluator if membership and membership.purchased_certificate else None,
 		"certificate": certificate,
 	}
 

--- a/lms/tests/api/test_certification_api.py
+++ b/lms/tests/api/test_certification_api.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+import frappe
+from frappe.exceptions import FrappeTypeError
+from frappe.utils import getdate
+
+from lms.lms.api import get_certification_details
+from lms.lms.test_helpers import BaseTestUtils
+
+UNPUBLISHED_COURSE_MESSAGE = "You do not have permission to view this course."
+
+
+class TestGetCertificationDetails(BaseTestUtils):
+	"""LMS Student has no read permission on LMS Course, so everything the
+	certification page needs about the course has to come from here."""
+
+	def setUp(self):
+		super().setUp()
+		self.instructor = self._create_user(
+			"frappe@example.com", "Frappe", "Admin", ["Moderator", "Course Creator"]
+		)
+		self.student = self._create_user(
+			f"cert.learner.{frappe.generate_hash(length=8)}@example.com",
+			"Cert",
+			"Learner",
+			["LMS Student"],
+		)
+		self.outsider = self._create_user(
+			f"cert.outsider.{frappe.generate_hash(length=8)}@example.com",
+			"Cert",
+			"Outsider",
+			["LMS Student"],
+		)
+		self.evaluator = self._create_evaluator()
+		self.course = self._create_course()
+		self.previous_course_fields = frappe.db.get_value(
+			"LMS Course", self.course.name, ["paid_certificate", "evaluator", "published"], as_dict=1
+		)
+		frappe.db.set_value(
+			"LMS Course",
+			self.course.name,
+			{"paid_certificate": 1, "evaluator": self.evaluator.name},
+		)
+		self._create_enrollment(self.student.name, self.course.name)
+		frappe.db.set_value(
+			"LMS Enrollment",
+			{"course": self.course.name, "member": self.student.name},
+			"purchased_certificate",
+			1,
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_value("LMS Course", self.course.name, self.previous_course_fields)
+		super().tearDown()
+
+	def test_learner_gets_the_course_title_and_evaluator(self):
+		frappe.set_user(self.student.name)
+		# The gate this endpoint exists to get past.
+		self.assertFalse(frappe.has_permission("LMS Course", "read"))
+
+		details = get_certification_details(self.course.name)
+		self.assertEqual(details["title"], self.course.title)
+		self.assertEqual(details["evaluator"], self.evaluator.name)
+		self.assertEqual(details["paid_certificate"], 1)
+		self.assertEqual(details["membership"]["purchased_certificate"], 1)
+
+	def test_evaluator_is_withheld_from_someone_not_on_the_course(self):
+		frappe.set_user(self.outsider.name)
+		details = get_certification_details(self.course.name)
+		self.assertIsNone(details["membership"])
+		self.assertIsNone(details["evaluator"])
+		self.assertEqual(details["title"], self.course.title)
+
+	def test_evaluator_is_withheld_until_the_certificate_is_paid_for(self):
+		# Enrolment alone is self-service on a published course; the page only
+		# reads the evaluator past the purchase gate.
+		frappe.db.set_value(
+			"LMS Enrollment",
+			{"course": self.course.name, "member": self.student.name},
+			"purchased_certificate",
+			0,
+		)
+		frappe.set_user(self.student.name)
+
+		details = get_certification_details(self.course.name)
+		self.assertIsNotNone(details["membership"])
+		self.assertIsNone(details["evaluator"])
+
+	def test_a_guest_is_not_a_permitted_caller(self):
+		# allow_guest is what frappe checks at dispatch, and it records the
+		# function in frappe.guest_methods rather than tagging it.
+		self.assertNotIn(get_certification_details, frappe.guest_methods)
+
+		frappe.set_user("Guest")
+		details = get_certification_details(self.course.name)
+		self.assertIsNone(details["membership"])
+		self.assertIsNone(details["evaluator"])
+		self.assertIsNone(details["certificate"])
+
+	def test_a_user_with_no_lms_role_gets_no_evaluator(self):
+		stranger = self._create_user(
+			f"cert.stranger.{frappe.generate_hash(length=8)}@example.com",
+			"Cert",
+			"Stranger",
+			[],
+		)
+		frappe.set_user(stranger.name)
+
+		details = get_certification_details(self.course.name)
+		self.assertIsNone(details["membership"])
+		self.assertIsNone(details["evaluator"])
+
+	def test_certificate_carries_the_issue_date_the_page_renders(self):
+		certificate = self._create_certificate(self.course.name, self.student.name)
+		frappe.set_user(self.student.name)
+
+		details = get_certification_details(self.course.name)
+		self.assertEqual(details["certificate"]["name"], certificate.name)
+		self.assertEqual(getdate(details["certificate"]["issue_date"]), getdate(certificate.issue_date))
+
+	def test_unpublished_course_title_is_withheld_from_an_outsider(self):
+		# get_course_details hides an unpublished course from anyone who isn't
+		# enrolled, modifying it, or staff; this endpoint skipped that check.
+		frappe.db.set_value("LMS Course", self.course.name, "published", 0)
+		frappe.set_user(self.outsider.name)
+
+		with self.assertRaisesRegex(frappe.PermissionError, UNPUBLISHED_COURSE_MESSAGE):
+			get_certification_details(self.course.name)
+
+	def test_unpublished_course_is_still_visible_to_the_enrolled_learner(self):
+		frappe.db.set_value("LMS Course", self.course.name, "published", 0)
+		frappe.set_user(self.student.name)
+
+		details = get_certification_details(self.course.name)
+		self.assertEqual(details["title"], self.course.title)
+
+	def test_unpublished_course_is_still_visible_to_the_instructor(self):
+		frappe.db.set_value("LMS Course", self.course.name, "published", 0)
+		frappe.set_user(self.instructor.name)
+
+		details = get_certification_details(self.course.name)
+		self.assertEqual(details["title"], self.course.title)
+
+	def test_unknown_course_returns_no_details(self):
+		frappe.set_user(self.student.name)
+		details = get_certification_details(f"missing-{frappe.generate_hash(length=8)}")
+		self.assertIsNone(details["title"])
+		self.assertIsNone(details["evaluator"])
+		self.assertIsNone(details["certificate"])
+
+	def test_non_string_course_is_rejected_at_the_boundary(self):
+		# A filter list is the exploit db.get_value's flexibility hands you.
+		frappe.set_user(self.student.name)
+		with self.assertRaises(FrappeTypeError):
+			get_certification_details(["!=", ""])
+
+	def test_the_isinstance_guard_rejects_it_too(self):
+		# require_type_annotated_api_methods makes frappe coerce before the body
+		# runs, so the guard above it is only reachable undecorated. Without this
+		# the guard has no coverage at all and the test above passes on a commit
+		# that never had one.
+		frappe.set_user(self.student.name)
+		with self.assertRaises(frappe.ValidationError):
+			get_certification_details.__wrapped__(["!=", ""])


### PR DESCRIPTION
The certification page read the course title and evaluator with
frappe.client.get_value on LMS Course, which LMS Student has no read
permission for. 

The call failed, `courses` never populated, and
UpcomingEvaluations never rendered, so a learner who had bought a
certificate had no way to book an evaluation and saw a page with no title.
get_certification_details now returns the title and the evaluator, and the
page takes the enrollment and the certificate from that same call.

The evaluator is a staff email address, so it is only returned once the
certificate has been paid for. The title is not gated: any signed-in user
could already read it through this endpoint's sibling fields.

The page is now TypeScript and shares CertificationInfo with
CertificationLinks rather than describing the response twice. It reports a
failed load instead of rendering an empty page, and skips the request for a
guest, who this route admits and the endpoint rejects.

Regression tests in test_certification_api.py and courseCertification.test.ts.

