### PR TITLE
fix: carry contact-us images inside the email instead of linking them

### DIFF
--- a/frontend/src/components/ContactUsEmail.vue
+++ b/frontend/src/components/ContactUsEmail.vue
@@ -35,7 +35,7 @@
 import { Button, call, Dialog, FormControl, toast } from 'frappe-ui'
 import { ref, useId } from 'vue'
 import { InputLabel } from '@/components/Form/labeling'
-import { useSettings } from '@/stores/settings'
+import { resourceErrorMessage } from '@/utils/resource'
 import RichTextEditor from '@/components/RichTextEditor.vue'
 
 const messageLabelId = useId()
@@ -43,14 +43,15 @@ const messageLabelId = useId()
 const show = defineModel<boolean>({ required: true, default: false })
 const subject = ref('')
 const message = ref('')
-const settingsStore = useSettings()
 
+/* Sent server-side so the recipient comes from LMS Settings rather than the
+   request, and so an image pasted into the message is embedded into the mail
+   itself. Its upload is private, and a /private/files/ URL in an email is
+   served to nobody. */
 const sendMail = (close: Function) => {
-	call('frappe.core.doctype.communication.email.make', {
-		recipients: settingsStore.settings?.data?.contact_us_email,
+	call('lms.lms.api.send_contact_us_email', {
 		subject: subject.value,
 		content: message.value,
-		send_email: true,
 	})
 		.then(() => {
 			toast.success(__('Email sent successfully'))
@@ -58,9 +59,10 @@ const sendMail = (close: Function) => {
 			subject.value = ''
 			message.value = ''
 		})
-		.catch(() => {
-			toast.error(__('Failed to send email'))
-			close()
+		.catch((error: unknown) => {
+			// The dialog stays open: the message is worth keeping when the
+			// failure is something the sender can fix.
+			toast.error(resourceErrorMessage(error, __('Failed to send email')))
 		})
 }
 </script>

--- a/frontend/src/tests/contactUsEmail.test.ts
+++ b/frontend/src/tests/contactUsEmail.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+// The send goes through the LMS endpoint, not communication.email.make: the
+// recipient has to come from LMS Settings server-side, and an image pasted into
+// the message is uploaded private, so it only reaches the recipient if the mail
+// carries its bytes.
+const { callMock, toastMock, closeMock } = vi.hoisted(() => {
+	window.matchMedia ??= (() => ({
+		matches: false,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+	})) as unknown as typeof window.matchMedia
+	return {
+		callMock: vi.fn(() => Promise.resolve('COMM-0001')),
+		toastMock: { success: vi.fn(), error: vi.fn() },
+		closeMock: vi.fn(),
+	}
+})
+
+vi.mock('frappe-ui', () => ({
+	call: callMock,
+	toast: toastMock,
+	Button: {
+		inheritAttrs: false,
+		template: '<button v-bind="$attrs"><slot /></button>',
+	},
+	FormControl: {
+		props: ['modelValue', 'label', 'type', 'required'],
+		emits: ['update:modelValue'],
+		template: `<input :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`,
+	},
+	Dialog: {
+		name: 'Dialog',
+		props: ['open', 'title', 'size'],
+		emits: ['update:open'],
+		methods: {
+			close() {
+				closeMock()
+			},
+		},
+		template: `<div v-if="open"><slot /><slot name="actions" :close="close" /></div>`,
+	},
+}))
+
+// Kept so this file still exercises the component if the recipient ever moves
+// back to the client: without it the old settings-store read dies at setup and
+// the red below would be a missing mock rather than a wrong call.
+vi.mock('@/stores/settings', () => ({
+	useSettings: () => ({
+		settings: { data: { contact_us_email: 'client-chosen@example.com' } },
+	}),
+}))
+
+vi.mock('@/components/Form/labeling', () => ({
+	InputLabel: { props: ['id', 'label', 'required'], template: '<label />' },
+}))
+
+vi.mock('@/components/RichTextEditor.vue', () => ({
+	default: {
+		name: 'RichTextEditor',
+		props: ['fixedMenu', 'editorClass'],
+		emits: ['change'],
+		template: '<div />',
+	},
+}))
+
+import ContactUsEmail from '@/components/ContactUsEmail.vue'
+
+const MESSAGE = '<p>see this</p><img src="/private/files/shot.png">'
+
+async function fillAndSend() {
+	const wrapper = mount(ContactUsEmail, {
+		props: { modelValue: true },
+		global: { mocks: { __: (text: string) => text } },
+	})
+	await wrapper.find('input').setValue('Broken video')
+	wrapper.findComponent({ name: 'RichTextEditor' }).vm.$emit('change', MESSAGE)
+	await flushPromises()
+	await wrapper.find('button').trigger('click')
+	await flushPromises()
+	return wrapper
+}
+
+describe('ContactUsEmail', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		callMock.mockImplementation(() => Promise.resolve('COMM-0001'))
+	})
+
+	it('sends through the LMS endpoint and names no recipient', async () => {
+		await fillAndSend()
+		expect(callMock).toHaveBeenCalledTimes(1)
+		expect(callMock).toHaveBeenCalledWith('lms.lms.api.send_contact_us_email', {
+			subject: 'Broken video',
+			content: MESSAGE,
+		})
+	})
+
+	it('closes and clears the form once the mail is away', async () => {
+		const wrapper = await fillAndSend()
+		expect(toastMock.success).toHaveBeenCalled()
+		expect(closeMock).toHaveBeenCalled()
+		expect(wrapper.find('input').element.value).toBe('')
+	})
+
+	it('keeps the message on screen when the server rejects it', async () => {
+		callMock.mockImplementation(() =>
+			Promise.reject({ messages: ['This site has no contact address.'] })
+		)
+		const wrapper = await fillAndSend()
+
+		expect(toastMock.error).toHaveBeenCalledWith(
+			'This site has no contact address.'
+		)
+		expect(closeMock).not.toHaveBeenCalled()
+		expect(wrapper.find('input').element.value).toBe('Broken video')
+	})
+})

--- a/lms/lms/api.py
+++ b/lms/lms/api.py
@@ -12,6 +12,7 @@ from xml.dom.minidom import parseString
 
 import frappe
 from frappe import _
+from frappe.email.email_body import get_message_id
 from frappe.integrations.frappe_providers.frappecloud_billing import (
 	current_site_info,
 	is_fc_site,
@@ -24,6 +25,8 @@ from frappe.utils import (
 	flt,
 	format_date,
 	get_datetime,
+	get_fullname,
+	get_string_between,
 	get_system_timezone,
 	get_time,
 	getdate,
@@ -40,6 +43,7 @@ from lms.lms.doctype.course_lesson.course_lesson import (
 from lms.lms.sidebar import LEGACY_VISIBILITY_FIELDS, ROW_FIELDS, get_sidebar_rows
 from lms.lms.utils import (
 	LMS_ROLES,
+	attach_file_to_doc,
 	can_modify_batch,
 	can_modify_course,
 	format_timezone,
@@ -53,7 +57,9 @@ from lms.lms.utils import (
 	has_course_instructor_role,
 	has_evaluator_role,
 	has_lms_role,
+	has_message,
 	has_moderator_role,
+	prepare_inline_images,
 )
 
 
@@ -2008,6 +2014,68 @@ def cancel_evaluation(evaluation: dict):
 
 			frappe.delete_doc("Event Participants", event.name, ignore_permissions=True)
 			frappe.delete_doc("Event", event.parent, ignore_permissions=True)
+
+
+@frappe.whitelist(methods=["POST"])
+def send_contact_us_email(subject: str, content: str) -> str:
+	"""Email the address configured in LMS Settings, images and all.
+
+	The recipient is read here rather than taken from the request, which is what
+	the browser's old call to frappe.core.doctype.communication.email.make did.
+	That method is still whitelisted and still listed in lms.auth.ALLOWED_PATHS,
+	so this closes the path the LMS UI takes, not the method itself.
+	"""
+	if not isinstance(subject, str) or not isinstance(content, str):
+		frappe.throw(_("Subject and message must both be text."))
+
+	if not subject.strip():
+		frappe.throw(_("Please add a subject."))
+
+	if not has_message(content):
+		frappe.throw(_("Please write a message."))
+
+	recipient = frappe.db.get_single_value("LMS Settings", "contact_us_email")
+	if not recipient:
+		frappe.throw(_("This site has no contact address. Ask a moderator to set one in LMS Settings."))
+
+	subject = subject.strip()
+	message_id = get_string_between("<", get_message_id(), ">")
+	# Every field that decides where this goes is set here, not accepted from the request.
+	# nosemgrep: lms-unjustified-ignore-permissions - a student holds no create permission on Communication
+	communication = frappe.get_doc(
+		{
+			"doctype": "Communication",
+			"communication_type": "Communication",
+			"communication_medium": "Email",
+			"subject": subject,
+			"content": content,
+			"sender": frappe.session.user,
+			"sender_full_name": get_fullname(frappe.session.user),
+			"recipients": recipient,
+			"sent_or_received": "Sent",
+			# Without it a reply cannot be threaded back to this record.
+			"message_id": message_id,
+		}
+	).insert(ignore_permissions=True)
+
+	# Built from the stored copy, which Communication sanitizes on save, rather
+	# than from the request. The record keeps its `src` URLs, so it still
+	# renders in Desk once the files below are attached to it; only the outgoing
+	# message carries `embed`. Same split as Helpdesk's HD Ticket.
+	body, inline_images = prepare_inline_images(communication.content)
+	for image in inline_images:
+		attach_file_to_doc(image["filename"], "Communication", communication.name)
+
+	frappe.sendmail(
+		recipients=[recipient],
+		sender=frappe.session.user,
+		subject=subject,
+		content=body,
+		inline_images=inline_images,
+		communication=communication.name,
+		message_id=message_id,
+	)
+	return communication.name
 
 
 @frappe.whitelist()

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 
 import frappe
 import requests
+from bs4 import BeautifulSoup, Comment
 from frappe import _
 from frappe.desk.doctype.dashboard_chart.dashboard_chart import get_result
 from frappe.desk.doctype.notification_log.notification_log import make_notification_logs
@@ -27,6 +28,7 @@ from frappe.utils import (
 	getdate,
 	nowtime,
 	rounded,
+	strip_html,
 	to_timedelta,
 	validate_email_address,
 )
@@ -819,6 +821,170 @@ def format_timezone(timezone: str, at=None) -> str:
 	hours, minutes = divmod(abs(total_minutes), 60)
 	sign = "+" if total_minutes >= 0 else "-"
 	return f"{timezone} (GMT{sign}{hours}:{minutes:02d})"
+
+
+MAX_INLINE_IMAGES = 10
+MAX_INLINE_IMAGE_BYTES = 5 * 1024 * 1024
+
+
+def has_message(html: str | None) -> bool:
+	"""An image on its own is a message.
+
+	The editor uploads a pasted screenshot as a file and leaves the body around
+	it empty, so strip_html returns "" for the one thing a contact-us mail most
+	often carries.
+	"""
+	if not html:
+		return False
+
+	if strip_html(html).replace("\xa0", " ").replace("&nbsp;", " ").strip():
+		return True
+
+	return bool(BeautifulSoup(html, "html.parser").find(["img", "video"]))
+
+
+def prepare_inline_images(html: str | None) -> tuple[str, list[dict]]:
+	"""Rewrite site images to `embed` and return their bytes alongside.
+
+	frappe turns `<img embed="...">` into a real inline attachment carrying a
+	Content-Id (email_body.replace_filename_with_cid), which is the only way a
+	private file reaches an external recipient: a /private/files/ URL in an
+	email is served to nobody.
+
+	The bytes travel with the message instead of being re-read from a path at
+	send time. set_part_html prefers what the caller supplies, and letting
+	frappe resolve the path itself means trusting a string the client sent:
+	get_filecontent_from_path has no permission check of its own, and matching
+	that string against the database first does not help, because
+	tabFile.file_url is utf8mb4_unicode_ci while the filesystem is
+	case-sensitive. So `/private/files/Offer.pdf`, which the sender uploaded,
+	matches the row for `/private/files/offer.pdf`, which they cannot read.
+	Here the row decides: its own file_url goes into `embed`, and its own
+	content is what travels.
+	"""
+	if not html:
+		return "", []
+
+	soup = BeautifulSoup(html, "html.parser")
+	# to_markdown turns a comment into visible text in the plaintext part.
+	for comment in soup.find_all(string=lambda text: isinstance(text, Comment)):
+		comment.extract()
+
+	candidate_tags = []
+	for tag in soup.find_all(["img", "video"]):
+		src = tag.get("src")
+		if isinstance(src, str) and src.startswith(("/files/", "/private/files/")):
+			candidate_tags.append((tag, src))
+
+	# One query (plus one permission check per candidate row) for every image in
+	# the message, instead of one query per tag: a message with several embeds
+	# was otherwise a query per embed.
+	files_by_url = get_readable_files([src for _tag, src in candidate_tags])
+
+	inline_images = []
+	total_bytes = 0
+
+	for tag, src in candidate_tags:
+		file = files_by_url.get(src)
+		if not file:
+			continue
+
+		if len(inline_images) >= MAX_INLINE_IMAGES:
+			frappe.throw(
+				_("An email can carry at most {0} images. Please send the rest separately.").format(
+					MAX_INLINE_IMAGES
+				)
+			)
+
+		# Checked against the File row's own recorded size before reading the
+		# content, so a file that alone blows the budget is rejected without
+		# loading it into memory first.
+		if file.file_size and total_bytes + file.file_size > MAX_INLINE_IMAGE_BYTES:
+			frappe.throw(
+				_("These images come to more than {0} MB. Please send smaller ones.").format(
+					MAX_INLINE_IMAGE_BYTES // (1024 * 1024)
+				)
+			)
+
+		content = file.get_content()
+		total_bytes += len(content)
+		if total_bytes > MAX_INLINE_IMAGE_BYTES:
+			frappe.throw(
+				_("These images come to more than {0} MB. Please send smaller ones.").format(
+					MAX_INLINE_IMAGE_BYTES // (1024 * 1024)
+				)
+			)
+
+		tag["embed"] = file.file_url
+		del tag["src"]
+		inline_images.append({"filename": file.file_url, "filecontent": content})
+
+	return str(soup), inline_images
+
+
+def get_readable_files(file_urls: list[str]) -> dict:
+	"""The File each URL in `file_urls` resolves to, keyed by that exact URL.
+
+	One query covers every URL. tabFile.file_url is case-insensitive, so a
+	caller's string can match more than one row; permission decides between
+	them, not which one the database happens to return first.
+	"""
+	if not file_urls:
+		return {}
+
+	candidates = frappe.get_all("File", filters={"file_url": ["in", file_urls]}, fields=["name", "file_url"])
+	names_by_lower_url = {}
+	for row in candidates:
+		names_by_lower_url.setdefault(row.file_url.lower(), []).append(row.name)
+
+	resolved = {}
+	for file_url in file_urls:
+		if file_url in resolved:
+			continue
+		for name in names_by_lower_url.get(file_url.lower(), []):
+			# has_permission(doc=name) would refetch the row internally to
+			# evaluate it; fetch once and pass the doc so a match costs one
+			# read, not two.
+			candidate = frappe.get_doc("File", name)
+			if frappe.has_permission("File", ptype="read", doc=candidate):
+				resolved[file_url] = candidate
+				break
+
+	return resolved
+
+
+def attach_file_to_doc(file_url: str, doctype: str, docname: str) -> None:
+	"""Point a File row at `docname` so the stored copy renders.
+
+	File.has_permission grants a private file to its owner, an explicit share,
+	or whoever can read the document it is attached to. An editor upload is
+	attached to nothing, so without this the image in a saved Communication is
+	broken for every reader but the sender. Mirrors Helpdesk's
+	HDTicket.attach_file_with_doc.
+	"""
+	# Lock the row this file is attaching to before the check below, or two
+	# concurrent callers can both see "no File row yet" and both insert one.
+	# Same shape as the batch and course locks elsewhere in this file.
+	frappe.db.get_value(doctype, docname, "name", for_update=True)
+
+	filters = {
+		"file_url": file_url,
+		"attached_to_doctype": doctype,
+		"attached_to_name": docname,
+	}
+	if frappe.db.exists("File", filters):
+		return
+
+	# A student cannot create a File row against a Communication they do not own.
+	# nosemgrep: lms-unjustified-ignore-permissions - prepare_inline_images already checked has_permission on this file
+	frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_url": file_url,
+			"is_private": 1 if file_url.startswith("/private/") else 0,
+			**filters,
+		}
+	).insert(ignore_permissions=True)
 
 
 def check_multicurrency(amount: float, currency: str, country: str = None, amount_usd: float = None):

--- a/lms/tests/api/test_contact_us_api.py
+++ b/lms/tests/api/test_contact_us_api.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2026, Frappe and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.email.email_body import replace_filename_with_cid
+from frappe.exceptions import FrappeTypeError
+
+from lms.lms.api import send_contact_us_email
+from lms.lms.test_helpers import BaseTestUtils
+from lms.lms.utils import attach_file_to_doc, has_message, prepare_inline_images
+
+CONTACT_ADDRESS = "support@example.com"
+PNG = b"\x89PNG\r\n\x1a\n"
+
+
+class ContactUsTestCase(BaseTestUtils):
+	def setUp(self):
+		super().setUp()
+		self.sender = self._create_user(
+			f"contact.sender.{frappe.generate_hash(length=8)}@example.com",
+			"Contact",
+			"Sender",
+			["LMS Student"],
+		)
+		self.other = self._create_user(
+			f"contact.other.{frappe.generate_hash(length=8)}@example.com",
+			"Contact",
+			"Other",
+			["LMS Student"],
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def _file(self, owner, file_name=None, content=PNG, is_private=1):
+		frappe.set_user(owner)
+		doc = frappe.new_doc("File")
+		doc.file_name = file_name or f"probe-{frappe.generate_hash(length=8)}.png"
+		doc.is_private = is_private
+		doc.content = content
+		doc.save(ignore_permissions=True)
+		self.cleanup_items.append(("File", doc.name))
+		frappe.set_user("Administrator")
+		return doc
+
+
+class TestHasMessage(BaseTestUtils):
+	def test_an_image_on_its_own_is_a_message(self):
+		# strip_html leaves nothing behind for a pasted screenshot, which is the
+		# single most common contact-us body.
+		self.assertTrue(has_message('<img src="/private/files/shot.png">'))
+		self.assertTrue(has_message('<p><img src="/private/files/shot.png"></p>'))
+
+	def test_text_is_a_message(self):
+		self.assertTrue(has_message("<p>the player will not load</p>"))
+
+	def test_an_empty_body_is_not_a_message(self):
+		for body in (None, "", "<p></p>", "<p><br></p>", "<p>&nbsp;</p>", "<p>\xa0</p>"):
+			with self.subTest(body=body):
+				self.assertFalse(has_message(body))
+
+
+class TestPrepareInlineImages(ContactUsTestCase):
+	"""An image only reaches the recipient if the mail carries its bytes."""
+
+	def test_a_private_file_the_sender_owns_becomes_an_embed(self):
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		body, images = prepare_inline_images(f'<p>hi</p><img src="{file.file_url}">')
+
+		self.assertIn(f'embed="{file.file_url}"', body)
+		self.assertNotIn("src=", body)
+		self.assertEqual(images, [{"filename": file.file_url, "filecontent": PNG}])
+
+	def test_a_public_file_the_sender_owns_becomes_an_embed(self):
+		file = self._file(self.sender.name, is_private=0)
+		frappe.set_user(self.sender.name)
+
+		body, images = prepare_inline_images(f'<img src="{file.file_url}">')
+		self.assertIn(f'embed="{file.file_url}"', body)
+		self.assertEqual(len(images), 1)
+
+	def test_a_file_the_sender_cannot_read_keeps_its_src(self):
+		file = self._file(self.other.name)
+		frappe.set_user(self.sender.name)
+
+		body, images = prepare_inline_images(f'<img src="{file.file_url}">')
+		self.assertIn(f'src="{file.file_url}"', body)
+		self.assertNotIn("embed=", body)
+		self.assertEqual(images, [])
+
+	def test_a_case_variant_path_cannot_reach_another_users_file(self):
+		"""tabFile.file_url is utf8mb4_unicode_ci and the filesystem is not.
+
+		Matching the caller's string in the database and then handing that same
+		string to frappe to open is what made this reachable: a row the sender
+		owns satisfies the lookup while the path resolves to someone else's
+		file. The row has to decide both the URL and the bytes.
+		"""
+		stem = frappe.generate_hash(length=8)
+		secret = PNG + b"VICTIM-SECRET"
+		# The sender's row is written first so the victim's is the newer one, and
+		# get_all hands it back first. Ordered the other way the sender's row
+		# comes out on top and the test passes even with no permission check.
+		mine = self._file(self.sender.name, file_name=f"OFFER-{stem}.png", content=PNG + b"MINE")
+		victim = self._file(self.other.name, file_name=f"offer-{stem}.png", content=secret)
+		self.assertNotEqual(victim.file_url, mine.file_url)
+
+		# The premise: one lookup on the victim's path returns both rows. Without
+		# this the test could pass by matching nothing at all.
+		matched = frappe.get_all("File", filters={"file_url": victim.file_url}, pluck="name")
+		self.assertIn(victim.name, matched)
+		self.assertIn(mine.name, matched)
+
+		frappe.set_user(self.sender.name)
+		body, images = prepare_inline_images(f'<img src="{victim.file_url}">')
+
+		self.assertNotIn(secret, [image["filecontent"] for image in images])
+		self.assertNotIn(victim.file_url, body)
+		self.assertEqual(images, [{"filename": mine.file_url, "filecontent": PNG + b"MINE"}])
+		self.assertIn(f'embed="{mine.file_url}"', body)
+
+	def test_an_external_image_is_left_alone(self):
+		frappe.set_user(self.sender.name)
+		body, images = prepare_inline_images('<img src="https://example.com/cat.png">')
+		self.assertIn('src="https://example.com/cat.png"', body)
+		self.assertEqual(images, [])
+
+	def test_empty_content_stays_empty(self):
+		self.assertEqual(prepare_inline_images(""), ("", []))
+		self.assertEqual(prepare_inline_images(None), ("", []))
+
+	def test_comments_are_dropped(self):
+		frappe.set_user(self.sender.name)
+		body, _images = prepare_inline_images("<p>a</p><!-- mso conditional --><p>b</p>")
+		self.assertNotIn("mso conditional", body)
+
+	@patch("lms.lms.utils.MAX_INLINE_IMAGES", 1)
+	def test_more_images_than_the_cap_are_refused(self):
+		first = self._file(self.sender.name)
+		second = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		with self.assertRaises(frappe.ValidationError):
+			prepare_inline_images(f'<img src="{first.file_url}"><img src="{second.file_url}">')
+
+	@patch("lms.lms.utils.MAX_INLINE_IMAGE_BYTES", 4)
+	def test_images_over_the_byte_cap_are_refused(self):
+		# as_dict builds the whole MIME string inside the request, so an
+		# unbounded payload is a request-time cost, not a queue one.
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		with self.assertRaises(frappe.ValidationError):
+			prepare_inline_images(f'<img src="{file.file_url}">')
+
+	@patch("lms.lms.utils.MAX_INLINE_IMAGE_BYTES", 4)
+	def test_the_byte_cap_is_checked_before_reading_the_file(self):
+		# file.file_size alone already exceeds the cap here, so get_content
+		# (which loads the whole file into memory) should never run.
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		with patch("frappe.core.doctype.file.file.File.get_content") as get_content:
+			with self.assertRaises(frappe.ValidationError):
+				prepare_inline_images(f'<img src="{file.file_url}">')
+			get_content.assert_not_called()
+
+	def test_one_query_resolves_every_image_in_the_message(self):
+		# get_readable_files takes every src at once; the loop over tags in
+		# prepare_inline_images must not call frappe.get_all again per tag.
+		first = self._file(self.sender.name)
+		second = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		with patch("frappe.get_all", wraps=frappe.get_all) as get_all:
+			_body, images = prepare_inline_images(
+				f'<img src="{first.file_url}"><img src="{second.file_url}">'
+			)
+
+		self.assertEqual(len(images), 2)
+		file_lookups = [call for call in get_all.call_args_list if call.args and call.args[0] == "File"]
+		self.assertEqual(len(file_lookups), 1)
+
+	def test_a_matched_file_is_fetched_only_once(self):
+		# has_permission(doc=name) fetches the row itself internally
+		# (frappe.get_lazy_doc, invisible to a frappe.get_doc patch); passing
+		# the already-fetched doc instead drops one "select * from tabFile
+		# where name = " round trip per matched image.
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+		real_sql = frappe.db.sql
+		file_selects = []
+
+		def counting_sql(*args, **kwargs):
+			query = args[0] if args else kwargs.get("query", "")
+			if "tabFile" in query and "where `name`" in query.lower():
+				file_selects.append(query)
+			return real_sql(*args, **kwargs)
+
+		with patch("frappe.db.sql", side_effect=counting_sql):
+			_body, images = prepare_inline_images(f'<img src="{file.file_url}">')
+
+		self.assertEqual(len(images), 1)
+		self.assertEqual(len(file_selects), 1)
+
+
+class TestSendContactUsEmail(ContactUsTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.previous_contact = frappe.db.get_single_value("LMS Settings", "contact_us_email")
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.set_single_value("LMS Settings", "contact_us_email", cls.previous_contact)
+		super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		frappe.db.set_single_value("LMS Settings", "contact_us_email", CONTACT_ADDRESS)
+
+	def _send(self, subject, content):
+		with patch("frappe.sendmail") as sendmail:
+			name = send_contact_us_email(subject, content)
+		self.cleanup_items.append(("Communication", name))
+		return name, sendmail.call_args.kwargs
+
+	def test_the_recipient_comes_from_settings_not_the_caller(self):
+		frappe.set_user(self.sender.name)
+		_name, sent = self._send("Broken video", "<p>The player will not load.</p>")
+		self.assertEqual(sent["recipients"], [CONTACT_ADDRESS])
+
+	def test_an_image_on_its_own_can_be_sent(self):
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		_name, sent = self._send("Broken video", f'<img src="{file.file_url}">')
+		self.assertIn(f'embed="{file.file_url}"', sent["content"])
+		self.assertEqual(sent["inline_images"], [{"filename": file.file_url, "filecontent": PNG}])
+
+	def test_the_outgoing_copy_embeds_the_image_and_the_stored_one_keeps_its_url(self):
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+		content = f'<p>see this</p><img src="{file.file_url}">'
+
+		name, sent = self._send("Broken video", content)
+
+		self.assertIn(f'embed="{file.file_url}"', sent["content"])
+		self.assertEqual(frappe.db.get_value("Communication", name, "content"), content)
+
+	def test_the_embedded_file_is_attached_so_the_record_still_renders(self):
+		# File.has_permission grants a private file to its owner or to whoever
+		# can read the doc it hangs off. An editor upload hangs off nothing.
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		name, _sent = self._send("Broken video", f'<img src="{file.file_url}">')
+		self.assertTrue(
+			frappe.db.exists(
+				"File",
+				{
+					"file_url": file.file_url,
+					"attached_to_doctype": "Communication",
+					"attached_to_name": name,
+				},
+			)
+		)
+
+	def test_the_mail_carries_the_sanitized_copy(self):
+		frappe.set_user(self.sender.name)
+		_name, sent = self._send(
+			"Broken video", '<p>hi</p><script>alert(1)</script><a href="javascript:alert(1)">x</a>'
+		)
+		self.assertNotIn("<script>", sent["content"])
+		self.assertNotIn("javascript:", sent["content"])
+
+	def test_the_communication_can_be_replied_to(self):
+		frappe.set_user(self.sender.name)
+		name, sent = self._send("Broken video", "<p>hi</p>")
+
+		message_id = frappe.db.get_value("Communication", name, "message_id")
+		self.assertTrue(message_id)
+		self.assertEqual(sent["message_id"], message_id)
+
+	def test_the_communication_records_the_sender_and_recipient(self):
+		frappe.set_user(self.sender.name)
+		name, _sent = self._send("Broken video", "<p>hi</p>")
+
+		communication = frappe.db.get_value(
+			"Communication", name, ["sender", "recipients", "subject"], as_dict=1
+		)
+		self.assertEqual(communication.sender, self.sender.name)
+		self.assertEqual(communication.recipients, CONTACT_ADDRESS)
+		self.assertEqual(communication.subject, "Broken video")
+
+	def test_an_unset_contact_address_is_reported(self):
+		frappe.db.set_single_value("LMS Settings", "contact_us_email", "")
+		frappe.set_user(self.sender.name)
+		with self.assertRaises(frappe.ValidationError):
+			send_contact_us_email("Broken video", "<p>hi</p>")
+
+	def test_a_blank_subject_is_rejected(self):
+		frappe.set_user(self.sender.name)
+		with self.assertRaises(frappe.ValidationError):
+			send_contact_us_email("   ", "<p>hi</p>")
+
+	def test_a_message_with_neither_words_nor_images_is_rejected(self):
+		frappe.set_user(self.sender.name)
+		with self.assertRaises(frappe.ValidationError):
+			send_contact_us_email("Broken video", "<p><br></p>")
+
+	def test_a_guest_is_not_a_permitted_caller(self):
+		# allow_guest is what frappe checks at dispatch, and it records the
+		# function in frappe.guest_methods rather than tagging it.
+		self.assertNotIn(send_contact_us_email, frappe.guest_methods)
+
+	def test_non_string_arguments_are_rejected(self):
+		frappe.set_user(self.sender.name)
+		with self.assertRaises((frappe.ValidationError, FrappeTypeError)):
+			send_contact_us_email(["Broken video"], "<p>hi</p>")
+
+
+class TestAttachFileToDoc(ContactUsTestCase):
+	def test_locks_the_target_row_before_checking_for_an_existing_attachment(self):
+		# Without the lock, two concurrent callers can both see "no File row
+		# yet" for the same (file_url, doctype, docname) and both insert one.
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+
+		calls = []
+		real_get_value = frappe.db.get_value
+
+		def spy(*args, **kwargs):
+			calls.append((args, kwargs))
+			return real_get_value(*args, **kwargs)
+
+		with patch("frappe.db.get_value", side_effect=spy):
+			attach_file_to_doc(file.file_url, "User", self.sender.name)
+
+		lock_calls = [c for c in calls if c[0][:2] == ("User", self.sender.name) and c[1].get("for_update")]
+		self.assertEqual(len(lock_calls), 1)
+
+		attached = frappe.db.get_value(
+			"File",
+			{"file_url": file.file_url, "attached_to_doctype": "User", "attached_to_name": self.sender.name},
+		)
+		self.cleanup_items.append(("File", attached))
+
+
+class TestEmbedIsWhatFrappeInlines(ContactUsTestCase):
+	"""Pins the frappe contract the fix rests on. replace_filename_with_cid
+	*strips* an embed it cannot resolve, so if this ever stops holding the
+	images vanish from the mail rather than raising anything."""
+
+	def test_an_embed_becomes_a_content_id_and_carries_the_bytes(self):
+		file = self._file(self.sender.name)
+		frappe.set_user(self.sender.name)
+		body, images = prepare_inline_images(f'<img src="{file.file_url}">')
+
+		provided = {image["filename"]: image["filecontent"] for image in images}
+		message, inline_images = replace_filename_with_cid(body, provided)
+
+		self.assertEqual(len(inline_images), 1)
+		self.assertEqual(inline_images[0]["filecontent"], PNG)
+		self.assertIn(f'src="cid:{inline_images[0]["content_id"]}"', message)
+		self.assertNotIn(file.file_url, message)


### PR DESCRIPTION
## Summary

- Paste an image into the Contact Us form and the recipient saw a broken image.
- The editor uploads pasted images as private files, and the email carried only a link to one. A private file link needs a logged-in account with permission to open it, which a recipient's mail app does not have.
- Images now travel inside the email as proper inline attachments, the way Gmail does it. The file stays private and nothing is made publicly readable.
- Frappe already supports this: an image marked with `embed` instead of `src` becomes a real inline attachment. The pattern is copied from Helpdesk's `HDTicket.parse_content`.

## Security

- Only files the sender is actually allowed to read are attached. This matters because the framework function that reads the file off disk performs no permission check of its own.
- The bytes come from the file record the sender has permission on, and that same record supplies the address written into the email. Nothing the browser sends is used to look up a file on disk.
- **This was caught in review of an earlier revision of this PR — it is not a flaw in `develop`.** That revision matched the browser's text against the database and then let the framework re-open the same text as a path. The two do not agree: the database column ignores letter case, the filesystem does not. So a user could upload their own `Offer-Letter.pdf`, reference someone else's `offer-letter.pdf`, pass the check against their own file, and have the other person's file read and emailed. Closed.
- The number of embedded images and their total size are now capped, because the email is assembled while the user's request is still waiting.

## Other fixes included

- A message that is only a pasted image, with no text, used to be rejected as empty. That is the commonest way people use this form, and it now works.
- The email carries the cleaned-up version of the message that gets saved, rather than the raw text from the browser, so scripts and dangerous links cannot reach the recipient's inbox.
- Replies can be matched back to the saved record — a message id was missing.
- Embedded images are linked to the saved record, so staff viewing the message later see it correctly.
- Sending goes through a new server endpoint that takes the recipient address from LMS Settings, instead of the browser telling the server who to email.
