### PR TITLE
fix: translate student-facing interface messages

### DIFF
--- a/frontend/src/components/DiscussionReplies.vue
+++ b/frontend/src/components/DiscussionReplies.vue
@@ -97,7 +97,7 @@
 			:content="newReply"
 			:mentions="mentionUsers"
 			@change="(val) => (newReply = val)"
-			placeholder="Type your reply here..."
+			:placeholder="__('Type your reply here...')"
 			:fixedMenu="true"
 			editorClass="ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 prose-sm max-w-none border border-outline-gray-2 rounded-b-md min-h-[7rem] py-1 px-2"
 		/>

--- a/frontend/src/components/Modals/EditCoverImage.vue
+++ b/frontend/src/components/Modals/EditCoverImage.vue
@@ -13,7 +13,7 @@
 					<div class="flex items-center justify-center gap-x-2">
 						<TextInput
 							type="text"
-							placeholder="search by keyword"
+							:placeholder="__('search by keyword')"
 							:aria-label="__('Search images by keyword')"
 							v-model="search"
 							:debounce="300"
@@ -30,7 +30,11 @@
 							>
 								<div class="">
 									<Button @click="openFileSelector" :loading="uploading">
-										{{ uploading ? `Uploading ${progress}%` : 'Upload Image' }}
+										{{
+											uploading
+												? __('Uploading {0}%').format(progress)
+												: __('Upload Image')
+										}}
 									</Button>
 								</div>
 							</template>
@@ -137,7 +141,7 @@ const saveImage = (file) => {
 const validateFile = (file) => {
 	let extension = file.name.split('.').pop().toLowerCase()
 	if (!['jpg', 'jpeg', 'png'].includes(extension)) {
-		return 'Only image file is allowed.'
+		return __('Only image file is allowed.')
 	}
 }
 </script>

--- a/frontend/src/pages/Billing.vue
+++ b/frontend/src/pages/Billing.vue
@@ -227,7 +227,7 @@
 		</div>
 		<div v-else-if="!user.data?.name">
 			<NotPermitted
-				text="Please login to access this page."
+				:text="__('Please login to access this page.')"
 				:buttonLink="`/login?redirect-to=${getLmsRoute(
 					`billing/${type}/${name}`
 				)}`"

--- a/frontend/src/tests/coverImageTranslations.test.ts
+++ b/frontend/src/tests/coverImageTranslations.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import EditCoverImage from '@/components/Modals/EditCoverImage.vue'
+import translationPlugin from '@/translation'
+
+vi.mock('frappe-ui', () => ({
+	Popover: { template: '<div><slot /></div>' },
+	TextInput: { template: '<input />' },
+	Button: { template: '<button><slot /></button>' },
+	FileUploader: {
+		name: 'FileUploader',
+		props: ['validateFile'],
+		data: () => ({ uploading: false, progress: 0 }),
+		template:
+			'<div><slot :uploading="uploading" :progress="progress" :openFileSelector="() => {}" /></div>',
+	},
+	createResource: () => ({ data: null, loading: false, reload: vi.fn() }),
+}))
+
+const messages = {
+	'search by keyword': 'buscar por palavra-chave',
+	'Upload Image': 'Enviar imagem',
+	'Uploading {0}%': 'Enviando {0}%',
+	'Only image file is allowed.': 'Somente arquivos de imagem são permitidos.',
+}
+
+let wrapper: ReturnType<typeof mount>
+const browser = window as Window & {
+	translatedMessages?: Record<string, string>
+	__?: (message: string) => unknown
+}
+let previousMessages: typeof browser.translatedMessages
+let previousTranslate: typeof browser.__
+
+beforeEach(() => {
+	previousMessages = browser.translatedMessages
+	previousTranslate = browser.__
+	browser.translatedMessages = messages
+	wrapper = mount(EditCoverImage, { global: { plugins: [translationPlugin] } })
+})
+
+afterEach(() => {
+	wrapper.unmount()
+	browser.translatedMessages = previousMessages
+	browser.__ = previousTranslate
+})
+
+describe('cover-image translations', () => {
+	it('translates the search placeholder and upload action', () => {
+		expect(wrapper.get('input').attributes('placeholder')).toBe(
+			messages['search by keyword']
+		)
+		expect(wrapper.get('button').text()).toBe(messages['Upload Image'])
+	})
+
+	it.each([0, 37, 100])(
+		'preserves upload progress %s in the translation',
+		async (progress) => {
+			await wrapper.getComponent({ name: 'FileUploader' }).setData({
+				uploading: true,
+				progress,
+			})
+			expect(wrapper.get('button').text()).toBe(`Enviando ${progress}%`)
+		}
+	)
+
+	it('translates validation feedback while preserving allowed image extensions', () => {
+		const validate = wrapper
+			.getComponent({ name: 'FileUploader' })
+			.props('validateFile')
+		expect(validate({ name: 'notes.txt' })).toBe(
+			messages['Only image file is allowed.']
+		)
+		for (const extension of ['jpg', 'jpeg', 'png', 'JPG']) {
+			expect(validate({ name: `cover.${extension}` })).toBeUndefined()
+		}
+	})
+
+	it('keeps English fallback text when translations are unavailable', async () => {
+		wrapper.unmount()
+		browser.translatedMessages = {}
+		wrapper = mount(EditCoverImage, {
+			global: { plugins: [translationPlugin] },
+		})
+		expect(wrapper.get('input').attributes('placeholder')).toBe(
+			'search by keyword'
+		)
+		expect(wrapper.get('button').text()).toBe('Upload Image')
+		await wrapper
+			.getComponent({ name: 'FileUploader' })
+			.setData({ uploading: true, progress: 37 })
+		expect(wrapper.get('button').text()).toBe('Uploading 37%')
+	})
+})


### PR DESCRIPTION
Several student-facing messages remain in English even when the site supplies translations. Route the discussion reply placeholder, billing login notice, and cover-image picker's search/upload/progress/validation messages through the existing translation helper. Upload progress is formatted after translation. Existing English wording, accepted file extensions, and application behavior are preserved.

Partially addresses #2578: the discussion, billing login, and cover-image messages. The report's chart labels, dates, plurals, tab routing, and branding preferences remain outside this patch. No production translations are supplied.

Validation of head 6ca091d9:
- Full Linux frontend suite rerun: **150 suites / 1,604 tests passed**.
- Production `yarn build` rerun and passed, including the HTML copy step, using the project's CI-style `apps/lms`, `apps/frappe/ui`, and `sites/common_site_config.json` layout. Frozen lockfile, Node 24.21.0, Python 3.12, Frappe source dac01d6. No dependency or Vite configuration patches. Existing Browserslist/PWA glob warnings remain.
- Compiled the actual discussion and billing templates with Vue and rendered them through the actual translation helper. Both Portuguese outputs failed before their changes; Portuguese and English fallback outputs all pass afterward. The render probe supplies template state and stubs child components; it is not a live discussion or billing integration test.
- The committed cover-image component tests use the actual component/translation plugin and a Portuguese test dictionary, with UI primitives and requests stubbed: five regression cases failed before the fix; all six pass, including 0/37/100% progress and English fallback.
- Earlier native Chromium check of the unchanged cover-image component through Vite used real Frappe UI controls: translated placeholder/upload button/progress rendered, and the component emitted the selected image URL after a stubbed response, with no page errors. No live backend, authentication, or file persistence was tested.
- Changed files pass Prettier 2.7.1 and `git diff --check`. No dependency, lockfile, generated declaration, or site-config changes are included.

Prepared with AI assistance; reproduction output and the focused diff were reviewed before submission.
